### PR TITLE
feat: 🎸 change API for useToggle hook

### DIFF
--- a/docs/useToggle.md
+++ b/docs/useToggle.md
@@ -9,14 +9,14 @@ React state hook that tracks value of a boolean.
 import {useToggle} from 'react-use';
 
 const Demo = () => {
-  const [on, toggle, set] = useToggle(true);
+  const [on, toggle] = useToggle(true);
 
   return (
     <div>
       <div>{on ? 'ON' : 'OFF'}</div>
-      <button onClick={toggle}>Toggle</button>
-      <button onClick={() => set(true)}>set ON</button>
-      <button onClick={() => set(false)}>set OFF</button>
+      <button onClick={() => toggle()}>Toggle</button>
+      <button onClick={() => toggle(true)}>set ON</button>
+      <button onClick={() => toggle(false)}>set OFF</button>
     </div>
   );
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Collection of React Hooks",
   "main": "lib/index.js",
   "files": [

--- a/src/__stories__/useToggle.story.tsx
+++ b/src/__stories__/useToggle.story.tsx
@@ -4,14 +4,14 @@ import {useToggle} from '..';
 import ShowDocs from '../util/ShowDocs';
 
 const Demo = () => {
-  const [on, toggle, set] = useToggle(true);
+  const [on, toggle] = useToggle(true);
 
   return (
     <div>
       <div>{on ? 'ON' : 'OFF'}</div>
-      <button onClick={toggle}>Toggle</button>
-      <button onClick={() => set(true)}>set ON</button>
-      <button onClick={() => set(false)}>set OFF</button>
+      <button onClick={() => toggle()}>Toggle</button>
+      <button onClick={() => toggle(true)}>set ON</button>
+      <button onClick={() => toggle(false)}>set OFF</button>
     </div>
   );
 };

--- a/src/useToggle.ts
+++ b/src/useToggle.ts
@@ -2,15 +2,22 @@ import {useState} from './react';
 
 export type UseToggle = (state: boolean) => [
   boolean, // state
-  () => void, // toggle
-  (state: boolean) => void // set
+  (nextValue?: boolean) => void // toggle
 ];
 
 const useToggle: UseToggle = state => {
-  const [on, set] = useState<boolean>(state);
-  const toggle = () => set(!on);
+  const [value, setValue] = useState<boolean>(state);
 
-  return [on, toggle, set];
+  const toggle = (nextValue?: boolean) => {
+    if (typeof nextValue === 'boolean') {
+      setValue(nextValue);
+      return;
+    }
+
+    setValue(!value)
+  };
+
+  return [value, toggle];
 };
 
 export default useToggle;


### PR DESCRIPTION
It's better option to decrease useToggle params destruction and keep flexibility

New API look like
```js
const [on, toggle] = useToggle(true);
```