### PR TITLE
docs: fix module name typo

### DIFF
--- a/docs/useTimeout.md
+++ b/docs/useTimeout.md
@@ -2,19 +2,14 @@
 
 Returns `true` after a specified number of milliseconds.
 
-
 ## Usage
 
 ```jsx
-import {useTimeouta} from 'react-use';
+import { useTimeout } from 'react-use';
 
 const Demo = () => {
   const ready = useTimeout(2000);
 
-  return (
-    <div>
-      Ready: {ready ? 'Yes' : 'No'}
-    </div>
-  );
+  return <div>Ready: {ready ? 'Yes' : 'No'}</div>;
 };
 ```


### PR DESCRIPTION
- fix typo in module name