### PR TITLE
Fix synchronously re-render bug of useRef hook

### DIFF
--- a/src/useRaf.ts
+++ b/src/useRaf.ts
@@ -1,9 +1,9 @@
-import {useState, useEffect} from './react';
+import {useState, useLayoutEffect} from './react';
 
 const useRaf = (ms: number = 1e12, delay: number = 0): number => {
   const [elapsed, set] = useState<number>(0);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     let raf, timerStop, start;
 
     const onFrame = () => {


### PR DESCRIPTION
* Another animation frame will be requested before the cleanup function for `useEffect` is executed.
* Use `useLayoutEffect` to replace `useEffect`, in order to guarantee `cancelAnimationFrame` can work well.

More details can be found in issue https://github.com/streamich/react-use/issues/76