### PR TITLE
Pass arguments to memoized callback in useAsync

### DIFF
--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -25,7 +25,7 @@ const useAsync = <T>(fn: () => Promise<T>, args?) => {
 
   useEffect(() => {
     let mounted = true;
-    const promise = memoized();
+    const promise = memoized.apply(this, args);
 
     promise
       .then(value => {


### PR DESCRIPTION
Currently no arguments are passed into the memoized callback. This means the use of an async function that requires arguments isn't possible. For instance;

```
const fetchItems = async function(searchTerm) {
  return (await fetch(`/api/items?q=${searchTerm}`)).json();
};

function Results({ searchTerm }) {
  const { value } = useAsync(fetchItems, [searchTerm]);
  // shows results
  return (
    <ul/> 
  );
}
```

`searchTerm` in the `fetchItems` function will be `undefined`.

As stated in the `useCallback` [docs][1], the array of inputs as used on ln 24 is not passed as arguments, they must be passed when the memoized function is called.

> Note
> The array of inputs is not passed as arguments to the callback. Conceptually, though, that’s what they represent: every value referenced inside the callback should also appear in the inputs array. In the future, a sufficiently advanced compiler could create this array automatically.

This change passes the arguments to the memoized function.

[1]: https://reactjs.org/docs/hooks-reference.html#usecallback