### PR TITLE
Lock react and react-dom to a fixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "devDependencies": {
     "@storybook/react": "^3.4.11",
-    "react": "next",
-    "react-dom": "next",
+    "react": "16.7.0-alpha.2",
+    "react-dom": "16.7.0-alpha.2",
     "typescript": "^3.2.2",
     "ts-node": "^7.0.1",
     "ts-loader": "3",
@@ -58,8 +58,8 @@
     "react-spring": "^6.1.4"
   },
   "peerDependencies": {
-    "react": "16.7.0-alpha.0",
-    "react-dom": "16.7.0-alpha.0"
+    "react": "16.7.0-alpha.2",
+    "react-dom": "16.7.0-alpha.2"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
According to React Blog, the newest version of React v16.7 doesn't include React Hooks, before they tag an extra version for upcoming hooks, we should lock the version to latest react 16.7.0 alpha version, rather than use `next` to specify its version info in `package.json`. More details can be found at https://reactjs.org/blog/2018/12/19/react-v-16-7.html#can-i-use-hooks-yet