### PR TITLE
docs(useKeyPress): renamed keyboardjs -> useKeyboardJS

### DIFF
--- a/docs/useKeyPress.md
+++ b/docs/useKeyPress.md
@@ -3,9 +3,9 @@
 React UI sensor hook that detects when the user is pressing a specific
 key on their keyboard.
 
-Complex bindings like detecting when multiple keys are held down at the same 
-time or requiring them to be held down in a specified order are also available 
-via [KeyboardJS key combos](https://github.com/RobertWHurst/KeyboardJS). 
+Complex bindings like detecting when multiple keys are held down at the same
+time or requiring them to be held down in a specified order are also available
+via [KeyboardJS key combos](https://github.com/RobertWHurst/KeyboardJS).
 Check its documentation for further details on how to make combo strings.
 
 ## Usage
@@ -21,7 +21,7 @@ const Demo = () => {
   const hasPressedT = useKeyPress("t");
   const hasPressedY = useKeyPress("y");
   const hasPressedWord = useKeyPress("q + w + e + r + t + y", {
-    keyboardjs: true
+    useKeyboardJS: true
   });
 
   return (


### PR DESCRIPTION
Fixed a minor mistake in the `useKeyPress` docs (`keyboardjs` is an invalid option property).