### PR TITLE
fix: useSetState bug

### DIFF
--- a/src/useSetState.ts
+++ b/src/useSetState.ts
@@ -3,8 +3,7 @@ import {useState} from 'react';
 const useSetState = <T extends object>(initialState: T = {} as T): [T, (patch: Partial<T> | Function) => void]=> {
   const [state, set] = useState<T>(initialState);
   const setState = patch => {
-    if (patch instanceof Function) set(prevState => Object.assign({}, prevState, patch(prevState)));
-    else set(Object.assign({}, state, patch));
+    set(prevState => Object.assign({}, prevState, patch instanceof Function ? patch(prevState) : patch));
   };
 
   return [state, setState];


### PR DESCRIPTION
When we fetch data from server, use `setState(stateChangeObject)` in `useEffect` callback, the result is not correct.
See demo https://codesandbox.io/s/z6vn85pwpm. 
## The reason
The reason is fetch data useEffect only execute once, it will not update when re-render. So [assign state](https://github.com/streamich/react-use/blob/master/src/useSetState.ts#L7) point the old state.

## How to fix
Do not use `setState(stateChangeObject)` but always use `setState(stateUpdaterFunction)`, refer to the old state can be avoided

