### PR TITLE
Add useKeyPressEvent custom hook with associated doc

### DIFF
--- a/docs/useKeyPressEvent.md
+++ b/docs/useKeyPressEvent.md
@@ -1,0 +1,57 @@
+# `useKeyPressEvent`
+
+React UI sensor hook that detects when the user is pressing a specific
+key on their keyboard and fires a specified keyup and/or keydown effect. If
+you only need to retrieve the state, see [useKeyPress](#).
+
+Complex bindings like detecting when multiple keys are held down at the same
+time or requiring them to be held down in a specified order are also available
+via [KeyboardJS key combos](https://github.com/RobertWHurst/KeyboardJS).
+Check its documentation for further details on how to make combo strings.
+
+The first argument is the key(s) to watch. If only a second argument
+(a function) is passed, it will be used in the keydown event. On the other hand,
+if a second and third argument are passed, the second will be used in the keyup
+event and the third in the keydown event. Essentially, keydown takes precedence.
+
+## Usage
+
+```jsx
+import React, { useState } from React;
+import { useKeyPressEvent } from "react-use";
+
+const Demo = () => {
+  const [count, setCount] = useState(0);
+
+  const onKeyup = keys => {
+    console.log(`onKeyup: ${keys}`);
+  };
+
+  const onKeydown = keys => {
+    console.log(`onKeydown: ${keys}`);
+    setCount(count => ++count);
+  };
+
+  useKeyPressEvent('h', onKeyup, onKeydown);
+
+  useKeyPressEvent('l', () => {
+    console.log(`onKeydown for 'l'`);
+    setCount(count => ++count);
+  });
+
+  return (
+    <div>
+      <p>Try pressing <code>h</code> or <code>l</code> to see the count increment</p>
+      <p>Count: {countOfPressed}</p>
+    </div>
+  );
+};
+```
+
+## Reference
+
+```js
+useKeyPressEvent('<key>', onKeydown);
+
+useKeyPressEvent('<key>', onKeyup, onKeydown);
+```

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "semantic-release": "15.13.3",
     "ts-loader": "3.5.0",
     "ts-node": "7.0.1",
-    "typescript": "3.3.3333"
+    "typescript": "^3.3.3333"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/src/useKeyPressEvent.ts
+++ b/src/useKeyPressEvent.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+const { useEffect } = React;
+import useKeyPress from './useKeyPress';
+
+type KeyPressCallback = ((targetKey: string) => void) | undefined | null;
+
+const useKeyPressEvent = (
+  targetKey: string,
+  onKeyup: KeyPressCallback = undefined,
+  onKeydown: KeyPressCallback = undefined
+) => {
+  const useKeyboardJS: boolean = targetKey.length > 1;
+  const pressedKeys: boolean = useKeyPress(targetKey, {
+    useKeyboardJS,
+  });
+
+  if (onKeydown === undefined) {
+    onKeydown = onKeyup;
+    onKeyup = null;
+  }
+
+  useEffect(
+    () => {
+      if (!pressedKeys) {
+        if (onKeyup) onKeyup(targetKey);
+        return;
+      }
+
+      if (onKeydown) onKeydown(targetKey);
+    },
+    [pressedKeys]
+  );
+};
+
+export default useKeyPressEvent;


### PR DESCRIPTION
This focuses on utilizing the onKeyup and/or onKeydown events unlike useKeyPress which involves state. useKeyPressEvent uses useKeyPress to achieve this functionality.

My needs were to fire an event on keyup and/or keydown, not just know whether it was pressed or not.

I am partial on the parameter implementation. I like named parameters when there are more than 2, especially when some are optional, but most custom hooks I have seen do not use objects. Let me know your thoughts on this. Also, as you'll see in the doc, this code sets a precedence on the keydown functionality (I assume this is used more), but maybe having named parameters would be better to easily do one or the other just as easily.

Lastly, I am automatically determining whether to use the useKeyboardJS param based on the length of the "key" passed. I'm honestly not too familiar with that package, so if this will cause issues I can change the API.