### PR TITLE
feat: more precise size for useMouse

### DIFF
--- a/src/useMouse.ts
+++ b/src/useMouse.ts
@@ -29,7 +29,7 @@ const useMouse = (ref: RefObject<HTMLElement>): State => {
       cancelAnimationFrame(frame.current)
       frame.current = requestAnimationFrame(() => {
         if (ref && ref.current) {
-          const {left, top} = ref.current.getBoundingClientRect()
+          const {left, top, width, height} = ref.current.getBoundingClientRect()
           const posX = left + window.scrollX;
           const posY = top + window.scrollY;
 
@@ -40,8 +40,8 @@ const useMouse = (ref: RefObject<HTMLElement>): State => {
             posY,
             elX: event.pageX - posX,
             elY: event.pageY - posY,
-            elH: ref.current.offsetHeight,
-            elW: ref.current.offsetWidth,
+            elH: height,
+            elW: width,
           });
         }
       });


### PR DESCRIPTION
`element.offsetHeight` and `element.offsetWidth` will round the value to an integer.
`width` and `height` from `element.getBoundingClientRect()` is more precise.