### PR TITLE
feat: emit code in ES Module format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ typings/
 
 # build output
 lib/
+esm
 
 .DS_Store
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "yarn storybook",
     "test": "echo hmm...",
     "build:cjs": "tsc",
-    "build:es": "tsc -m esNext --outDir lib/es",
+    "build:es": "tsc -m esNext --outDir esm",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf lib storybook-static",
     "storybook": "start-storybook -p 6008",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "module": "lib/es/index.js",
   "files": [
-    "lib/"
+    "lib/",
+    "esm/"
   ],
   "types": "lib/index.d.ts",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.1.0",
   "description": "Collection of React Hooks",
   "main": "lib/index.js",
+  "module": "lib/es/index.js",
   "files": [
     "lib/"
   ],
@@ -11,7 +12,9 @@
   "scripts": {
     "start": "yarn storybook",
     "test": "echo hmm...",
-    "build": "tsc",
+    "build:cjs": "tsc",
+    "build:es": "tsc -m esNext --outDir lib/es",
+    "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf lib storybook-static",
     "storybook": "start-storybook -p 6008",
     "storybook:build": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:cjs": "tsc",
     "build:es": "tsc -m esNext --outDir esm",
     "build": "yarn build:cjs && yarn build:es",
-    "clean": "rimraf lib storybook-static",
+    "clean": "rimraf lib storybook-static esm",
     "storybook": "start-storybook -p 6008",
     "storybook:build": "build-storybook",
     "storybook:upload": "gh-pages -d storybook-static",


### PR DESCRIPTION
Export the whole library in ES Module format as well so that bundlers like webpack, rollup and parcel can enable code splitting when `import { usexxx } from "react-use"`.

> currently only export in commonjs format

