### PR TITLE
useFullscreen ref consistency

### DIFF
--- a/src/__stories__/useFullscreen.story.tsx
+++ b/src/__stories__/useFullscreen.story.tsx
@@ -9,7 +9,7 @@ const Demo = () => {
   const videoRef = React.useRef(null)
   const isFullScreen = useFullscreen(ref, show, {
     onClose: () => toggle(false),
-    video: videoRef.current
+    video: videoRef
   });
 
   const controls = (

--- a/src/__stories__/useFullscreen.story.tsx
+++ b/src/__stories__/useFullscreen.story.tsx
@@ -7,7 +7,10 @@ const Demo = () => {
   const [show, toggle] = useToggle(false);
   const ref = React.useRef(null)
   const videoRef = React.useRef(null)
-  const isFullScreen = useFullscreen(ref, show, {onClose: () => toggle(false)});
+  const isFullScreen = useFullscreen(ref, show, {
+    onClose: () => toggle(false),
+    video: videoRef.current
+  });
 
   const controls = (
     <div style={{background: 'white', padding: '20px'}}>


### PR DESCRIPTION
The demo didn't use the `video` option. I added this in my first commit and got a TypeScript error:
```
Argument of type '{ onClose: () => void; video: null; }' is not assignable to parameter of type 'FullScreenOptions | undefined'.
  Type '{ onClose: () => void; video: null; }' is not assignable to type 'FullScreenOptions'.
    Types of property 'video' are incompatible.
      Type 'null' is not assignable to type 'HTMLVideoElement | undefined'.
```

In the second commit the `video` option expects a video ref instead of a video element which makes this hook work without TypeScript errors. It's also more consistent to accept a ref in the options as the first parameter is already ref. 