### PR TITLE
Default dependency array for useAsync and useAsyncRetry

### DIFF
--- a/src/__stories__/useAsync.story.tsx
+++ b/src/__stories__/useAsync.story.tsx
@@ -10,13 +10,15 @@ const fn = () => new Promise<string>((resolve) => {
 });
 
 const Demo = () => {
-  const {loading, value} = useAsync<string>(fn);
+  const {loading, error, value} = useAsync<string>(fn);
 
   return (
     <div>
       {loading
         ? <div>Loading...</div>
-        : <div>Value: {value}</div>
+        : error
+          ? <div>Error: {error.message}</div>
+          : <div>Value: {value}</div>
       }
     </div>
   );

--- a/src/__stories__/useAsyncRetry.story.tsx
+++ b/src/__stories__/useAsyncRetry.story.tsx
@@ -19,13 +19,13 @@ const DemoRetry = () => {
 
   return (
     <div>
-      {loading?
-        <div>Loading...</div>
-        : error?
-        <div>Error: {error.message}</div>
-        : <div>Value: {value}</div>
+      {loading
+        ? <div>Loading...</div>
+        : error
+          ? <div>Error: {error.message}</div>
+          : <div>Value: {value}</div>
       }
-      <a href='javascript:void 0' onClick={() => retry()}>Retry</a>
+      <button onClick={() => retry()}>Retry</button>
     </div>
   );
 };

--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -17,7 +17,7 @@ export type AsyncState<T> =
   value: T;
 };
 
-const useAsync = <T>(fn: () => Promise<T>, deps: DependencyList) => {
+const useAsync = <T>(fn: () => Promise<T>, deps: DependencyList = []) => {
   const [state, set] = useState<AsyncState<T>>({
     loading: true
   });

--- a/src/useAsyncRetry.ts
+++ b/src/useAsyncRetry.ts
@@ -4,9 +4,10 @@ import useAsync, { AsyncState } from './useAsync';
 export type AsyncStateRetry<T> = AsyncState<T> & {
   retry():void
 }
-const useAsyncRetry = <T>(fn: () => Promise<T>, deps: DependencyList) => {
+
+const useAsyncRetry = <T>(fn: () => Promise<T>, deps: DependencyList = []) => {
   const [attempt, setAttempt] = useState<number>(0);
-  const state = useAsync(fn,[...deps, attempt]);
+  const state = useAsync(fn, [...deps, attempt]);
 
   const stateLoading = state.loading;
   const retry = useCallback(() => {
@@ -14,8 +15,10 @@ const useAsyncRetry = <T>(fn: () => Promise<T>, deps: DependencyList) => {
       if (process.env.NODE_ENV === 'development') {
         console.log('You are calling useAsyncRetry hook retry() method while loading in progress, this is a no-op.');
       }
+
       return;
     }
+
     setAttempt(attempt => attempt + 1);
   }, [...deps, stateLoading, attempt]);
 


### PR DESCRIPTION
The dependency array is optional for `useEffect` so I think we should follow that pattern too. If `useEffect` doesn't have a dependency array it runs on every render. This doesn't seem like the behaviour you want would want from a hook like this so the best solution seems to make the default `deps` parameter an empty array.