### PR TITLE
useEffectOnce

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
     <br/>
     <br/>
 - [**Lifecycles**](./docs/Lifecycles.md)
+  - [`useEffectOnce`](./docs/useEffectOnce.md) &mdash; a modified [`useEffect`](https://reactjs.org/docs/hooks-reference.html#useeffect) hook that only runs once.
   - [`useEvent`](./docs/useEvent.md) &mdash; subscribe to events.
   - [`useLifecycles`](./docs/useLifecycles.md) &mdash; calls `mount` and `unmount` callbacks.
   - [`useRefMounted`](./docs/useRefMounted.md) &mdash; tracks if component is mounted.

--- a/docs/useEffectOnce.md
+++ b/docs/useEffectOnce.md
@@ -1,0 +1,27 @@
+# `useEffectOnce`
+
+React lifecycle hook that runs an effect only once.
+
+## Usage
+
+```jsx
+import {useEffectOnce} from 'react-use';
+
+const Demo = () => {
+  useEffectOnce(() => {
+    console.log('Running effect once on mount')
+
+    return () => {
+      console.log('Running clean-up of effect on unmount')
+    }
+  });
+
+  return null;
+};
+```
+
+## Reference
+
+```js
+useEffectOnce(effect: EffectCallback);
+```

--- a/src/__stories__/useEffectOnce.story.tsx
+++ b/src/__stories__/useEffectOnce.story.tsx
@@ -1,0 +1,21 @@
+import {storiesOf} from '@storybook/react';
+import * as React from 'react';
+import {useEffectOnce} from '..';
+import ConsoleStory from './util/ConsoleStory'
+import ShowDocs from '../util/ShowDocs';
+
+const Demo = () => {
+  useEffectOnce(() => {
+    console.log('Running effect once on mount')
+
+    return () => {
+      console.log('Running clean-up of effect on unmount')
+    }
+  });
+
+  return <ConsoleStory />;
+};
+
+storiesOf('Lifecycles|useEffectOnce', module)
+  .add('Docs', () => <ShowDocs md={require('../../docs/useEffectOnce.md')} />)
+  .add('Demo', () => <Demo/>)

--- a/src/__stories__/util/ConsoleStory.tsx
+++ b/src/__stories__/util/ConsoleStory.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+const ConsoleStory = ({message = 'Open the developer console to see logs'}) => (
+  <p>{message}</p>
+);
+
+export default ConsoleStory

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import useDropArea from './useDropArea';
 import useCounter from './useCounter';
 import useCss from './useCss';
 import useDebounce from './useDebounce';
+import useEffectOnce from './useEffectOnce';
 import useEvent from './useEvent';
 import useFavicon from './useFavicon';
 import useFullscreen from './useFullscreen';
@@ -77,6 +78,7 @@ export {
   useCounter,
   useCss,
   useDebounce,
+  useEffectOnce,
   useEvent,
   useFavicon,
   useFullscreen,

--- a/src/useEffectOnce.ts
+++ b/src/useEffectOnce.ts
@@ -1,0 +1,14 @@
+import {useRef, useEffect, EffectCallback} from 'react';
+
+const useEffectOnce = (effect: EffectCallback) => {
+  const didRun = useRef(false);
+
+  useEffect(() => {
+    if (!didRun.current) {
+      didRun.current = true;
+      return effect();
+    }
+  });
+}
+
+export default useEffectOnce;

--- a/src/useEffectOnce.ts
+++ b/src/useEffectOnce.ts
@@ -1,14 +1,7 @@
-import {useRef, useEffect, EffectCallback} from 'react';
+import {useEffect, EffectCallback} from 'react';
 
 const useEffectOnce = (effect: EffectCallback) => {
-  const didRun = useRef(false);
-
-  useEffect(() => {
-    if (!didRun.current) {
-      didRun.current = true;
-      return effect();
-    }
-  });
+  useEffect(effect, []);
 }
 
 export default useEffectOnce;


### PR DESCRIPTION
A modified [`useEffect`](https://reactjs.org/docs/hooks-reference.html#useeffect) hook that only runs once. Similar to [useLifecycles](https://github.com/streamich/react-use/blob/master/docs/useLifecycles.md) but implementation can be used more similar to React's `useEffect`.

This implementation uses a ref to know if the effect already ran. I have seen a lot of people using this kind of implementation but I'm not sure if it's the best way. A more straightforward way would be:

```ts
import {useEffect, EffectCallback} from 'react';

const useEffectOnce = (effect: EffectCallback) => {
  useEffect(effect, []);
}

export default useEffectOnce;
```

I thought I read somewhere that the ref implementation is preferable but I can't find it back.