### PR TITLE
useMount and useUnmount refactor

### DIFF
--- a/docs/useMount.md
+++ b/docs/useMount.md
@@ -1,8 +1,6 @@
 # `useMount`
 
-React lifecycle hook that call `mount` callback, when
-component is mounted.
-
+React lifecycle hook that calls a function after the component is mounted.
 
 ## Usage
 
@@ -15,9 +13,8 @@ const Demo = () => {
 };
 ```
 
-
 ## Reference
 
 ```js
-useMount(mount);
+useMount(fn: () => void);
 ```

--- a/docs/useUnmount.md
+++ b/docs/useUnmount.md
@@ -1,8 +1,6 @@
 # `useUnmount`
 
-React lifecycle hook that call `unmount` callback, when
-component is un-mounted.
-
+React lifecycle hook that calls a function when the component will unmount.
 
 ## Usage
 
@@ -15,9 +13,8 @@ const Demo = () => {
 };
 ```
 
-
 ## Reference
 
-```js
-useUnmount(mount);
+```ts
+useUnmount(fn: () => void | undefined);
 ```

--- a/src/__stories__/useMount.story.tsx
+++ b/src/__stories__/useMount.story.tsx
@@ -2,14 +2,14 @@ import {storiesOf} from '@storybook/react';
 import * as React from 'react';
 import {useMount} from '..';
 import ShowDocs from '../util/ShowDocs';
+import ConsoleStory from './util/ConsoleStory'
 
 const Demo = () => {
   useMount(() => console.log('MOUNTED'));
-  return null;
+
+  return <ConsoleStory />;
 };
 
 storiesOf('Lifecycles|useMount', module)
   .add('Docs', () => <ShowDocs md={require('../../docs/useMount.md')} />)
-  .add('Demo', () =>
-    <Demo/>
-  )
+  .add('Demo', () => <Demo/>)

--- a/src/__stories__/useUnmount.story.tsx
+++ b/src/__stories__/useUnmount.story.tsx
@@ -2,15 +2,15 @@ import {storiesOf} from '@storybook/react';
 import * as React from 'react';
 import {useUnmount} from '..';
 import ShowDocs from '../util/ShowDocs';
+import ConsoleStory from './util/ConsoleStory'
 
 const Demo = () => {
   useUnmount(() => console.log('UNMOUNTED'));
-  return null;
+
+  return <ConsoleStory />;
 };
 
 storiesOf('Lifecycles|useUnmount', module)
   .add('Docs', () => <ShowDocs md={require('../../docs/useUnmount.md')} />)
-  .add('Demo', () =>
-    <Demo/>
-  )
+  .add('Demo', () => <Demo/>)
 

--- a/src/useMount.ts
+++ b/src/useMount.ts
@@ -1,5 +1,9 @@
-import {useEffect} from 'react';
+import useEffectOnce from './useEffectOnce'
 
-const useMount = (mount) => useEffect(mount, []);
+const useMount = (fn: () => void) => {
+  useEffectOnce(() => {
+    fn();
+  });
+}
 
 export default useMount;

--- a/src/useUnmount.ts
+++ b/src/useUnmount.ts
@@ -1,9 +1,7 @@
-import {useEffect} from 'react';
+import useEffectOnce from './useEffectOnce'
 
-const useUnmount = (unmount) => {
-  useEffect(() => () => {
-    if (unmount) unmount();
-  }, []);
+const useUnmount = (fn: () => void | undefined) => {
+  useEffectOnce(() => fn);
 };
 
 export default useUnmount;


### PR DESCRIPTION
Refactored `useMount` and `useUnmount` to reuse `useEffectOnce` as described in https://github.com/streamich/react-use/pull/196#issuecomment-478322228. Functionally the only difference is `useMount` can not have a clean-up routine.

I also added proper types and updated docs and stories