### PR TITLE
useLogger refactor

### DIFF
--- a/docs/useLogger.md
+++ b/docs/useLogger.md
@@ -1,6 +1,6 @@
 # `useLogger`
 
-React lifecycle hook that logs in console as component transitions through life-cycles.
+React lifecycle hook that console logs parameters as component transitions through lifecycles.
 
 ## Usage
 
@@ -13,21 +13,19 @@ const Demo = (props) => {
 };
 ```
 
-
 ## Example Output
 
 ```
-Demo mounted
-Demo props updated {}
-Demo un-mounted
+Demo mounted {}
+Demo updated {}
+Demo unmounted
 ```
-
 
 ## Reference
 
 ```js
-useLogger(name, props);
+useLogger(componentName: string, ...rest);
 ```
 
-- `name` &mdash; component name.
-- `props` &mdash; latest props.
+- `componentName` &mdash; component name.
+- `...rest` &mdash; parameters to log.

--- a/src/__stories__/useLogger.story.tsx
+++ b/src/__stories__/useLogger.story.tsx
@@ -1,15 +1,35 @@
 import {storiesOf} from '@storybook/react';
+import {withKnobs, text, boolean} from '@storybook/addon-knobs';
 import * as React from 'react';
+import {useCounter} from '..';
 import {useLogger} from '..';
 import ShowDocs from '../util/ShowDocs';
 
 const Demo = (props) => {
-  useLogger('Demo', props);
-  return null;
+  const [state, {inc}] = useCounter(0);
+
+  useLogger('Demo', props, state);
+
+  return (
+    <>
+      <p style={{fontWeight: props.bold ? 'bold' : 'normal'}}>
+        {props.title}
+      </p>
+      <button onClick={() => inc()}>
+        Update state ({state})
+      </button>
+    </>
+  );
 };
 
 storiesOf('Lifecycles|useLogger', module)
+  .addDecorator(withKnobs)
   .add('Docs', () => <ShowDocs md={require('../../docs/useLogger.md')} />)
-  .add('Demo', () =>
-    <Demo/>
-  )
+  .add('Demo', () => {
+    const props = {
+      title: text('title', 'Open the developer console to see logs'),
+      bold: boolean('bold', false),
+    }
+
+    return <Demo {...props} />
+  })

--- a/src/useLogger.ts
+++ b/src/useLogger.ts
@@ -1,10 +1,14 @@
-import {useEffect} from 'react';
-import useLifecycles from './useLifecycles';
+import useEffectOnce from './useEffectOnce';
+import useUpdateEffect from './useUpdateEffect';
 
-const useLogger = (name, props) => {
-  useLifecycles(() => console.log(`${name} mounted`), () => console.log(`${name} un-mounted`));
-  useEffect(() => {
-    console.log(`${name} props updated`, props);
+const useLogger = (componentName: string, ...rest) => {
+  useEffectOnce(() => {
+    console.log(`${componentName} mounted`, ...rest)
+    return () => console.log(`${componentName} unmounted`)
+  });
+
+  useUpdateEffect(() => {
+    console.log(`${componentName} updated`, ...rest);
   });
 };
 


### PR DESCRIPTION
Refactored `useLogger` to reuse `useEffectOnce` and `useUpdateEffect` instead of `useLifecycles`. You are also able to log multiple parameters now which can be handy if you want to log props and state which I tried to show in the updated story.

It would be nice if the hook could pick up the component displayName automatically but this does not seem possible: https://github.com/facebook/react/issues/15031.