### PR TITLE
useDeepCompareEffect

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
   - [`useMount`](./docs/useMount.md) &mdash; calls `mount` callbacks.
   - [`useUnmount`](./docs/useUnmount.md) &mdash; calls `unmount` callbacks.
   - [`useUpdateEffect`](./docs/useUpdateEffect.md) &mdash; run an `effect` only on updates.
+  - [`useDeepCompareEffect`](./docs/useUpdateEffect.md) &mdash; run an `effect` depending on deep comparison of its dependencies
     <br/>
     <br/>
 - [**State**](./docs/State.md)

--- a/docs/useDeepCompareEffect.md
+++ b/docs/useDeepCompareEffect.md
@@ -1,0 +1,30 @@
+# `useDeepCompareEffect`
+
+A modified useEffect hook that is using deep comparison on its dependencies instead of reference equality.
+
+## Usage
+
+```jsx
+import {useCounter, useDeepCompareEffect} from 'react-use';
+
+const Demo = () => {
+  const [count, {inc: inc}] = useCounter(0);
+  const options = { step: 2 };
+
+  useDeepCompareEffect(() => {
+    inc(options.step)
+  }, [options]);
+
+  return (
+    <div>
+      <p>useDeepCompareEffect: {count}</p>
+    </div>
+  );
+};
+```
+
+## Reference
+
+```ts
+useDeepCompareEffect(effect: () => void | (() => void | undefined), deps: any[]);
+```

--- a/package.json
+++ b/package.json
@@ -35,15 +35,16 @@
   "homepage": "https://github.com/streamich/react-use#readme",
   "dependencies": {
     "nano-css": "^5.1.0",
+    "react-fast-compare": "^2.0.4",
     "react-wait": "^0.3.0",
     "screenfull": "^4.1.0",
     "throttle-debounce": "^2.0.1",
     "ts-easing": "^0.2.0"
   },
   "peerDependencies": {
+    "keyboardjs": "*",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "keyboardjs": "*",
     "rebound": "*"
   },
   "devDependencies": {

--- a/src/__stories__/useDeepCompareEffect.story.tsx
+++ b/src/__stories__/useDeepCompareEffect.story.tsx
@@ -1,0 +1,33 @@
+import {storiesOf} from '@storybook/react';
+import * as React from 'react';
+import {useCounter, useDeepCompareEffect} from '..';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const [countNormal, {inc: incNormal}] = useCounter(0);
+  const [countDeep, {inc: incDeep}] = useCounter(0);
+  const options = {max: 500}
+
+  React.useEffect(() => {
+    if (countNormal < options.max) {
+      incNormal()
+    }
+  }, [options]);
+
+  useDeepCompareEffect(() => {
+    if (countNormal < options.max) {
+      incDeep()
+    }
+  }, [options]);
+
+  return (
+    <div>
+      <p>useEffect: {countNormal}</p>
+      <p>useDeepCompareEffect: {countDeep}</p>
+    </div>
+  );
+};
+
+storiesOf('useDeepCompareEffect', module)
+  .add('Docs', () => <ShowDocs md={require('../../docs/useDeepCompareEffect.md')} />)
+  .add('Demo', () => <Demo/>)

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import useDropArea from './useDropArea';
 import useCounter from './useCounter';
 import useCss from './useCss';
 import useDebounce from './useDebounce';
+import useDeepCompareEffect from './useDeepCompareEffect';
 import useEffectOnce from './useEffectOnce';
 import useEvent from './useEvent';
 import useFavicon from './useFavicon';
@@ -78,6 +79,7 @@ export {
   useCounter,
   useCss,
   useDebounce,
+  useDeepCompareEffect,
   useEffectOnce,
   useEvent,
   useFavicon,

--- a/src/useDeepCompareEffect.ts
+++ b/src/useDeepCompareEffect.ts
@@ -1,0 +1,30 @@
+import { useRef, useEffect, EffectCallback, DependencyList } from 'react';
+import * as isEqual from 'react-fast-compare';
+
+const isPrimitive = (val: any) => val !== Object(val)
+
+const useDeepCompareEffect = (effect: EffectCallback, deps: any[]) => {
+  if (process.env.NODE_ENV !== 'production') {
+    if (!deps || !deps.length) {
+      throw new Error(
+        'useDeepCompareEffect should not be used with no dependencies. Use React.useEffect instead.',
+      )
+    }
+
+    if (deps.every(isPrimitive)) {
+      throw new Error(
+        'useDeepCompareEffect should not be used with dependencies that are all primitive values. Use React.useEffect instead.',
+      );
+    }
+  }
+
+  const ref = useRef<DependencyList | undefined>(undefined);
+
+  if (!isEqual(deps, ref.current)) {
+    ref.current = deps
+  }
+
+  useEffect(effect, ref.current)
+}
+
+export default useDeepCompareEffect

--- a/src/useDeepCompareEffect.ts
+++ b/src/useDeepCompareEffect.ts
@@ -6,14 +6,14 @@ const isPrimitive = (val: any) => val !== Object(val)
 const useDeepCompareEffect = (effect: EffectCallback, deps: any[]) => {
   if (process.env.NODE_ENV !== 'production') {
     if (!deps || !deps.length) {
-      throw new Error(
-        'useDeepCompareEffect should not be used with no dependencies. Use React.useEffect instead.',
-      )
+      console.warn(
+        '`useDeepCompareEffect` should not be used with no dependencies. Use React.useEffect instead.'
+      );
     }
 
     if (deps.every(isPrimitive)) {
-      throw new Error(
-        'useDeepCompareEffect should not be used with dependencies that are all primitive values. Use React.useEffect instead.',
+      console.warn(
+        '`useDeepCompareEffect` should not be used with dependencies that are all primitive values. Use React.useEffect instead.'
       );
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8938,7 +8938,7 @@ react-error-overlay@^5.1.4:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.4.tgz#88dfb88857c18ceb3b9f95076f850d7121776991"
   integrity sha512-fp+U98OMZcnduQ+NSEiQa4s/XMsbp+5KlydmkbESOw4P69iWZ68ZMFM5a2BuE0FgqPBKApJyRuYHR95jM8lAmg==
 
-react-fast-compare@^2.0.2:
+react-fast-compare@^2.0.2, react-fast-compare@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==


### PR DESCRIPTION
A modified useEffect hook that is using deep comparison on its dependencies instead of reference equality. Using [`react-fast-compare`](https://github.com/FormidableLabs/react-fast-compare) as per recommendation.

I have "borrowed" dev warnings from https://github.com/kentcdodds/use-deep-compare-effect/blob/master/src/index.js. I wasn't sure if I had to use `process.env.NODE_ENV !== 'production'` or `process.env.NODE_ENV === 'development'` since I see both styles in this codebase.

Close #197 