### PR TITLE
Improved useCopyToClipboard

### DIFF
--- a/docs/useCopyToClipboard.md
+++ b/docs/useCopyToClipboard.md
@@ -2,13 +2,23 @@
 
 Copy text to a user's clipboard.
 
-
 ## Usage
-
-Basic usage
 
 ```jsx
 const Demo = () => {
+  const [text, setText] = React.useState('');
+  const [state, copyToClipboard] = useCopyToClipboard();
+
+  return (
+    <div>
+      <input value={text} onChange={e => setText(e.target.value)} />
+      <button type="button" onClick={() => copyToClipboard(text)}>copy text</button>
+      {state.error
+        ? <p>Unable to copy value: {state.error.message}</p>
+        : state.value && <p>Copied {state.value}</p>}
+    </div>
+  )
+
   const [text, setText] = React.useState('');
   const [copied, copyToClipboard] = useCopyToClipboard(text);
 
@@ -25,11 +35,5 @@ const Demo = () => {
 ## Reference
 
 ```js
-const [copied, copyToClipboard] = useCopyToClipboard(text);
-const [copied, copyToClipboard] = useCopyToClipboard(text, writeText);
+const [state, copyToClipboard] = useCopyToClipboard();
 ```
-
-, where
-
-- `writeText` &mdash; function that receives a single string argument, which
-  it copies to user's clipboard.

--- a/src/__stories__/useCopyToClipboard.story.tsx
+++ b/src/__stories__/useCopyToClipboard.story.tsx
@@ -5,19 +5,21 @@ import {useCopyToClipboard} from '..';
 
 const Demo = () => {
   const [text, setText] = React.useState('');
-  const [copied, copyToClipboard] = useCopyToClipboard(text, {
-    onCopy: txt => alert('success: ' + txt),
-    onError: err => alert(err),
-  });
+  const [state, copyToClipboard] = useCopyToClipboard();
 
   return (
     <div>
       <input value={text} onChange={e => setText(e.target.value)} />
-      <button type="button" onClick={copyToClipboard}>copy text</button>
-      <div>Copied: {copied ? 'Yes' : 'No'}</div>
-      <div style={{margin: 10}}>
-        <input type="text" placeholder="now paste it in here"/>
-      </div>
+      <button type="button" onClick={() => copyToClipboard(text)}>copy text</button>
+      {state.error
+        ? <p>Unable to copy value: {state.error.message}</p>
+        : state.value && (
+          <>
+            <p>Copied {state.value} {state.noUserInteraction ? 'without' : 'with'} user interaction</p>
+            <input type="text" placeholder="Paste it in here to check"/>
+          </>
+        )}
+      
     </div>
   )
 }

--- a/src/useCopyToClipboard.ts
+++ b/src/useCopyToClipboard.ts
@@ -19,17 +19,15 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
 
   const copyToClipboard = useCallback((value) => {
     try {
-      if (!value) {
-        throw new Error('No value to copy to clipboard')
-      }
-
-      if (typeof value !== "string") {
-        throw new Error(`Cannot copy typeof ${typeof value} to clipboard, must be a string`);
+      if (process.env.NODE_ENV === 'development') {
+        if (typeof value !== "string") {
+          console.error(`Cannot copy typeof ${typeof value} to clipboard, must be a string`);
+        }
       }
 
       const noUserInteraction = writeText(value);
-      if (!mounted.current) return;
 
+      if (!mounted.current) return;
       setState({
         value,
         error: undefined,
@@ -37,7 +35,6 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
       });
     } catch (error) {
       if (!mounted.current) return;
-
       setState({
         value: undefined,
         error,

--- a/src/useCopyToClipboard.ts
+++ b/src/useCopyToClipboard.ts
@@ -1,55 +1,52 @@
-import {useState, useCallback, useRef} from 'react';
-import useUpdateEffect from './useUpdateEffect';
+import {useCallback} from 'react';
+import useSetState from './useSetState'
 import useRefMounted from './useRefMounted';
-const writeTextDefault = require('copy-to-clipboard');
+import * as writeText from 'copy-to-clipboard';
 
-export type WriteText = (text: string) => Promise<void>; // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText
-export interface UseCopyToClipboardOptions {
-  writeText?: WriteText;
-  onCopy?: (text: string) => void;
-  onError?: (error: any, text: string) => void;
+export interface CopyToClipboardState {
+  value?: string,
+  noUserInteraction: boolean,
+  error?: Error,
 }
-export type UseCopyToClipboard = (text?: string, options?: UseCopyToClipboardOptions) => [boolean, () => void];
 
-const useCopyToClipboard: UseCopyToClipboard = (text = '', options) => {
-  const {writeText = writeTextDefault, onCopy, onError} = (options || {}) as UseCopyToClipboardOptions;
-
-  if (process.env.NODE_ENV !== 'production') {
-    if (typeof text !== 'string') {
-      console.warn('useCopyToClipboard hook expects first argument to be string.');
-    }
-  }
-
+const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] => {
   const mounted = useRefMounted();
-  const latestText = useRef(text);
-  const [copied, setCopied] = useState(false);
-  const copyToClipboard = useCallback(async () => {
-    if (latestText.current !== text) {
-      if (process.env.NODE_ENV !== 'production') {
-        console.warn('Trying to copy stale text.');
-      }
-      return;
-    }
+  const [state, setState] = useSetState<CopyToClipboardState>({
+    value: undefined,
+    error: undefined,
+    noUserInteraction: true
+  });
 
+  const copyToClipboard = useCallback((value) => {
     try {
-      await writeText(text);
+      if (!value) {
+        throw new Error('No value to copy to clipboard')
+      }
+
+      if (typeof value !== "string") {
+        throw new Error(`Cannot copy typeof ${typeof value} to clipboard, must be a string`);
+      }
+
+      const noUserInteraction = writeText(value);
       if (!mounted.current) return;
-      setCopied(true);
-      onCopy && onCopy(text);
+
+      setState({
+        value,
+        error: undefined,
+        noUserInteraction
+      });
     } catch (error) {
       if (!mounted.current) return;
-      console.error(error);
-      setCopied(false);
-      onError && onError(error, text);
+
+      setState({
+        value: undefined,
+        error,
+        noUserInteraction: true
+      });
     }
-  }, [text]);
+  }, []);
 
-  useUpdateEffect(() => {
-    setCopied(false);
-    latestText.current = text;
-  }, [text]);
-
-  return [copied, copyToClipboard];
+  return [state, copyToClipboard];
 }
 
 export default useCopyToClipboard;


### PR DESCRIPTION
The current implementation assumes an asynchronous copy to clipboard function but uses [`copy-to-clipboard`](https://github.com/sudodoki/copy-to-clipboard) by default which is synchronous. `copy-to-clipboard` also [returns a boolean](https://github.com/sudodoki/copy-to-clipboard#api) if additional user interaction was needed as a prompt modal is presented in browsers that don't support `execCommand`. This value is not accessible in the current version. 2 examples why the hook itself has to determine how text is copied to the clipboard as I have pointed out in https://github.com/streamich/react-use/issues/208#issuecomment-480472083.

After playing around with it a little bit more I came to the conclusion that it might be a bad pattern to have callbacks in the parameters of a hook. I changed the hook to return a state object with the `value` that was copied, an `error` when copying fails and a `noUserInteraction` boolean forwarded from `copy-to-clipboard`. You can have side effects depending on the state of `copyToClipboard` by using `useEffect`. An example for @scottc11's timeout effect in #208:

```jsx
const [text, setText] = React.useState('');
const [showSuccess, setShowSuccess] = React.useState(false);
const [state, copyToClipboard] = useCopyToClipboard();

React.useEffect(() => {
  if (state.value) {
    setShowSuccess(true);
    setTimeout( () => setShowSuccess(false), 2000);
  }
}, [state])

return (
  <div>
    <input value={text} onChange={e => setText(e.target.value)} />
    <button type="button" onClick={() => copyToClipboard(text)}>copy text</button>
    {showSuccess && `Copied ${text} to clipboard`}
  </div>
)
```

This feels more like a react hooks way of doing things as the `onSuccess` and `onError` callbacks they actually are effects.