### PR TITLE
Upgrade babel core and add babel loader for storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "rebound": "*"
   },
   "devDependencies": {
+    "@babel/core": "^7.4.3",
     "@babel/preset-env": "7.4.3",
     "@babel/preset-react": "7.0.0",
     "@babel/preset-typescript": "7.3.3",
@@ -64,6 +65,7 @@
     "@types/jest": "24.0.11",
     "@types/react": "16.8.13",
     "babel-core": "6.26.3",
+    "babel-loader": "^8.0.5",
     "fork-ts-checker-webpack-plugin": "1.0.1",
     "gh-pages": "2.0.1",
     "jest": "24.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0":
+"@babel/core@^7.1.0", "@babel/core@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.3.tgz#198d6d3af4567be3989550d97e068de94503074f"
   integrity sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==
@@ -3156,7 +3156,7 @@ babel-jest@^24.7.1:
     chalk "^2.4.2"
     slash "^2.0.0"
 
-babel-loader@8.0.5:
+babel-loader@8.0.5, babel-loader@^8.0.5:
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.5.tgz#225322d7509c2157655840bba52e46b6c2f2fe33"
   integrity sha512-NTnHnVRd2JnRqPC0vW+iOQWU5pchDbYXsG2E6DMXEpMfUcQKclF9gmf3G3ZMhzG7IG9ji4coL0cm+FxeWxDpnw==


### PR DESCRIPTION
yarn start wasn't working as (i think) babel-loader wasn't being installed as a peer dependency of existing babel 6? so added babel-loader directly

Also, as babel presets were at >v7 and are also part of the @babel scope, thought it'd be best to upgrade babel to v7 using the same scope.

Now yarn start works as expected and the new test still works