### PR TITLE
Add ability to pass position options to useGeolocation

### DIFF
--- a/docs/useGeolocation.md
+++ b/docs/useGeolocation.md
@@ -1,7 +1,6 @@
 # `useGeolocation`
 
-React sensor hook that tracks user's geographic location.
-
+React sensor hook that tracks user's geographic location. This hook accepts [position options](https://developer.mozilla.org/docs/Web/API/PositionOptions).
 
 ## Usage
 
@@ -17,4 +16,10 @@ const Demo = () => {
     </pre>
   );
 };
+```
+
+## Reference
+
+```ts
+useGeolocation(options: PositionOptions)
 ```

--- a/src/useGeolocation.ts
+++ b/src/useGeolocation.ts
@@ -13,7 +13,7 @@ export interface GeoLocationSensorState {
   error?: Error | PositionError;
 }
 
-const useGeolocation = (): GeoLocationSensorState => {
+const useGeolocation = (options: PositionOptions): GeoLocationSensorState => {
   const [state, setState] = useState<GeoLocationSensorState>({
     loading: true,
     accuracy: null,
@@ -47,8 +47,8 @@ const useGeolocation = (): GeoLocationSensorState => {
     mounted && setState(oldState => ({ ...oldState, loading: false, error }));
 
   useEffect(() => {
-    navigator.geolocation.getCurrentPosition(onEvent, onEventError);
-    watchId = navigator.geolocation.watchPosition(onEvent, onEventError);
+    navigator.geolocation.getCurrentPosition(onEvent, onEventError, options);
+    watchId = navigator.geolocation.watchPosition(onEvent, onEventError, options);
 
     return () => {
       mounted = false;

--- a/src/useGeolocation.ts
+++ b/src/useGeolocation.ts
@@ -13,7 +13,7 @@ export interface GeoLocationSensorState {
   error?: Error | PositionError;
 }
 
-const useGeolocation = (options: PositionOptions): GeoLocationSensorState => {
+const useGeolocation = (options?: PositionOptions): GeoLocationSensorState => {
   const [state, setState] = useState<GeoLocationSensorState>({
     loading: true,
     accuracy: null,


### PR DESCRIPTION
This PR adds ability to pass [position options](https://developer.mozilla.org/docs/Web/API/PositionOptions) for `useGeolocation` hook.