### PR TITLE
fix(useRefMounted): only run and cleanup once

### DIFF
--- a/src/useRefMounted.ts
+++ b/src/useRefMounted.ts
@@ -9,7 +9,7 @@ const useRefMounted = (): RefObject<boolean> => {
     return () => {
       refMounted.current = false;
     };
-  });
+  }, []);
 
   return refMounted;
 };


### PR DESCRIPTION
Not sure if this is intentional or not but theres no need for this to rerun on every render? Tho I suppose its not really an issue.

> If you want to run an effect and clean it up only once (on mount and unmount), you can pass an empty array ([]) as a second argument.

[Tip: Optimizing Performance by Skipping Effects](https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects)