### PR TITLE
fix(useAudio): src change should reset isPlaying state

### DIFF
--- a/src/util/createHTMLMediaHook.ts
+++ b/src/util/createHTMLMediaHook.ts
@@ -205,15 +205,16 @@ const createHTMLMediaHook = (tag: 'audio' | 'video') => {
         return;
       }
 
+      setState({
+        volume: el.volume,
+        muted: el.muted,
+        isPlaying: !el.paused,
+      });
+
       // Start media, if autoPlay requested.
       if (props.autoPlay && el.paused) {
         controls.play();
       }
-
-      setState({
-        volume: el.volume,
-        muted: el.muted,
-      });
     }, [props.src]);
 
     return [element, state, controls, ref];


### PR DESCRIPTION
Given: `useAudio` which is playing and `autoPlay: false` (default)

When: `src` changes

Then expected: Audio stops playing and `state.isPlaying` changes to `false`
Then actual: Audio stops playing, but `state.isPlaying` remains `true`

This PR fixes this. The issue is that `onPause` doesn't fire when `src` changes even though playback is stopped.

Affected browsers: Chrome, Firefox and maybe others