### PR TITLE
fix(useMap): more stringent type

### DIFF
--- a/src/useMap.ts
+++ b/src/useMap.ts
@@ -1,27 +1,28 @@
 import { useState } from 'react';
 
-export interface Actions<K, V> {
-  get: (key: K) => any;
-  set: (key: K, value: V) => void;
-  remove: (key: K) => void;
+export interface Actions<T extends object> {
+  get: <K extends keyof T>(key: K) => T[K];
+  set: <K extends keyof T>(key: K, value: T[K]) => void;
+  remove: <K extends keyof T>(key: K) => void;
   reset: () => void;
 }
 
-const useMap = <T extends { [key: string]: any }>(initialMap: any = {}): [T, Actions<string, any>] => {
-  const [map, set] = useState<T>(initialMap as any);
+const useMap = <T extends object = any>(initialMap: T = {} as T): [T, Actions<T>] => {
+  const [map, set] = useState<T>(initialMap);
 
   return [
     map,
     {
-      get: (key: string) => map[key],
-      set: (key: string, entry: any) =>
+      get: (key: keyof T) => map[key as string],
+      set: <K extends keyof T>(key: K, entry: T[K]) => {
         set({
-          ...(map as any),
+          ...map,
           [key]: entry,
-        }),
-      remove: (key: string) => {
-        const { [key]: omit, ...rest } = map as any;
-        set(rest);
+        });
+      },
+      remove: (key: keyof T) => {
+        const { [key]: omit, ...rest } = map;
+        set(rest as T);
       },
       reset: () => set(initialMap),
     },


### PR DESCRIPTION
The type of useMap is too simplistic.

### Old version:  

```typescript
const [state1, setState1] = useMap<{ [key: string]: boolean }>();

setState1.get('test');      // the `get` method will return `any`
setState1.set('test', 123); // type of 123 is number, but there not error

const [state2, setState2] = useMap({
    abc: 123,
    bcd: '456',
    cde: {
        test: 123,
    },
});

// all method under there are legal
setState2.get('test');
setState2.get('bcd');
setState2.get('cde');

setState2.set('abc', '123');
setState2.set('bcd', 123);
setState2.set('test', 78);

setState2.remove('abcdefg');
```

### Modification:  

```typescript
const [state1, setState1] = useMap<{ [key: string]: boolean }>();

setState1.get('test');      // the `get` method will return `boolean`
setState1.set('test', 123); // throw a error, `123` is not boolean

const [state2, setState2] = useMap({
  abc: 123,
  bcd: '456',
  cde: {
    test: 123,
  },
});

setState2.get('test');          // throw error, 'test' isn't keyof useMap's input
setState2.get('bcd');           // return `string`
setState2.get('cde');           // return `{ test: string }`

setState2.set('abc', '123');    // throw error, value of the key named 'abc' must be a number
setState2.set('bcd', 123);      // throw error, value of the key named 'bcd' must be a string
setState2.set('test', 78);      // throw error, 'test' isn't keyof useMap's input

setState2.remove('abcdefg');    // throw error, 'abcdefg' isn't keyof useMap's input
```