### PR TITLE
Pass arguments to useAsyncFn fetcher

### DIFF
--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -18,17 +18,17 @@ export type AsyncState<T> =
       value: T;
     };
 
-const useAsyncFn = <T>(fn: () => Promise<T>, deps: DependencyList = []): [AsyncState<T>, () => void] => {
+const useAsyncFn = <T>(fn: (...args: any[]) => Promise<T>, deps: DependencyList = []): [AsyncState<T>, () => void] => {
   const [state, set] = useState<AsyncState<T>>({
     loading: false,
   });
 
   const mounted = useRefMounted();
 
-  const callback = useCallback(() => {
+  const callback = useCallback((...args) => {
     set({ loading: true });
 
-    fn().then(
+    fn(...args).then(
       value => {
         if (mounted.current) {
           set({ value, loading: false });


### PR DESCRIPTION
Passing arguments to `useAsyncFn` fetcher might be very useful, for example in case of autocomplete:

```jsx
const [state, fetchSuggestions] = useAsyncFn(query => { /* fetch result somehow */ });

<Autocomplete onLoad={fetchSuggestions} items={state.value} />
```