### PR TITLE
Fix useSetState callback parameter type

### DIFF
--- a/src/useSetState.ts
+++ b/src/useSetState.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-const useSetState = <T extends object>(initialState: T = {} as T): [T, (patch: Partial<T> | (() => void)) => void] => {
+const useSetState = <T extends object>(initialState: T = {} as T): [T, (patch: Partial<T> | ((prevState: T) => Partial<T>)) => void] => {
   const [state, set] = useState<T>(initialState);
   const setState = patch => {
     set(prevState => Object.assign({}, prevState, patch instanceof Function ? patch(prevState) : patch));


### PR DESCRIPTION
I'm not a TS guru by any means, but I found it odd that the callback type 1.) didn't accept a `prevState`, nor return a _partial_ of `prevState`.

Updating this type seems to fix the issue for me.