### PR TITLE
Fixed useSetState definition

### DIFF
--- a/src/useSetState.ts
+++ b/src/useSetState.ts
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 
-const useSetState = <T extends object>(initialState: T = {} as T): [T, (patch: Partial<T> | (() => void)) => void] => {
+const useSetState = <T extends object>(
+  initialState: T = {} as T
+): [T, (patch: Partial<T> | ((prevState: T) => void)) => void] => {
   const [state, set] = useState<T>(initialState);
   const setState = patch => {
     set(prevState => Object.assign({}, prevState, patch instanceof Function ? patch(prevState) : patch));


### PR DESCRIPTION
Correct the definition that the setState updater function must to have the prevState parameter.