### PR TITLE
Add useScrolling hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ import usePromise from './usePromise';
 import useRaf from './useRaf';
 import useRefMounted from './useRefMounted';
 import useScroll from './useScroll';
+import useScrolling from './useScrolling';
 import useSessionStorage from './useSessionStorage';
 import useSetState from './useSetState';
 import useSize from './useSize';
@@ -127,6 +128,7 @@ export {
   useRaf,
   useRefMounted,
   useScroll,
+  useScrolling,
   useSessionStorage,
   useSetState,
   useSize,

--- a/src/useScrolling.ts
+++ b/src/useScrolling.ts
@@ -1,0 +1,31 @@
+import { RefObject, useEffect, useState } from 'react';
+
+const useScrolling = (ref: RefObject<HTMLElement>): boolean => {
+  const [scrolling, setScrolling] = useState<boolean>(false);
+
+  useEffect(
+    () => {
+      if (ref.current) {
+        let scrollingTimeout;
+
+        const handleScrollEnd = () => {
+          setScrolling(false);
+        };
+
+        const handleScroll = () => {
+          setScrolling(true);
+          clearTimeout(scrollingTimeout);
+          scrollingTimeout = setTimeout(() => handleScrollEnd(), 150);
+        };
+
+        ref.current.addEventListener('scroll', handleScroll, false);
+        return () => ref.current.removeEventListener('scroll', handleScroll, false);
+      }
+    },
+    [ref.current],
+  );
+
+  return scrolling;
+};
+
+export default useScrolling;


### PR DESCRIPTION
This hook keeps track of whether the user is scrolling or not. It can be used like this:

```javascript
const scrolling = useScrolling(scrollerRef);
```

Or can be used with the `usePrevious` hook to detect when a scroll starts or ends:

```javascript
const scrolling = useScrolling(scrollerRef);
const prevScrolling = usePrevious(scrolling);

useEffect(
  () => {
    if (scrolling && !prevScrolling) {
      // scroll started
    } else if (!scrolling && prevScrolling) {
      // scroll ended
    }
  },
  [scrolling],
);
```