### PR TITLE
fix: fix Storybook docs Markdown import

### DIFF
--- a/src/__stories__/util/ShowDocs.tsx
+++ b/src/__stories__/util/ShowDocs.tsx
@@ -11,7 +11,7 @@ const ShowDocs = props => {
         padding: '0 20px',
       },
       dangerouslySetInnerHTML: {
-        __html: props.md,
+        __html: props.md.default,
       },
     }),
     h('style', {


### PR DESCRIPTION
Markdown files don't render properly in Storybook. I'm not sure what broke it so not sure if this is the best fix