### PR TITLE
useMap uses previous map state upon set and remove

### DIFF
--- a/src/useList.ts
+++ b/src/useList.ts
@@ -18,7 +18,8 @@ const useList = <T>(initialList: T[] = []): [T[], Actions<T>] => {
     {
       set,
       clear: () => set([]),
-      updateAt: (index, entry) => set(currentList => [...currentList.slice(0, index), entry, ...currentList.slice(index + 1)]),
+      updateAt: (index, entry) =>
+        set(currentList => [...currentList.slice(0, index), entry, ...currentList.slice(index + 1)]),
       remove: index => set(currentList => [...currentList.slice(0, index), ...currentList.slice(index + 1)]),
       push: entry => set(currentList => [...currentList, entry]),
       filter: fn => set(currentList => currentList.filter(fn)),

--- a/src/useMap.ts
+++ b/src/useMap.ts
@@ -15,7 +15,7 @@ const useMap = <T extends object = any>(initialMap: T = {} as T): [T, Actions<T>
     {
       get: (key: keyof T) => map[key as string],
       set: <K extends keyof T>(key: K, entry: T[K]) => {
-        set((prevMap)=>({
+        set(prevMap => ({
           ...prevMap,
           [key]: entry,
         }));

--- a/src/useMap.ts
+++ b/src/useMap.ts
@@ -21,8 +21,10 @@ const useMap = <T extends object = any>(initialMap: T = {} as T): [T, Actions<T>
         }));
       },
       remove: (key: keyof T) => {
-        const { [key]: omit, ...rest } = map;
-        set(rest as T);
+        set(prevMap => {
+          const { [key]: omit, ...rest } = prevMap;
+          return rest as T;
+        } );
       },
       reset: () => set(initialMap),
     },

--- a/src/useMap.ts
+++ b/src/useMap.ts
@@ -15,10 +15,10 @@ const useMap = <T extends object = any>(initialMap: T = {} as T): [T, Actions<T>
     {
       get: (key: keyof T) => map[key as string],
       set: <K extends keyof T>(key: K, entry: T[K]) => {
-        set({
-          ...map,
+        set((prevMap)=>({
+          ...prevMap,
           [key]: entry,
-        });
+        }));
       },
       remove: (key: keyof T) => {
         const { [key]: omit, ...rest } = map;


### PR DESCRIPTION
I only explored this route as I was seeing useMap not update object state correctly when using `...map`. IE the state was getting overwritten always with the new field only. 

I don't know why this was happening in some circumstances and not in others, but this makes it work in both environments.