### PR TITLE
fix(useSize): prevents accessing iframe's property when it's not defined

### DIFF
--- a/src/useSize.tsx
+++ b/src/useSize.tsx
@@ -45,7 +45,13 @@ const useSize = (
   };
 
   useEffect(() => {
-    const iframe: HTMLIFrameElement = ref.current!;
+    const iframe: HTMLIFrameElement = ref.current;
+
+    if(!iframe) {
+      // iframe will be undefined if component is already unmounted
+      return;
+    }
+
     if (iframe.contentWindow) {
       window = iframe.contentWindow!;
       onWindow(window);


### PR DESCRIPTION
Fixes error in useSize: Cannot read property 'contentWindow' of null

ref #442