### PR TITLE
useMedia - initialize state with call to media query

### DIFF
--- a/src/useMedia.ts
+++ b/src/useMedia.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-const useMedia = (query: string, defaultState: boolean = false) => {
-  const [state, setState] = useState(defaultState);
+const useMedia = (query: string) => {
+  const [state, setState] = useState(() => window.matchMedia(query).matches);
 
   useEffect(() => {
     let mounted = true;


### PR DESCRIPTION
Initializing state with result from call to window.matchMedia avoids possible initial flicker of returned value, when media query matched initially