### PR TITLE
Remove peer deps from index export

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -6,7 +6,7 @@ You need to have React [`16.8.0`](https://reactjs.org/blog/2019/02/06/react-v16.
 import useToggle from 'react-use/lib/useToggle'
 ```
 
-or use ES6 named imports
+or use ES6 named imports (tree shaking recommended)
 
 ```js
 import {useToggle} from 'react-use'

--- a/docs/useEvent.md
+++ b/docs/useEvent.md
@@ -6,8 +6,7 @@ React sensor hook that subscribes a `handler` to events.
 ## Usage
 
 ```jsx
-import useEvent from 'react-use/lib/useEvent';
-import useList from 'react-use/lib/useList';
+import {useEvent, useList} from 'react-use';
 
 const Demo = () => {
   const [list, {push, clear}] = useList();

--- a/docs/useFullscreen.md
+++ b/docs/useFullscreen.md
@@ -5,8 +5,7 @@ Display an element full-screen, optional fallback for fullscreen video on iOS.
 ## Usage
 
 ```jsx
-import useFullscreen from 'react-use/lib/useFullscreen';
-import useToggle from 'react-use/lib/useToggle';
+import {useFullscreen, useToggle} from 'react-use';
 
 const Demo = () => {
   const ref = useRef(null)

--- a/docs/useInterval.md
+++ b/docs/useInterval.md
@@ -6,7 +6,7 @@ React hook that allow you using declarative `setInterval`.
 
 ```jsx
 import * as React from 'react';
-import useInterval from 'react-use/lib/useInterval';
+import {useInterval} from 'react-use';
 
 const Demo = () => {
   const [count, setCount] = React.useState(0);

--- a/docs/useKey.md
+++ b/docs/useKey.md
@@ -5,7 +5,7 @@ React UI sensor hook that executes a `handler` when a keyboard key is used.
 ## Usage
 
 ```jsx
-import useKey from 'react-use/lib/useKey';
+import {useKey} from 'react-use';
 
 const Demo = () => {
   const [count, set] = useState(0);

--- a/docs/useKeyPress.md
+++ b/docs/useKeyPress.md
@@ -7,7 +7,7 @@ key on their keyboard.
 ## Usage
 
 ```jsx
-import useKeyPress from 'react-use/lib/useKeyPress';
+import {useKeyPress} from 'react-use';
 
 const keys = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'];
 

--- a/docs/useKeyPressEvent.md
+++ b/docs/useKeyPressEvent.md
@@ -9,7 +9,7 @@ if you press and hold a key, it will fire `keydown` callback only once.
 
 ```jsx
 import React, { useState } from React;
-import useKeyPressEvent from 'react-use/lib/useKeyPressEvent';
+import {useKeyPressEvent} from 'react-use';
 
 const Demo = () => {
   const [count, setCount] = useState(0);

--- a/docs/useKeyboardJs.md
+++ b/docs/useKeyboardJs.md
@@ -22,6 +22,8 @@ const Demo = () => {
 };
 ```
 
+Note: Because of dependency on `keyboardjs` you have to import this hook directly like shown above.
+
 ## Requirements
 
 Install [`keyboardjs`](https://github.com/RobertWHurst/KeyboardJS) peer dependency:

--- a/docs/useSpring.md
+++ b/docs/useSpring.md
@@ -6,7 +6,7 @@ to spring dynamics.
 ## Usage
 
 ```jsx
-import useSpring from 'react-use/lib/useSprint';
+import useSpring from 'react-use/lib/useSpring';
 
 const Demo = () => {
   const [target, setTarget] = useState(50);

--- a/docs/useSpring.md
+++ b/docs/useSpring.md
@@ -6,7 +6,7 @@ to spring dynamics.
 ## Usage
 
 ```jsx
-import {useSpring} from 'react-use';
+import useSpring from 'react-use/lib/useSprint';
 
 const Demo = () => {
   const [target, setTarget] = useState(50);
@@ -22,6 +22,8 @@ const Demo = () => {
   );
 };
 ```
+
+Note: Because of dependency on `rebound` you have to import this hook directly like shown above.
 
 ## Requirements
 

--- a/docs/useStartTyping.md
+++ b/docs/useStartTyping.md
@@ -6,7 +6,7 @@ to focus default input field on the page.
 ## Usage
 
 ```jsx
-import useStartTyping from 'react-use/lib/useStartTyping';
+import {useStartTyping} from 'react-use';
 
 const Demo = () => {
   useStartTyping(() => alert('Started typing...'));

--- a/package.json
+++ b/package.json
@@ -55,10 +55,8 @@
     "ts-easing": "^0.2.0"
   },
   "peerDependencies": {
-    "keyboardjs": "*",
     "react": "^16.8.0",
-    "react-dom": "^16.8.0",
-    "rebound": "*"
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "@babel/core": "7.5.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,8 @@ import useIdle from './useIdle';
 import useInterval from './useInterval';
 import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 import useKey from './useKey';
-import useKeyboardJs from './useKeyboardJs';
+// not exported because of peer dependency
+// import useKeyboardJs from './useKeyboardJs';
 import useKeyPress from './useKeyPress';
 import useKeyPressEvent from './useKeyPressEvent';
 import useLifecycles from './useLifecycles';
@@ -60,7 +61,8 @@ import useSessionStorage from './useSessionStorage';
 import useSetState from './useSetState';
 import useSize from './useSize';
 import useSpeech from './useSpeech';
-import useSpring from './useSpring';
+// not exported because of peer dependency
+// import useSpring from './useSpring';
 import useStartTyping from './useStartTyping';
 import useThrottle from './useThrottle';
 import useThrottleFn from './useThrottleFn';
@@ -107,7 +109,6 @@ export {
   useInterval,
   useIsomorphicLayoutEffect,
   useKey,
-  useKeyboardJs,
   useKeyPress,
   useKeyPressEvent,
   useLifecycles,
@@ -139,7 +140,6 @@ export {
   useSetState,
   useSize,
   useSpeech,
-  useSpring,
   useStartTyping,
   useThrottle,
   useThrottleFn,


### PR DESCRIPTION
Fixes #384 #183 

I've unified docs to show ES6 import. I can revert that if you want to keep it like that for some reason.