### PR TITLE
fix: useMouse & useMouseHovered type definitions for SVG

### DIFF
--- a/src/useMouse.ts
+++ b/src/useMouse.ts
@@ -11,7 +11,7 @@ export interface State {
   elW: number;
 }
 
-const useMouse = (ref: RefObject<HTMLElement>): State => {
+const useMouse = (ref: RefObject<Element>): State => {
   if (process.env.NODE_ENV === 'development') {
     if (typeof ref !== 'object' || typeof ref.current === 'undefined') {
       console.error('useMouse expects a single ref argument.');

--- a/src/useMouseHovered.ts
+++ b/src/useMouseHovered.ts
@@ -9,7 +9,7 @@ export interface UseMouseHoveredOptions {
 
 const nullRef = { current: null };
 
-const useMouseHovered = (ref: RefObject<HTMLElement>, options: UseMouseHoveredOptions = {}): State => {
+const useMouseHovered = (ref: RefObject<Element>, options: UseMouseHoveredOptions = {}): State => {
   const whenHovered = !!options.whenHovered;
   const bound = !!options.bound;
 


### PR DESCRIPTION
Closes #465 