### PR TITLE
feat: useUpsert

### DIFF
--- a/docs/useUpsert.md
+++ b/docs/useUpsert.md
@@ -1,0 +1,28 @@
+# `useUpsert`
+
+Superset of `useList`. Provides an additional method to upsert (update or insert) an element into the list. 
+## Usage
+
+```jsx
+import {useUpsert} from 'react-use';
+
+const Demo = () => {
+  const comparisonFunction = (a: DemoType, b: DemoType) => {
+    return a.id === b.id;
+  };
+  const [list, { set, upsert, remove }] = useUpsert(comparisonFunction, initialItems);
+
+  return (
+    <div style={{ display: 'inline-flex', flexDirection: 'column' }}>
+      {list.map((item: DemoType, index: number) => (
+        <div key={item.id}>
+          <input value={item.text} onChange={e => upsert({ ...item, text: e.target.value })} />
+          <button onClick={() => remove(index)}>Remove</button>
+        </div>
+      ))}
+      <button onClick={() => upsert({ id: (list.length + 1).toString(), text: '' })}>Add item</button>
+      <button onClick={() => set([])}>Reset</button>
+    </div>
+  );
+};
+```

--- a/src/__stories__/useUpsert.story.tsx
+++ b/src/__stories__/useUpsert.story.tsx
@@ -1,0 +1,35 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import ShowDocs from './util/ShowDocs';
+import { useUpsert } from '../index';
+
+interface DemoType {
+  id: string;
+  text: string;
+}
+
+const initialItems: DemoType[] = [{ id: '1', text: 'Sample' }, { id: '2', text: '' }];
+
+const Demo = () => {
+  const comparisonFunction = (a: DemoType, b: DemoType) => {
+    return a.id === b.id;
+  };
+  const [list, { set, upsert, remove }] = useUpsert(comparisonFunction, initialItems);
+
+  return (
+    <div style={{ display: 'inline-flex', flexDirection: 'column' }}>
+      {list.map((item: DemoType, index: number) => (
+        <div key={item.id}>
+          <input value={item.text} onChange={e => upsert({ ...item, text: e.target.value })} />
+          <button onClick={() => remove(index)}>Remove</button>
+        </div>
+      ))}
+      <button onClick={() => upsert({ id: (list.length + 1).toString(), text: '' })}>Add item</button>
+      <button onClick={() => set([])}>Reset</button>
+    </div>
+  );
+};
+
+storiesOf('State|useUpsert', module)
+  .add('Docs', () => <ShowDocs md={require('../../docs/useUpsert.md')} />)
+  .add('Demo', () => <Demo />);

--- a/src/__tests__/useUpsert.test.ts
+++ b/src/__tests__/useUpsert.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import useUpsert from '../useUpsert';
+
+interface TestItem {
+  id: string;
+  text: string;
+}
+
+const testItems: TestItem[] = [{ id: '1', text: '1' }, { id: '2', text: '2' }];
+
+const itemsAreEqual = (a: TestItem, b: TestItem) => {
+  return a.id === b.id;
+};
+
+const setUp = (initialList: TestItem[] = []) => renderHook(() => useUpsert<TestItem>(itemsAreEqual, initialList));
+
+describe('useUpsert', () => {
+  describe('initialization', () => {
+    const { result } = setUp(testItems);
+    const [list, utils] = result.current;
+
+    it('properly initiates the list content', () => {
+      expect(list).toEqual(testItems);
+    });
+
+    it('returns an upsert function', () => {
+      expect(utils.upsert).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('upserting a new item', () => {
+    const { result } = setUp(testItems);
+    const [, utils] = result.current;
+
+    const newItem: TestItem = {
+      id: '3',
+      text: '3',
+    };
+    act(() => {
+      utils.upsert(newItem);
+    });
+
+    it('inserts a new item', () => {
+      expect(result.current[0]).toContain(newItem);
+    });
+    it('works immutably', () => {
+      expect(result.current[0]).not.toBe(testItems);
+    });
+  });
+
+  describe('upserting an existing item', () => {
+    const { result } = setUp(testItems);
+    const [, utils] = result.current;
+
+    const newItem: TestItem = {
+      id: '2',
+      text: '4',
+    };
+    act(() => {
+      utils.upsert(newItem);
+    });
+    const updatedList = result.current[0];
+
+    it('has the same length', () => {
+      expect(updatedList).toHaveLength(testItems.length);
+    });
+    it('updates the item', () => {
+      expect(updatedList).toContain(newItem);
+    });
+    it('works immutably', () => {
+      expect(updatedList).not.toBe(testItems);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export { default as useTween } from './useTween';
 export { default as useUnmount } from './useUnmount';
 export { default as useUpdate } from './useUpdate';
 export { default as useUpdateEffect } from './useUpdateEffect';
+export { default as useUpsert } from './useUpsert';
 export { default as useVideo } from './useVideo';
 export { useWait, Waiter } from './useWait';
 export { default as useWindowScroll } from './useWindowScroll';

--- a/src/useUpsert.ts
+++ b/src/useUpsert.ts
@@ -1,0 +1,37 @@
+import useList, { Actions as ListActions } from './useList';
+
+export interface Actions<T> extends ListActions<T> {
+  upsert: (item: T) => void;
+}
+
+const useUpsert = <T>(
+  itemsAreTheSame: (upsertedItem: T, existingItem: T) => boolean,
+  initialList: T[] = []
+): [T[], Actions<T>] => {
+  const [items, actions] = useList(initialList);
+
+  const upsert = (upsertedItem: T) => {
+    const itemAlreadyExists = items.find(item => itemsAreTheSame(upsertedItem, item));
+    if (itemAlreadyExists) {
+      return actions.set(
+        items.map(existingItem => {
+          if (itemsAreTheSame(upsertedItem, existingItem)) {
+            return upsertedItem;
+          }
+          return existingItem;
+        })
+      );
+    }
+    return actions.push(upsertedItem);
+  };
+
+  return [
+    items,
+    {
+      ...actions,
+      upsert,
+    },
+  ];
+};
+
+export default useUpsert;

--- a/src/useUpsert.ts
+++ b/src/useUpsert.ts
@@ -5,17 +5,17 @@ export interface Actions<T> extends ListActions<T> {
 }
 
 const useUpsert = <T>(
-  itemsAreTheSame: (upsertedItem: T, existingItem: T) => boolean,
+  comparisonFunction: (upsertedItem: T, existingItem: T) => boolean,
   initialList: T[] = []
 ): [T[], Actions<T>] => {
   const [items, actions] = useList(initialList);
 
   const upsert = (upsertedItem: T) => {
-    const itemAlreadyExists = items.find(item => itemsAreTheSame(upsertedItem, item));
+    const itemAlreadyExists = items.find(item => comparisonFunction(upsertedItem, item));
     if (itemAlreadyExists) {
       return actions.set(
         items.map(existingItem => {
-          if (itemsAreTheSame(upsertedItem, existingItem)) {
+          if (comparisonFunction(upsertedItem, existingItem)) {
             return upsertedItem;
           }
           return existingItem;

--- a/src/useUpsert.ts
+++ b/src/useUpsert.ts
@@ -11,18 +11,20 @@ const useUpsert = <T>(
   const [items, actions] = useList(initialList);
 
   const upsert = (upsertedItem: T) => {
-    const itemAlreadyExists = items.find(item => comparisonFunction(upsertedItem, item));
-    if (itemAlreadyExists) {
-      return actions.set(
-        items.map(existingItem => {
-          if (comparisonFunction(upsertedItem, existingItem)) {
-            return upsertedItem;
-          }
-          return existingItem;
-        })
-      );
+    let itemWasFound = false;
+    for (let i = 0; i < items.length; i++) {
+      const existingItem = items[i];
+
+      const shouldUpdate = comparisonFunction(existingItem, upsertedItem);
+      if (shouldUpdate) {
+        actions.updateAt(i, upsertedItem);
+        itemWasFound = true;
+        break;
+      }
     }
-    return actions.push(upsertedItem);
+    if (!itemWasFound) {
+      actions.push(upsertedItem);
+    }
   };
 
   return [


### PR DESCRIPTION
This PR adds the `useUpsert` hook.

`useUpsert` provides a superset of `useList`, with the additional method `upsert`, which combines update or insert functionality. `useUpsert` requires that a comparison function is passed when initialising the hook.

Looking forward to your feedback!