### PR TITLE
refactor: use useMountedState instead of useRefMounted

### DIFF
--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -1,5 +1,5 @@
 import { DependencyList, useCallback, useState } from 'react';
-import useRefMounted from './useRefMounted';
+import useMountedState from './useMountedState';
 
 export type AsyncState<T> =
   | {
@@ -30,23 +30,19 @@ export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
 ): AsyncFn<Result, Args> {
   const [state, set] = useState<AsyncState<Result>>(initialState);
 
-  const mounted = useRefMounted();
+  const isMounted = useMountedState();
 
   const callback = useCallback((...args: Args | []) => {
     set({ loading: true });
 
     return fn(...args).then(
       value => {
-        if (mounted.current) {
-          set({ value, loading: false });
-        }
+        isMounted() && set({ value, loading: false });
 
         return value;
       },
       error => {
-        if (mounted.current) {
-          set({ error, loading: false });
-        }
+        isMounted() && set({ error, loading: false });
 
         return error;
       }

--- a/src/useCopyToClipboard.ts
+++ b/src/useCopyToClipboard.ts
@@ -1,6 +1,6 @@
 import * as writeText from 'copy-to-clipboard';
 import { useCallback } from 'react';
-import useRefMounted from './useRefMounted';
+import useMountedState from './useMountedState';
 import useSetState from './useSetState';
 
 export interface CopyToClipboardState {
@@ -10,7 +10,7 @@ export interface CopyToClipboardState {
 }
 
 const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] => {
-  const mounted = useRefMounted();
+  const isMounted = useMountedState();
   const [state, setState] = useSetState<CopyToClipboardState>({
     value: undefined,
     error: undefined,
@@ -27,7 +27,7 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
 
       const noUserInteraction = writeText(value);
 
-      if (!mounted.current) {
+      if (!isMounted()) {
         return;
       }
       setState({
@@ -36,7 +36,7 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
         noUserInteraction,
       });
     } catch (error) {
-      if (!mounted.current) {
+      if (!isMounted()) {
         return;
       }
       setState({

--- a/src/useDrop.ts
+++ b/src/useDrop.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import useRefMounted from './useRefMounted';
+import useMountedState from './useMountedState';
 
 const { useState, useMemo, useCallback, useEffect } = React;
 
@@ -22,16 +22,13 @@ export interface DropAreaOptions {
 }
 
 const noop = () => {};
-/* 
+/*
 const defaultState: DropAreaState = {
   over: false,
-}; 
+};
 */
 
-const createProcess = (options: DropAreaOptions, mounted: React.RefObject<boolean>) => (
-  dataTransfer: DataTransfer,
-  event
-) => {
+const createProcess = (options: DropAreaOptions, mounted: boolean) => (dataTransfer: DataTransfer, event) => {
   const uri = dataTransfer.getData('text/uri-list');
 
   if (uri) {
@@ -46,7 +43,7 @@ const createProcess = (options: DropAreaOptions, mounted: React.RefObject<boolea
 
   if (dataTransfer.items && dataTransfer.items.length) {
     dataTransfer.items[0].getAsString(text => {
-      if (mounted.current) {
+      if (mounted) {
         (options.onText || noop)(text, event);
       }
     });
@@ -55,10 +52,10 @@ const createProcess = (options: DropAreaOptions, mounted: React.RefObject<boolea
 
 const useDrop = (options: DropAreaOptions = {}, args = []): DropAreaState => {
   const { onFiles, onText, onUri } = options;
-  const mounted = useRefMounted();
+  const isMounted = useMountedState();
   const [over, setOverRaw] = useState<boolean>(false);
   const setOver = useCallback(setOverRaw, []);
-  const process = useMemo(() => createProcess(options, mounted), [onFiles, onText, onUri]);
+  const process = useMemo(() => createProcess(options, isMounted()), [onFiles, onText, onUri]);
 
   useEffect(() => {
     const onDragOver = event => {

--- a/src/useDropArea.ts
+++ b/src/useDropArea.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import useRefMounted from './useRefMounted';
+import useMountedState from './useMountedState';
 
 export interface DropAreaState {
   over: boolean;
@@ -20,16 +20,13 @@ export interface DropAreaOptions {
 }
 
 const noop = () => {};
-/* 
+/*
 const defaultState: DropAreaState = {
   over: false,
-}; 
+};
 */
 
-const createProcess = (options: DropAreaOptions, mounted: React.RefObject<boolean>) => (
-  dataTransfer: DataTransfer,
-  event
-) => {
+const createProcess = (options: DropAreaOptions, mounted: boolean) => (dataTransfer: DataTransfer, event) => {
   const uri = dataTransfer.getData('text/uri-list');
 
   if (uri) {
@@ -44,7 +41,7 @@ const createProcess = (options: DropAreaOptions, mounted: React.RefObject<boolea
 
   if (dataTransfer.items && dataTransfer.items.length) {
     dataTransfer.items[0].getAsString(text => {
-      if (mounted.current) {
+      if (mounted) {
         (options.onText || noop)(text, event);
       }
     });
@@ -76,9 +73,9 @@ const createBond = (process, setOver): DropAreaBond => ({
 
 const useDropArea = (options: DropAreaOptions = {}): [DropAreaBond, DropAreaState] => {
   const { onFiles, onText, onUri } = options;
-  const mounted = useRefMounted();
+  const isMounted = useMountedState();
   const [over, setOver] = useState<boolean>(false);
-  const process = useMemo(() => createProcess(options, mounted), [onFiles, onText, onUri]);
+  const process = useMemo(() => createProcess(options, isMounted()), [onFiles, onText, onUri]);
   const bond: DropAreaBond = useMemo(() => createBond(process, setOver), [process, setOver]);
 
   return [bond, { over }];

--- a/src/useMountedState.ts
+++ b/src/useMountedState.ts
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 
 export default function useMountedState(): () => boolean {
   const mountedRef = useRef<boolean>(false);
+  const get = useCallback(() => mountedRef.current, []);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -11,5 +12,5 @@ export default function useMountedState(): () => boolean {
     };
   });
 
-  return () => mountedRef.current;
+  return get;
 }

--- a/src/usePromise.ts
+++ b/src/usePromise.ts
@@ -1,22 +1,18 @@
 import { useCallback } from 'react';
-import useRefMounted from './useRefMounted';
+import useMountedState from './useMountedState';
 
 export type UsePromise = () => <T>(promise: Promise<T>) => Promise<T>;
 
 const usePromise: UsePromise = () => {
-  const refMounted = useRefMounted();
+  const isMounted = useMountedState();
   return useCallback(
     (promise: Promise<any>) =>
       new Promise<any>((resolve, reject) => {
         const onValue = value => {
-          if (refMounted.current) {
-            resolve(value);
-          }
+          isMounted() && resolve(value);
         };
         const onError = error => {
-          if (refMounted.current) {
-            reject(error);
-          }
+          isMounted() && reject(error);
         };
         promise.then(onValue, onError);
       }),


### PR DESCRIPTION
- Improved useMountedState (now returns only one function instead a new one each call);
- Replaced all `useRefMounted` to `useMountedState` to deprecate first one in later releases;