### PR TITLE
Improve useWindowSize performance with requestAnimationFrame

### DIFF
--- a/src/__tests__/useWindowSize.test.tsx
+++ b/src/__tests__/useWindowSize.test.tsx
@@ -1,5 +1,23 @@
 import { act, renderHook } from '@testing-library/react-hooks';
+import { replaceRaf } from 'raf-stub';
 import useWindowSize from '../useWindowSize';
+
+interface RequestAnimationFrame {
+  reset(): void;
+  step(): void;
+}
+
+declare var requestAnimationFrame: RequestAnimationFrame;
+
+replaceRaf();
+
+beforeEach(() => {
+  requestAnimationFrame.reset();
+});
+
+afterEach(() => {
+  requestAnimationFrame.reset();
+});
 
 // simulate window resize
 function fireResize(type, value) {
@@ -27,12 +45,14 @@ describe('useWindowSize', () => {
   it('should update width', () => {
     act(() => {
       fireResize('width', 320);
-      hook.rerender();
+      requestAnimationFrame.step();
     });
+
     expect(hook.result.current.width).toBe(320);
+
     act(() => {
       fireResize('width', 640);
-      hook.rerender();
+      requestAnimationFrame.step();
     });
     expect(hook.result.current.width).toBe(640);
   });
@@ -40,12 +60,13 @@ describe('useWindowSize', () => {
   it('should update height', () => {
     act(() => {
       fireResize('height', 500);
-      hook.rerender();
+      requestAnimationFrame.step();
     });
     expect(hook.result.current.height).toBe(500);
+
     act(() => {
       fireResize('height', 1000);
-      hook.rerender();
+      requestAnimationFrame.step();
     });
     expect(hook.result.current.height).toBe(1000);
   });

--- a/src/useWindowSize.ts
+++ b/src/useWindowSize.ts
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { isClient } from './util';
 
 const useWindowSize = (initialWidth = Infinity, initialHeight = Infinity) => {
+  const frame = useRef(0);
   const [state, setState] = useState<{ width: number; height: number }>({
     width: isClient ? window.innerWidth : initialWidth,
     height: isClient ? window.innerHeight : initialHeight,
@@ -10,13 +11,23 @@ const useWindowSize = (initialWidth = Infinity, initialHeight = Infinity) => {
   useEffect(() => {
     if (isClient) {
       const handler = () => {
-        setState({
-          width: window.innerWidth,
-          height: window.innerHeight,
+        cancelAnimationFrame(frame.current);
+
+        frame.current = requestAnimationFrame(() => {
+          setState({
+            width: window.innerWidth,
+            height: window.innerHeight,
+          });
         });
       };
+
       window.addEventListener('resize', handler);
-      return () => window.removeEventListener('resize', handler);
+
+      return () => {
+        cancelAnimationFrame(frame.current);
+
+        window.removeEventListener('resize', handler);
+      };
     } else {
       return undefined;
     }


### PR DESCRIPTION
Use [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) to improve performance of resize handler. Currently tests are failing though so it would be nice if someone could point me in the right direction on how to mock requestAnimationFrame 🙂