### PR TITLE
fix: async test warnings

### DIFF
--- a/src/__tests__/useAsync.test.tsx
+++ b/src/__tests__/useAsync.test.tsx
@@ -107,11 +107,14 @@ describe('useAsync', () => {
         return 'new value';
       };
 
-      beforeEach(() => {
+      beforeEach(done => {
         callCount = 0;
+
         hook = renderHook(({ fn }) => useAsync(fn, [fn]), {
           initialProps: { fn: initialFn },
         });
+
+        hook.waitForNextUpdate().then(done);
       });
 
       it('renders the first value', () => {
@@ -140,7 +143,7 @@ describe('useAsync', () => {
         return `counter is ${counter} and callCount is ${callCount}`;
       };
 
-      beforeEach(() => {
+      beforeEach(done => {
         callCount = 0;
         hook = renderHook(
           ({ fn, counter }) => {
@@ -154,6 +157,8 @@ describe('useAsync', () => {
             },
           }
         );
+
+        hook.waitForNextUpdate().then(done);
       });
 
       it('initial renders the first passed pargs', () => {


### PR DESCRIPTION
useAsync tests been missing render await in `onBefore` stage;
useAsyncFn tests been missing `act` calls;