### PR TITLE
fix: succeed useRafLoop tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "lint-staged": "9.2.3",
     "markdown-loader": "5.1.0",
     "prettier": "1.18.2",
+    "raf-stub": "^3.0.0",
     "react": "16.9.0",
     "react-dom": "16.9.0",
     "react-spring": "8.0.27",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9973,6 +9973,11 @@ raf-schd@^4.0.0:
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
   integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
 
+raf-stub@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/raf-stub/-/raf-stub-3.0.0.tgz#40e53dc3ad3b241311f914bbd41dc11a2c9ee0a9"
+  integrity sha512-64wjDTI8NAkplC3WYF3DUBXmdx8AZF0ubxiicZi83BKW5hcdvMtbwDe6gpFBngTo6+XIJbfwmUP8lMa85UPK6A==
+
 raf@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"


### PR DESCRIPTION
Fix: #546;
Fix useRafLoop tests. Now it always succeed.
Added `raf-stub` package to test RAF dependant hooks predictably.