### PR TITLE
Removed prepended window from setTimeout

### DIFF
--- a/src/useTimeoutFn.ts
+++ b/src/useTimeoutFn.ts
@@ -9,7 +9,7 @@ export default function useTimeoutFn(fn: Function, ms: number = 0): UseTimeoutFn
   const isReady = useCallback(() => ready.current, []);
   const set = useCallback(() => {
     ready.current = false;
-    timeout.current = window.setTimeout(() => {
+    timeout.current = setTimeout(() => {
       ready.current = true;
       fn();
     }, ms);

--- a/src/useTimeoutFn.ts
+++ b/src/useTimeoutFn.ts
@@ -4,7 +4,7 @@ export type UseTimeoutFnReturn = [() => boolean | null, () => void, () => void];
 
 export default function useTimeoutFn(fn: Function, ms: number = 0): UseTimeoutFnReturn {
   const ready = useRef<boolean | null>(false);
-  const timeout = useRef(0);
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
 
   const isReady = useCallback(() => ready.current, []);
   const set = useCallback(() => {


### PR DESCRIPTION
Similar to the `clearTimeout`, the `setTimeout` shouldn't need the `window` object.
As a result this function can work in node environment, e.g. SSR.