### PR TITLE
fix(useSetState): memoize setState callback

### DIFF
--- a/src/__tests__/useSetState.test.ts
+++ b/src/__tests__/useSetState.test.ts
@@ -40,3 +40,21 @@ it('should merge changes into current state when providing function', () => {
 
   expect(result.current[0]).toEqual({ foo: 'bar', count: 2, someBool: true });
 });
+
+/**
+ * Enforces cases where a hook can safely depend on the callback without
+ * causing an endless rerender cycle: useEffect(() => setState({ data }), [setState]);
+ */
+it('should return a memoized setState callback', () => {
+  const { result, rerender } = setUp({ ok: false });
+  const [, setState1] = result.current;
+
+  act(() => {
+    setState1({ ok: true });
+  });
+  rerender();
+
+  const [, setState2] = result.current;
+
+  expect(setState1).toBe(setState2);
+});

--- a/src/useSetState.ts
+++ b/src/useSetState.ts
@@ -1,12 +1,15 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 const useSetState = <T extends object>(
   initialState: T = {} as T
 ): [T, (patch: Partial<T> | ((prevState: T) => Partial<T>)) => void] => {
   const [state, set] = useState<T>(initialState);
-  const setState = patch => {
-    set(prevState => Object.assign({}, prevState, patch instanceof Function ? patch(prevState) : patch));
-  };
+  const setState = useCallback(
+    patch => {
+      set(prevState => Object.assign({}, prevState, patch instanceof Function ? patch(prevState) : patch));
+    },
+    [set]
+  );
 
   return [state, setState];
 };


### PR DESCRIPTION
Addresses https://github.com/streamich/react-use/issues/555 

Wraps the callback from `useSetState` in `useCallback` to memoize it so that folks following the Best Practices from the [React FAQ](https://reactjs.org/docs/hooks-faq.html#is-it-safe-to-omit-functions-from-the-list-of-dependencies) with the `react-hooks/exhaustive-deps` [rule](https://www.npmjs.com/package/eslint-plugin-react-hooks) enabled don't trigger endless rerenders in a `useEffect(() => {}, [setState]);` where `setState` is constantly changing out from under them.

I tried to write a couple tests for this but I'm not really sure what angle to approach it from or how to layer everything together to test for something useful.

### Problematic code fixed by this PR:

```js
const myComponent = () => {
  const [{ loading, data }, setState] = useSetState({ loading: true, data: null });

  useEffect(() => {
    console.log('hi');
    // fetch data
    setState({ loading: false, data: 'data!' });
  }, [setState])

  return null;
}
```

![image](https://user-images.githubusercontent.com/20718430/63574163-03902a00-c53c-11e9-9b30-5dcc411cad34.png)
