### PR TITLE
Improve useThrottleFn type definition

### DIFF
--- a/src/useThrottleFn.ts
+++ b/src/useThrottleFn.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import useUnmount from './useUnmount';
 
-const useThrottleFn = <T>(fn: (...args: any[]) => T, ms: number = 200, args: any[]) => {
+const useThrottleFn = <T, U extends any[]>(fn: (...args: U) => T, ms: number = 200, args: U) => {
   const [state, setState] = useState<T>(null as any);
   const timeout = useRef<ReturnType<typeof setTimeout>>();
   const nextArgs = useRef(null) as any;


### PR DESCRIPTION
## Issue

The typing of `useThrottleFn(fn, ms, args)` does not make sure that the type of `args` matches the type of the arguments of `fn`.

This may lead to runtime issues, for example with the following code:

```tsx
import React, { FC } from 'react';
import { useThrottleFn } from 'react-use';

interface Rect {
  size: {
    width: number;
    height: number;
  };
  color: string;
}

const area = (rect: Rect): number => rect.size.width * rect.size.height;

const Test: FC<{ foo: string }> = ({ foo }): JSX.Element => {
  const bar = useThrottleFn(area, 200, [foo]);
  return <div>{bar}</div>;
};

export default Test;
```

The above will crash at runtime, since `foo` (a `string`) is passed to `area` instead of a `Rect`:

![error](https://user-images.githubusercontent.com/3994389/64182484-95673380-ce68-11e9-82b2-a8cde1b0417b.png)


## Proposed solution

After this PR, the type is properly checked, and typing errors are raised appropriately:

![code](https://user-images.githubusercontent.com/3994389/64182742-fabb2480-ce68-11e9-9764-0d6fb89d9b55.png)
