### PR TITLE
feat: add updateItem removeItem for useList

### DIFF
--- a/src/__tests__/useList.test.ts
+++ b/src/__tests__/useList.test.ts
@@ -12,7 +12,9 @@ it('should init list and utils', () => {
     set: expect.any(Function),
     clear: expect.any(Function),
     updateAt: expect.any(Function),
+    updateItem: expect.any(Function),
     remove: expect.any(Function),
+    removeItem: expect.any(Function),
     push: expect.any(Function),
     filter: expect.any(Function),
     sort: expect.any(Function),
@@ -64,6 +66,19 @@ it('should update element at specific position', () => {
   expect(result.current[0]).not.toBe(initList); // checking immutability
 });
 
+it('should update element by predicate and updater', () => {
+  const initList = [{ id: 1, color: 'red' }, { id: 2, color: 'green' }, { id: 3, color: 'blue' }];
+  const { result } = setUp(initList);
+  const [, utils] = result.current;
+
+  act(() => {
+    utils.updateItem(item => item.id === 2, item => ({ ...item, color: 'black' }));
+  });
+
+  expect(result.current[0]).toEqual([{ id: 1, color: 'red' }, { id: 2, color: 'black' }, { id: 3, color: 'blue' }]);
+  expect(result.current[0]).not.toBe(initList); // checking immutability
+});
+
 it('should remove element at specific position', () => {
   const initList = [1, 2, 3];
   const { result } = setUp(initList);
@@ -74,6 +89,19 @@ it('should remove element at specific position', () => {
   });
 
   expect(result.current[0]).toEqual([1, 3]);
+  expect(result.current[0]).not.toBe(initList); // checking immutability
+});
+
+it('should remove element by predicate', () => {
+  const initList = [{ id: 1 }, { id: 2 }, { id: 3 }];
+  const { result } = setUp(initList);
+  const [, utils] = result.current;
+
+  act(() => {
+    utils.removeItem(item => item.id === 2);
+  });
+
+  expect(result.current[0]).toEqual([{ id: 1 }, { id: 3 }]);
   expect(result.current[0]).not.toBe(initList); // checking immutability
 });
 

--- a/src/useList.ts
+++ b/src/useList.ts
@@ -4,7 +4,9 @@ export interface Actions<T> {
   set: (list: T[]) => void;
   clear: () => void;
   updateAt: (index: number, item: T) => void;
+  updateItem: (predicate: (item: T, index: number) => boolean, updater: (item: T) => T) => void;
   remove: (index: number) => void;
+  removeItem: (predicate: (item: T) => boolean) => void;
   push: (item: T) => void;
   filter: (fn: (value: T) => boolean) => void;
   sort: (fn?: (a: T, b: T) => number) => void;
@@ -13,19 +15,22 @@ export interface Actions<T> {
 const useList = <T>(initialList: T[] = []): [T[], Actions<T>] => {
   const [list, set] = useState<T[]>(initialList);
 
-  return [
-    list,
-    {
-      set,
-      clear: () => set([]),
-      updateAt: (index, entry) =>
-        set(currentList => [...currentList.slice(0, index), entry, ...currentList.slice(index + 1)]),
-      remove: index => set(currentList => [...currentList.slice(0, index), ...currentList.slice(index + 1)]),
-      push: entry => set(currentList => [...currentList, entry]),
-      filter: fn => set(currentList => currentList.filter(fn)),
-      sort: (fn?) => set(currentList => [...currentList].sort(fn)),
+  const actions: Actions<T> = {
+    set,
+    clear: () => set([]),
+    updateAt: (index, entry) =>
+      set(currentList => [...currentList.slice(0, index), entry, ...currentList.slice(index + 1)]),
+    updateItem: (predicate, updater) => {
+      const item = list.find(predicate);
+      item && actions.updateAt(list.findIndex(predicate), updater(item));
     },
-  ];
+    remove: index => set(currentList => [...currentList.slice(0, index), ...currentList.slice(index + 1)]),
+    removeItem: predicate => actions.remove(list.findIndex(predicate)),
+    push: entry => set(currentList => [...currentList, entry]),
+    filter: fn => set(currentList => currentList.filter(fn)),
+    sort: (fn?) => set(currentList => [...currentList].sort(fn)),
+  };
+  return [list, actions];
 };
 
 export default useList;


### PR DESCRIPTION
```
it('should update element by predicate and updater', () => {
  const initList = [{ id: 1, color: 'red' }, { id: 2, color: 'green' }, { id: 3, color: 'blue' }];
  const { result } = setUp(initList);
  const [, utils] = result.current;

  act(() => {
    utils.updateItem(item => item.id === 2, item => ({ ...item, color: 'black' }));
  });

  expect(result.current[0]).toEqual([{ id: 1, color: 'red' }, { id: 2, color: 'black' }, { id: 3, color: 'blue' }]);
  expect(result.current[0]).not.toBe(initList); // checking immutability
});
```

```
it('should remove element by predicate', () => {
  const initList = [{ id: 1 }, { id: 2 }, { id: 3 }];
  const { result } = setUp(initList);
  const [, utils] = result.current;

  act(() => {
    utils.removeItem(item => item.id === 2);
  });

  expect(result.current[0]).toEqual([{ id: 1 }, { id: 3 }]);
  expect(result.current[0]).not.toBe(initList); // checking immutability
});
```