### PR TITLE
Flag to track if useMouseHovered is dirty

### DIFF
--- a/docs/useMouse.md
+++ b/docs/useMouse.md
@@ -13,14 +13,20 @@ import {useMouse} from 'react-use';
 
 const Demo = () => {
   const ref = React.useRef(null);
-  const {docX, docY, posX, posY, elX, elY, elW, elH} = useMouse(ref);
+  const {docX, docY, posX, posY, elX, elY, elW, elH, dirty} = useMouse(ref);
 
   return (
     <div ref={ref}>
-      <div>Mouse position in document - x:{docX} y:{docY}</div>
-      <div>Mouse position in element - x:{elX} y:{elY}</div>
-      <div>Element position- x:{posX} y:{posY}</div>
-      <div>Element dimensions - {elW}x{elH}</div>
+      {
+        dirty ?
+        <Fragment>
+          <div>Mouse position in document - x:{docX} y:{docY}</div>
+          <div>Mouse position in element - x:{elX} y:{elY}</div>
+          <div>Element position- x:{posX} y:{posY}</div>
+          <div>Element dimensions - {elW}x{elH}</div>
+        </Fragment>
+        : <div>Waiting for mouse to move...</div>
+      }
     </div>
   );
 };

--- a/src/useMouse.ts
+++ b/src/useMouse.ts
@@ -9,6 +9,7 @@ export interface State {
   elY: number;
   elH: number;
   elW: number;
+  dirty: boolean;
 }
 
 const useMouse = (ref: RefObject<Element>): State => {
@@ -28,6 +29,7 @@ const useMouse = (ref: RefObject<Element>): State => {
     elY: 0,
     elH: 0,
     elW: 0,
+    dirty: false,
   });
 
   useEffect(() => {
@@ -51,6 +53,7 @@ const useMouse = (ref: RefObject<Element>): State => {
             elY,
             elH,
             elW,
+            dirty: true,
           });
         }
       });


### PR DESCRIPTION
A solution to #478 

We could use NaN/null/undefined etc. for the variable values (i.e. docX, docY, elX and elY) but that would translate to poor DX overall. Moreover, it would break backward compatibility.

It would be much easier for those who are concerned with making updates after the mouse has moved once, to be able to wrap all their logic in a block that checks if the mouse has moved once, whilst the original values still stay 0 and not null or something.

I have given the name "dirty" to this flag.

Let me know what you think!