### PR TITLE
useAsyncFn - return Promise.reject() or Promise.resolve() in the promise resolution

### DIFF
--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -12,8 +12,14 @@ export default function useAsync<Result = any, Args extends any[] = any[]>(
   });
 
   useEffect(() => {
-    callback();
+    init();
   }, [callback]);
+
+  async function init() {
+    try {
+      await callback();
+    } catch {}
+  }
 
   return state;
 }

--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -39,12 +39,12 @@ export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
       value => {
         isMounted() && set({ value, loading: false });
 
-        return value;
+        return Promise.resolve(value);
       },
       error => {
         isMounted() && set({ error, loading: false });
 
-        return error;
+        return Promise.reject(error);
       }
     );
   }, deps);


### PR DESCRIPTION
# Problem

```javascript
const [registration, register] = useAsyncFn(Service.register)

async function handleSubmit(){
  try {
    await register(payload)
    // it always succeeds
  } catch(error){
    // it never reaches here
  } 
}
```
