### PR TITLE
useList allow pushing multiple items

### DIFF
--- a/src/__tests__/useList.test.ts
+++ b/src/__tests__/useList.test.ts
@@ -103,6 +103,19 @@ it('should push duplicated element at the end of the list', () => {
   expect(result.current[0]).not.toBe(initList); // checking immutability
 });
 
+it('should push multiple elements at the end of the list', () => {
+  const initList = [1, 2, 3];
+  const { result } = setUp(initList);
+  const [, utils] = result.current;
+
+  act(() => {
+    utils.push(4, 5, 6);
+  });
+
+  expect(result.current[0]).toEqual([1, 2, 3, 4, 5, 6]);
+  expect(result.current[0]).not.toBe(initList); // checking immutability
+});
+
 it('should filter current list by provided function', () => {
   const initList = [1, -1, 2, -2, 3, -3];
   const { result } = setUp(initList);

--- a/src/useList.ts
+++ b/src/useList.ts
@@ -5,7 +5,7 @@ export interface Actions<T> {
   clear: () => void;
   updateAt: (index: number, item: T) => void;
   remove: (index: number) => void;
-  push: (item: T) => void;
+  push: (...items: T[]) => void;
   filter: (fn: (value: T) => boolean) => void;
   sort: (fn?: (a: T, b: T) => number) => void;
 }
@@ -21,7 +21,7 @@ const useList = <T>(initialList: T[] = []): [T[], Actions<T>] => {
       updateAt: (index, entry) =>
         set(currentList => [...currentList.slice(0, index), entry, ...currentList.slice(index + 1)]),
       remove: index => set(currentList => [...currentList.slice(0, index), ...currentList.slice(index + 1)]),
-      push: entry => set(currentList => [...currentList, entry]),
+      push: (...entry) => set(currentList => [...currentList, ...entry]),
       filter: fn => set(currentList => currentList.filter(fn)),
       sort: (fn?) => set(currentList => [...currentList].sort(fn)),
     },


### PR DESCRIPTION
Update `useList`'s push to behave like [Array.prototype.push()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push) to allow pushing multiple items in one go.