### PR TITLE
useDebounce remove deps from function arguments

### DIFF
--- a/src/useDebounce.ts
+++ b/src/useDebounce.ts
@@ -1,14 +1,14 @@
+import { DependencyList } from 'react';
 import useUpdateEffect from './useUpdateEffect';
 
-const useDebounce = (fn: () => any, ms: number = 0, args: any[] = []) => {
+const useDebounce = (fn: () => any, ms: number = 0, deps: DependencyList = []) => {
   useUpdateEffect(() => {
-    const handle = setTimeout(fn.bind(null, args), ms);
+    const timeout = setTimeout(fn, ms);
 
     return () => {
-      // if args change then clear timeout
-      clearTimeout(handle);
+      clearTimeout(timeout);
     };
-  }, args);
+  }, deps);
 };
 
 export default useDebounce;


### PR DESCRIPTION
Removed hook dependencies from function arguments to align hook API with standard React hooks. The dependency array was also passed as single array and spread the items in the array as arguments which probably resulted in no developers using arguments of the timeout function.

I have also rename `args` to `deps` for consistency.

Closes #618 