### PR TITLE
Update screenfull to v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-fast-compare": "^2.0.4",
     "react-wait": "^0.3.0",
     "resize-observer-polyfill": "^1.5.1",
-    "screenfull": "^4.1.0",
+    "screenfull": "^5.0.0",
     "set-harmonic-interval": "^1.0.0",
     "throttle-debounce": "^2.0.1",
     "ts-easing": "^0.2.0"

--- a/src/useFullscreen.ts
+++ b/src/useFullscreen.ts
@@ -26,7 +26,7 @@ const useFullscreen = (ref: RefObject<Element>, on: boolean, options: FullScreen
     };
 
     const onChange = () => {
-      if (screenfull) {
+      if (screenfull.isEnabled) {
         const isScreenfullFullscreen = screenfull.isFullscreen;
         setIsFullscreen(isScreenfullFullscreen);
         if (!isScreenfullFullscreen) {
@@ -35,7 +35,7 @@ const useFullscreen = (ref: RefObject<Element>, on: boolean, options: FullScreen
       }
     };
 
-    if (screenfull && screenfull.enabled) {
+    if (screenfull.isEnabled) {
       try {
         screenfull.request(ref.current);
         setIsFullscreen(true);
@@ -55,7 +55,7 @@ const useFullscreen = (ref: RefObject<Element>, on: boolean, options: FullScreen
 
     return () => {
       setIsFullscreen(false);
-      if (screenfull && screenfull.enabled) {
+      if (screenfull.isEnabled) {
         try {
           screenfull.off('change', onChange);
           screenfull.exit();

--- a/yarn.lock
+++ b/yarn.lock
@@ -11239,10 +11239,10 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-screenfull@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-4.1.0.tgz#30eb338f615941f5a2cdd96c14e36063d2d9d764"
-  integrity sha512-/qH0HAmc+ilbZ9Vf8J7RHjjecSdqmjIh98iMkA6uCSKcHdJK1TiXhTbR+cin8rG70xi4Peyz7wW1KJVP6sp30g==
+screenfull@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.0.0.tgz#5c2010c0e84fd4157bf852877698f90b8cbe96f6"
+  integrity sha512-yShzhaIoE9OtOhWVyBBffA6V98CDCoyHTsp8228blmqYy1Z5bddzE/4FPiJKlr8DVR4VBiiUyfPzIQPIYDkeMA==
 
 scrollbarwidth@^0.1.3:
   version "0.1.3"


### PR DESCRIPTION
This updates the dependency and the code for `useFullscreen()` to be compatible with `screenfull` v5.0.0.

#598 is broken because it doesn't fix the code.