### PR TITLE
Remove ref.current from dependency lists

### DIFF
--- a/src/useFullscreen.ts
+++ b/src/useFullscreen.ts
@@ -65,7 +65,7 @@ const useFullscreen = (ref: RefObject<Element>, on: boolean, options: FullScreen
         video.current.webkitExitFullscreen();
       }
     };
-  }, [ref.current, video, on]);
+  }, [on, video, ref]);
 
   return isFullscreen;
 };

--- a/src/useMouse.ts
+++ b/src/useMouse.ts
@@ -62,7 +62,7 @@ const useMouse = (ref: RefObject<Element>): State => {
       cancelAnimationFrame(frame.current);
       document.removeEventListener('mousemove', moveHandler);
     };
-  }, [ref.current]);
+  }, [ref]);
 
   return state;
 };

--- a/src/useScroll.ts
+++ b/src/useScroll.ts
@@ -48,7 +48,7 @@ const useScroll = (ref: RefObject<HTMLElement>): State => {
         ref.current.removeEventListener('scroll', handler);
       }
     };
-  }, [ref.current]);
+  }, [ref]);
 
   return state;
 };

--- a/src/useScrolling.ts
+++ b/src/useScrolling.ts
@@ -25,7 +25,7 @@ const useScrolling = (ref: RefObject<HTMLElement>): boolean => {
       };
     }
     return () => {};
-  }, [ref.current]);
+  }, [ref]);
 
   return scrolling;
 };


### PR DESCRIPTION
It doesn't make sense to add `ref.current` to a dependency array, see https://github.com/facebook/react/issues/16121#issuecomment-511369830

Related #638 