### PR TITLE
fix: useSize avoid crash in Safari 11

### DIFF
--- a/src/useSize.tsx
+++ b/src/useSize.tsx
@@ -67,7 +67,7 @@ const useSize = (
     }
 
     return () => {
-      if (window) {
+      if (window && window.removeEventListener) {
         window.removeEventListener('resize', setSize);
       }
     };


### PR DESCRIPTION
 `window.removeEventListener` could be null for a **removed** iframe element in **Safari 11** while `window` is regarded as a reference to `iframe.contentWindow`.