### PR TITLE
[DRAFT] feat: useEnchanceableReducer and useReducerWithMiddleware

### DIFF
--- a/src/enhanceableReducer/applyMiddleware.ts
+++ b/src/enhanceableReducer/applyMiddleware.ts
@@ -1,4 +1,7 @@
-import { Dispatch, Store } from './createStore';
+// taken from redux and modified for hooks reality
+import { MutableRefObject } from 'react';
+import { compose } from './compose';
+import { Dispatch, Reducer, StoreCreator, StoreEnhancer } from './createStore';
 
 interface StoreAPI<D extends Dispatch = Dispatch, S = any> {
   dispatch: D;
@@ -9,11 +12,56 @@ export type Middleware<S = any, D extends Dispatch = Dispatch> = (
   store: StoreAPI<D, S>
 ) => (next: Dispatch<any>) => (action: any) => any;
 
-export function composeMiddleware<R>(...middlewares: Middleware[]): R;
-export function composeMiddleware(...middlewares: Middleware[]) {
-  return <State, Action>(store: Store<State, Action>, dispatch: Dispatch<Action>) =>
-    middlewares.reduce(
-      (disp: Dispatch<Action>, middleware: Middleware<State, Dispatch<Action>>) => middleware(store)(disp),
-      dispatch
-    );
+export function applyMiddleware(): StoreEnhancer;
+export function applyMiddleware<Ext1, S>(middleware1: Middleware<S, any>): StoreEnhancer<{ dispatch: Ext1 }>;
+export function applyMiddleware<Ext1, Ext2, S>(
+  middleware1: Middleware<S, any>,
+  middleware2: Middleware<S, any>
+): StoreEnhancer<{ dispatch: Ext1 & Ext2 }>;
+export function applyMiddleware<Ext1, Ext2, Ext3, S>(
+  middleware1: Middleware<S, any>,
+  middleware2: Middleware<S, any>,
+  middleware3: Middleware<S, any>
+): StoreEnhancer<{ dispatch: Ext1 & Ext2 & Ext3 }>;
+export function applyMiddleware<Ext1, Ext2, Ext3, Ext4, S>(
+  middleware1: Middleware<S, any>,
+  middleware2: Middleware<S, any>,
+  middleware3: Middleware<S, any>,
+  middleware4: Middleware<S, any>
+): StoreEnhancer<{ dispatch: Ext1 & Ext2 & Ext3 & Ext4 }>;
+export function applyMiddleware<Ext1, Ext2, Ext3, Ext4, Ext5, S>(
+  middleware1: Middleware<S, any>,
+  middleware2: Middleware<S, any>,
+  middleware3: Middleware<S, any>,
+  middleware4: Middleware<S, any>,
+  middleware5: Middleware<S, any>
+): StoreEnhancer<{ dispatch: Ext1 & Ext2 & Ext3 & Ext4 & Ext5 }>;
+export function applyMiddleware<Ext, S = any>(
+  ...middlewares: Array<Middleware<S, any>>
+): StoreEnhancer<{ dispatch: Ext }>;
+
+export function applyMiddleware(...middlewares: Middleware[]): StoreEnhancer<any> {
+  return (createStore: StoreCreator) => <State, Action = any>(
+    reducer: MutableRefObject<Reducer<State, Action>>,
+    ...args: any[]
+  ) => {
+    const store = createStore(reducer, ...args);
+    let dispatch: Dispatch = () => {
+      throw new Error(
+        'Dispatch during middleware construction is forbidden. Other middleware would not be applied to this dispatch.'
+      );
+    };
+
+    const storeAPI: StoreAPI = {
+      getState: store.getState,
+      dispatch: (action, ...arg) => dispatch(action, ...arg),
+    };
+
+    dispatch = compose<typeof dispatch>(...middlewares.map(middleware => middleware(storeAPI)))(store.dispatch);
+
+    return {
+      ...store,
+      dispatch,
+    };
+  };
 }

--- a/src/enhanceableReducer/applyMiddleware.ts
+++ b/src/enhanceableReducer/applyMiddleware.ts
@@ -1,0 +1,19 @@
+import { Dispatch, Store } from './createStore';
+
+interface StoreAPI<D extends Dispatch = Dispatch, S = any> {
+  dispatch: D;
+  getState: () => S;
+}
+
+export type Middleware<S = any, D extends Dispatch = Dispatch> = (
+  store: StoreAPI<D, S>
+) => (next: Dispatch<any>) => (action: any) => any;
+
+export function composeMiddleware<R>(...middlewares: Middleware[]): R;
+export function composeMiddleware(...middlewares: Middleware[]) {
+  return <State, Action>(store: Store<State, Action>, dispatch: Dispatch<Action>) =>
+    middlewares.reduce(
+      (disp: Dispatch<Action>, middleware: Middleware<State, Dispatch<Action>>) => middleware(store)(disp),
+      dispatch
+    );
+}

--- a/src/enhanceableReducer/compose.ts
+++ b/src/enhanceableReducer/compose.ts
@@ -1,0 +1,65 @@
+// taken from redux, as-is
+
+type Func0<R> = () => R;
+type Func1<T1, R> = (a1: T1) => R;
+type Func2<T1, T2, R> = (a1: T1, a2: T2) => R;
+type Func3<T1, T2, T3, R> = (a1: T1, a2: T2, a3: T3, ...args: any[]) => R;
+
+export function compose(): <R>(a: R) => R;
+
+export function compose<F extends Function>(f: F): F;
+
+/* two functions */
+export function compose<A, R>(f1: (b: A) => R, f2: Func0<A>): Func0<R>;
+export function compose<A, T1, R>(f1: (b: A) => R, f2: Func1<T1, A>): Func1<T1, R>;
+export function compose<A, T1, T2, R>(f1: (b: A) => R, f2: Func2<T1, T2, A>): Func2<T1, T2, R>;
+export function compose<A, T1, T2, T3, R>(f1: (b: A) => R, f2: Func3<T1, T2, T3, A>): Func3<T1, T2, T3, R>;
+
+/* three functions */
+export function compose<A, B, R>(f1: (b: B) => R, f2: (a: A) => B, f3: Func0<A>): Func0<R>;
+export function compose<A, B, T1, R>(f1: (b: B) => R, f2: (a: A) => B, f3: Func1<T1, A>): Func1<T1, R>;
+export function compose<A, B, T1, T2, R>(f1: (b: B) => R, f2: (a: A) => B, f3: Func2<T1, T2, A>): Func2<T1, T2, R>;
+export function compose<A, B, T1, T2, T3, R>(
+  f1: (b: B) => R,
+  f2: (a: A) => B,
+  f3: Func3<T1, T2, T3, A>
+): Func3<T1, T2, T3, R>;
+
+/* four functions */
+export function compose<A, B, C, R>(f1: (b: C) => R, f2: (a: B) => C, f3: (a: A) => B, f4: Func0<A>): Func0<R>;
+export function compose<A, B, C, T1, R>(
+  f1: (b: C) => R,
+  f2: (a: B) => C,
+  f3: (a: A) => B,
+  f4: Func1<T1, A>
+): Func1<T1, R>;
+export function compose<A, B, C, T1, T2, R>(
+  f1: (b: C) => R,
+  f2: (a: B) => C,
+  f3: (a: A) => B,
+  f4: Func2<T1, T2, A>
+): Func2<T1, T2, R>;
+export function compose<A, B, C, T1, T2, T3, R>(
+  f1: (b: C) => R,
+  f2: (a: B) => C,
+  f3: (a: A) => B,
+  f4: Func3<T1, T2, T3, A>
+): Func3<T1, T2, T3, R>;
+
+/* rest */
+export function compose<R>(f1: (b: any) => R, ...funcs: Function[]): (...args: any[]) => R;
+
+export function compose<R>(...funcs: Function[]): (...args: any[]) => R;
+
+export function compose(...funcs: Function[]) {
+  if (funcs.length === 0) {
+    // infer the argument type so it is usable in inference down the line
+    return <T>(arg: T) => arg;
+  }
+
+  if (funcs.length === 1) {
+    return funcs[0];
+  }
+
+  return funcs.reduce((a, b) => (...args: any) => a(b(...args)));
+}

--- a/src/enhanceableReducer/createStore.ts
+++ b/src/enhanceableReducer/createStore.ts
@@ -1,0 +1,72 @@
+export type Dispatch<A = any> = <T extends A>(action: T, ...extraArgs: any[]) => T;
+
+export type ExtendState<State, Extension> = [Extension] extends [never] ? State : State & Extension;
+
+export interface Store<State, Action> {
+  getState: () => State;
+  dispatch: Dispatch<Action>;
+}
+
+export type Reducer<State = any, Action = any> = (prevState: State, action: Action) => State;
+export type Initializer<State = any> = (initialState: any | undefined) => State;
+
+export type StoreEnhancerStoreCreator<StoreExt = {}, StateExt = never> = <State = any, Action = any>(
+  reducer: Reducer<State, Action>,
+  initialState?: State,
+  initializer?: Initializer<State>
+) => Store<ExtendState<State, StateExt>, Action> & StoreExt;
+
+export type StoreEnhancer<StoreExt = {}, StateExt = never> = (
+  next: StoreEnhancerStoreCreator<StoreExt, StateExt>
+) => StoreEnhancerStoreCreator<StoreExt, StateExt>;
+
+export type StoreCreator = <State, Action, StoreExt = {}, StateExt = never>(
+  reducer: Reducer<State, Action>,
+  initialState?: State,
+  initializer?: Initializer<State>,
+  enhancer?: StoreEnhancer<StoreExt, StateExt>
+) => Store<ExtendState<State, StateExt>, Action> & StoreExt;
+
+export function createStore<State, Action, StoreExt = {}, StateExt = never>(
+  reducer: Reducer<State, Action>,
+  initialState?: State,
+  initializer?: Initializer<State>,
+  enhancer?: StoreEnhancer<StoreExt, StateExt>
+): Store<ExtendState<State, StateExt>, Action> & StoreExt {
+  if (typeof enhancer !== 'undefined') {
+    if (typeof enhancer !== 'function') {
+      throw new Error('enhancer expected to be a function, got ' + typeof enhancer);
+    }
+
+    return enhancer(createStore)(reducer, initialState, initializer);
+  }
+
+  let currentState: State;
+  let isDispatching: boolean = false;
+
+  return {
+    getState: () => {
+      if (isDispatching) {
+        throw new Error(
+          'Calling getState during reduce process is forbidden. Reducer has received actual state as an argument, use it instead.'
+        );
+      }
+
+      return currentState;
+    },
+    dispatch: (action: Action) => {
+      if (isDispatching) {
+        throw new Error('reducers are not allowed to dispatch actions');
+      }
+
+      try {
+        isDispatching = true;
+        currentState = reducer(currentState, action);
+      } finally {
+        isDispatching = false;
+      }
+
+      return action;
+    },
+  } as Store<ExtendState<State, StateExt>, Action> & StoreExt;
+}

--- a/src/useEnhanceableReducer.ts
+++ b/src/useEnhanceableReducer.ts
@@ -1,93 +1,33 @@
-import { MutableRefObject, useRef } from 'react';
+import { useMemo, useRef } from 'react';
+import { createStore, Dispatch, Reducer, StoreEnhancer } from './enhanceableReducer/createStore';
 import useUpdate from './useUpdate';
 
-export type Reducer<S = any, A extends any = any> = (state: S | undefined, action: A) => S;
-
-export type Dispatch<A extends any = any> = <T extends A>(action: T, ...args: any[]) => T;
-
-export interface Store<State, Action> {
-  getState: () => State;
-  dispatch: Dispatch<Action>;
-}
-
-export type ExtendState<State, Extension> = [Extension] extends [never] ? State : State & Extension;
-
-export type StoreCreator = <S, A extends any, StoreExt = {}, StateExt = never>(
-  reducerRef: MutableRefObject<Reducer<S, A>>,
-  onStateSet?: Function,
-  initialState?: S,
+export function useEnhanceableReducer<State, Action, I, StoreExt = {}, StateExt = never>(
+  reducer: Reducer<State, Action>,
+  initialState?: I & State,
+  initializer?: (arg?: I & State) => State,
   enhancer?: StoreEnhancer<StoreExt, StateExt>
-) => Store<ExtendState<S, StateExt>, A> & StoreExt;
-
-export type StoreEnhancer<Ext = {}, StateExt = never> = (
-  next: StoreEnhancerStoreCreator<Ext, StateExt>
-) => StoreEnhancerStoreCreator<Ext, StateExt>;
-
-export type StoreEnhancerStoreCreator<StoreExt = {}, StateExt = never> = <S, A extends any>(
-  reducer: MutableRefObject<Reducer<S, A>>,
-  onStateSet?: Function,
-  initialState?: S
-) => Store<ExtendState<S, StateExt>, A> & StoreExt;
-
-function createStore<S, A extends any, StoreExt = {}, StateExt = never>(
-  reducerRef: MutableRefObject<Reducer<S, A>>,
-  onStateSet?: Function,
-  initialState?: S,
+): [State, Dispatch<Action>];
+export function useEnhanceableReducer<State, Action, I, StoreExt = {}, StateExt = never>(
+  reducer: Reducer<State, Action>,
+  initialState?: I,
+  initializer?: (arg?: I) => State,
   enhancer?: StoreEnhancer<StoreExt, StateExt>
-): Store<ExtendState<S, StateExt>, A> & StoreExt {
-  if (typeof enhancer !== 'undefined') {
-    if (typeof enhancer !== 'function') {
-      throw new Error('reducer expected to be a function, got ' + typeof enhancer);
-    }
-
-    return enhancer(createStore)(reducerRef, onStateSet, initialState) as Store<ExtendState<S, StateExt>, A> & StoreExt;
-  }
-
-  let currentState: S | undefined = initialState;
-  let isDispatching: boolean = false;
-
-  return {
-    dispatch: (action: A) => {
-      if (isDispatching) {
-        throw new Error('reducers are not allowed to dispatch actions');
-      }
-
-      try {
-        isDispatching = true;
-        currentState = reducerRef.current(currentState, action);
-      } finally {
-        isDispatching = false;
-      }
-
-      onStateSet && onStateSet();
-
-      return action;
-    },
-    getState: () => {
-      if (isDispatching) {
-        throw new Error(
-          'Calling getState during reduce process is forbidden. ' +
-            'Reducer has received actual state as an argument, use it instead.'
-        );
-      }
-
-      return currentState;
-    },
-  } as Store<ExtendState<S, StateExt>, A> & StoreExt;
-}
-
-export function useEnhanceableReducer<S, A extends any, StoreExt = {}, StateExt = never>(
-  reducer: Reducer<S, A>,
-  initialState?: S,
+): [State, Dispatch<Action>];
+export function useEnhanceableReducer<State, Action, StoreExt = {}, StateExt = never>(
+  reducer: Reducer<State, Action>,
+  initialState?: State,
+  initializer?: (arg?: State) => State,
   enhancer?: StoreEnhancer<StoreExt, StateExt>
-): [S, Dispatch<A>] {
+): [State, Dispatch<Action>] {
   if (typeof reducer !== 'function') {
     throw new Error('reducer expected to be a function, got ' + typeof reducer);
   }
 
   const reducerRef = useRef(reducer);
   const update = useUpdate();
-  const store = useRef(createStore<S, A, StoreExt, StateExt>(reducerRef, update, initialState, enhancer));
 
-  return [store.current.getState(), store.current.dispatch];
+  const store = useMemo(() => createStore(reducerRef, initialState, initializer, update, enhancer), []);
+
+  return [store.getState(), store.dispatch];
 }

--- a/src/useEnhanceableReducer.ts
+++ b/src/useEnhanceableReducer.ts
@@ -1,0 +1,93 @@
+import { MutableRefObject, useRef } from 'react';
+import useUpdate from './useUpdate';
+
+export type Reducer<S = any, A extends any = any> = (state: S | undefined, action: A) => S;
+
+export type Dispatch<A extends any = any> = <T extends A>(action: T, ...args: any[]) => T;
+
+export interface Store<State, Action> {
+  getState: () => State;
+  dispatch: Dispatch<Action>;
+}
+
+export type ExtendState<State, Extension> = [Extension] extends [never] ? State : State & Extension;
+
+export type StoreCreator = <S, A extends any, StoreExt = {}, StateExt = never>(
+  reducerRef: MutableRefObject<Reducer<S, A>>,
+  onStateSet?: Function,
+  initialState?: S,
+  enhancer?: StoreEnhancer<StoreExt, StateExt>
+) => Store<ExtendState<S, StateExt>, A> & StoreExt;
+
+export type StoreEnhancer<Ext = {}, StateExt = never> = (
+  next: StoreEnhancerStoreCreator<Ext, StateExt>
+) => StoreEnhancerStoreCreator<Ext, StateExt>;
+
+export type StoreEnhancerStoreCreator<StoreExt = {}, StateExt = never> = <S, A extends any>(
+  reducer: MutableRefObject<Reducer<S, A>>,
+  onStateSet?: Function,
+  initialState?: S
+) => Store<ExtendState<S, StateExt>, A> & StoreExt;
+
+function createStore<S, A extends any, StoreExt = {}, StateExt = never>(
+  reducerRef: MutableRefObject<Reducer<S, A>>,
+  onStateSet?: Function,
+  initialState?: S,
+  enhancer?: StoreEnhancer<StoreExt, StateExt>
+): Store<ExtendState<S, StateExt>, A> & StoreExt {
+  if (typeof enhancer !== 'undefined') {
+    if (typeof enhancer !== 'function') {
+      throw new Error('reducer expected to be a function, got ' + typeof enhancer);
+    }
+
+    return enhancer(createStore)(reducerRef, onStateSet, initialState) as Store<ExtendState<S, StateExt>, A> & StoreExt;
+  }
+
+  let currentState: S | undefined = initialState;
+  let isDispatching: boolean = false;
+
+  return {
+    dispatch: (action: A) => {
+      if (isDispatching) {
+        throw new Error('reducers are not allowed to dispatch actions');
+      }
+
+      try {
+        isDispatching = true;
+        currentState = reducerRef.current(currentState, action);
+      } finally {
+        isDispatching = false;
+      }
+
+      onStateSet && onStateSet();
+
+      return action;
+    },
+    getState: () => {
+      if (isDispatching) {
+        throw new Error(
+          'Calling getState during reduce process is forbidden. ' +
+            'Reducer has received actual state as an argument, use it instead.'
+        );
+      }
+
+      return currentState;
+    },
+  } as Store<ExtendState<S, StateExt>, A> & StoreExt;
+}
+
+export function useEnhanceableReducer<S, A extends any, StoreExt = {}, StateExt = never>(
+  reducer: Reducer<S, A>,
+  initialState?: S,
+  enhancer?: StoreEnhancer<StoreExt, StateExt>
+): [S, Dispatch<A>] {
+  if (typeof reducer !== 'function') {
+    throw new Error('reducer expected to be a function, got ' + typeof reducer);
+  }
+
+  const reducerRef = useRef(reducer);
+  const update = useUpdate();
+  const store = useRef(createStore<S, A, StoreExt, StateExt>(reducerRef, update, initialState, enhancer));
+
+  return [store.current.getState(), store.current.dispatch];
+}

--- a/src/useReducerWithMiddleware.ts
+++ b/src/useReducerWithMiddleware.ts
@@ -1,62 +1,35 @@
-import { MutableRefObject } from 'react';
-import { Dispatch, Reducer, StoreCreator, StoreEnhancer, useEnhanceableReducer } from './useEnhanceableReducer';
+import { applyMiddleware } from './enhanceableReducer/applyMiddleware';
+import { Dispatch, Reducer } from './enhanceableReducer/createStore';
+import { useEnhanceableReducer } from './useEnhanceableReducer';
 
 interface StoreAPI<D extends Dispatch = Dispatch, S = any> {
   dispatch: D;
-
-  getState(): S;
+  getState: () => S;
 }
 
-function compose<R>(...funcs: Array<(a: R) => R>): (...args: any[]) => R;
-function compose(...funcs: Function[]) {
-  if (funcs.length === 0) {
-    // infer the argument type so it is usable in inference down the line
-    return <T>(arg: T) => arg;
-  }
-
-  if (funcs.length === 1) {
-    return funcs[0];
-  }
-
-  return funcs.reduce((a, b) => (...args: any) => a(b(...args)));
-}
-
-export type Middleware<D extends Dispatch = Dispatch, S = any> = (
+export type Middleware<S = any, D extends Dispatch = Dispatch> = (
   store: StoreAPI<D, S>
-) => (dispatch: Dispatch<any>) => (action: any) => any;
+) => (next: Dispatch<any>) => (action: any) => any;
 
-export function applyMiddleware(...middlewares: Middleware[]): StoreEnhancer<any> {
-  return (createStore: StoreCreator) => <S, A extends any>(
-    reducer: MutableRefObject<Reducer<S, A>>,
-    ...args: any[]
-  ) => {
-    const store = createStore(reducer, ...args);
-    let dispatch: Dispatch = () => {
-      throw new Error(
-        'Dispatch during middleware construction is forbidden. ' +
-          'Other middleware would not be applied to this dispatch.'
-      );
-    };
+export function useReducerWithMiddleware<State, Action, I>(
+  reducer: Reducer<State, Action>,
+  middlewares: Array<Middleware<State, Dispatch<Action>>>,
+  initialState?: I & State,
+  initializer?: (arg?: I & State) => State
+): [State, Dispatch<Action>];
 
-    const storeAPI: StoreAPI = {
-      getState: store.getState,
-      dispatch: (action, ...arg) => dispatch(action, ...arg),
-    };
+export function useReducerWithMiddleware<State, Action, I>(
+  reducer: Reducer<State, Action>,
+  middlewares: Array<Middleware<State, Dispatch<Action>>>,
+  initialState?: I,
+  initializer?: (arg?: I) => State
+): [State, Dispatch<Action>];
 
-    const chain = middlewares.map(middleware => middleware(storeAPI));
-    dispatch = compose<typeof dispatch>(...chain)(store.dispatch);
-
-    return {
-      ...store,
-      dispatch,
-    };
-  };
-}
-
-export function useReducerWithMiddleware<S, A extends any>(
-  reducer: Reducer<S, A>,
-  middlewares: Array<Middleware<Dispatch<A>, S>>,
-  initialState?: S
-) {
-  return useEnhanceableReducer(reducer, initialState, applyMiddleware(...middlewares));
+export function useReducerWithMiddleware<State, Action>(
+  reducer: Reducer<State, Action>,
+  middlewares: Array<Middleware<State, Dispatch<Action>>>,
+  initialState?: State,
+  initializer?: (arg?: State) => State
+): [State, Dispatch<Action>] {
+  return useEnhanceableReducer(reducer, initialState, initializer, applyMiddleware(...middlewares));
 }

--- a/src/useReducerWithMiddleware.ts
+++ b/src/useReducerWithMiddleware.ts
@@ -1,0 +1,62 @@
+import { MutableRefObject } from 'react';
+import { Dispatch, Reducer, StoreCreator, StoreEnhancer, useEnhanceableReducer } from './useEnhanceableReducer';
+
+interface StoreAPI<D extends Dispatch = Dispatch, S = any> {
+  dispatch: D;
+
+  getState(): S;
+}
+
+function compose<R>(...funcs: Array<(a: R) => R>): (...args: any[]) => R;
+function compose(...funcs: Function[]) {
+  if (funcs.length === 0) {
+    // infer the argument type so it is usable in inference down the line
+    return <T>(arg: T) => arg;
+  }
+
+  if (funcs.length === 1) {
+    return funcs[0];
+  }
+
+  return funcs.reduce((a, b) => (...args: any) => a(b(...args)));
+}
+
+export type Middleware<D extends Dispatch = Dispatch, S = any> = (
+  store: StoreAPI<D, S>
+) => (dispatch: Dispatch<any>) => (action: any) => any;
+
+export function applyMiddleware(...middlewares: Middleware[]): StoreEnhancer<any> {
+  return (createStore: StoreCreator) => <S, A extends any>(
+    reducer: MutableRefObject<Reducer<S, A>>,
+    ...args: any[]
+  ) => {
+    const store = createStore(reducer, ...args);
+    let dispatch: Dispatch = () => {
+      throw new Error(
+        'Dispatch during middleware construction is forbidden. ' +
+          'Other middleware would not be applied to this dispatch.'
+      );
+    };
+
+    const storeAPI: StoreAPI = {
+      getState: store.getState,
+      dispatch: (action, ...arg) => dispatch(action, ...arg),
+    };
+
+    const chain = middlewares.map(middleware => middleware(storeAPI));
+    dispatch = compose<typeof dispatch>(...chain)(store.dispatch);
+
+    return {
+      ...store,
+      dispatch,
+    };
+  };
+}
+
+export function useReducerWithMiddleware<S, A extends any>(
+  reducer: Reducer<S, A>,
+  middlewares: Array<Middleware<Dispatch<A>, S>>,
+  initialState?: S
+) {
+  return useEnhanceableReducer(reducer, initialState, applyMiddleware(...middlewares));
+}


### PR DESCRIPTION
# Description
`useEnchanceableReducer` is, generally speaking, redux adaptaion for react hooks reality and less strict actions.

API made alike the native `useReducer` hook.

`useReducerWithMiddleware` is an example of `useEnchanceableReducer` usage. Almost any redux middleware can be used here.

# Checklist

- [x] Perform a self-review of my own code
- [ ] Comment my code, particularly in hard-to-understand areas
- [ ] Write documentation
- [ ] Write tests
- [ ] Ensure test suite passes (`yarn test`)
- [ ] Achieve 100% LOC tests coverage
- [ ] Create story
- [ ] Update the `README.md`
- [ ] Make sure code lints (`yarn lint`)
- [ ] Make sure types are fine (`yarn lint:types`)