### PR TITLE
fix(useStateList): rework the hook

### DIFF
--- a/src/__tests__/useStateList.test.ts
+++ b/src/__tests__/useStateList.test.ts
@@ -1,144 +1,162 @@
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import useStateList from '../useStateList';
 
-const callNext = hook => {
-  act(() => {
-    const { next } = hook.result.current;
-    next();
-  });
-};
-
-const callPrev = hook => {
-  act(() => {
-    const { prev } = hook.result.current;
-    prev();
-  });
-};
-
-describe('happy flow', () => {
-  const hook = renderHook(({ stateSet }) => useStateList(stateSet), {
-    initialProps: {
-      stateSet: ['a', 'b', 'c'],
-    },
+describe('useStateList', () => {
+  it('should be defined', () => {
+    expect(useStateList).toBeDefined();
   });
 
-  it('should return the first state on initial render', () => {
-    const { state } = hook.result.current;
-    expect(state).toBe('a');
+  function getHook(list: any[] = ['a', 'b', 'c']) {
+    return renderHook(({ states }) => useStateList(states), { initialProps: { states: list } });
+  }
+
+  it('should return an object containing `state`, `next` and `prev`', () => {
+    const res = getHook().result.current;
+
+    expect(typeof res).toBe('object');
+    expect(typeof res.state).toBe('string');
+    expect(typeof res.prev).toBe('function');
+    expect(typeof res.next).toBe('function');
   });
 
-  it('should return the second state after calling the "next" function', () => {
-    callNext(hook);
-
-    const { state } = hook.result.current;
-    expect(state).toBe('b');
+  it('should return the first state on init', () => {
+    expect(getHook().result.current.state).toBe('a');
   });
 
-  it('should return the first state again after calling the "next" function "stateSet.length" times', () => {
-    callNext(hook);
-    callNext(hook);
+  describe('next()', () => {
+    it('should switch states forward and cause re-render', () => {
+      const hook = getHook();
 
-    const { state } = hook.result.current;
-    expect(state).toBe('a');
-  });
+      expect(hook.result.current.state).toBe('a');
 
-  it('should return the last state again after calling the "prev" function', () => {
-    callPrev(hook);
+      act(() => {
+        hook.result.current.next();
+      });
+      expect(hook.result.current.state).toBe('b');
 
-    const { state } = hook.result.current;
-    expect(state).toBe('c');
-  });
-
-  it('should return the previous state after calling the "prev" function', () => {
-    callPrev(hook);
-
-    const { state } = hook.result.current;
-    expect(state).toBe('b');
-  });
-});
-
-describe('with empty state set', () => {
-  const hook = renderHook(({ stateSet }) => useStateList(stateSet), {
-    initialProps: {
-      stateSet: [],
-    },
-  });
-
-  it('should return undefined on initial render', () => {
-    const { state } = hook.result.current;
-    expect(state).toBe(undefined);
-  });
-
-  it('should always return undefined (calling next)', () => {
-    callNext(hook);
-
-    const { state } = hook.result.current;
-    expect(state).toBe(undefined);
-  });
-
-  it('should always return undefined (calling prev)', () => {
-    callPrev(hook);
-
-    const { state } = hook.result.current;
-    expect(state).toBe(undefined);
-  });
-});
-
-describe('with a single state set', () => {
-  const hook = renderHook(({ stateSet }) => useStateList(stateSet), {
-    initialProps: {
-      stateSet: ['a'],
-    },
-  });
-
-  it('should return "a" on initial render', () => {
-    const { state } = hook.result.current;
-    expect(state).toBe('a');
-  });
-
-  it('should always return "a" (calling next)', () => {
-    callNext(hook);
-
-    const { state } = hook.result.current;
-    expect(state).toBe('a');
-  });
-
-  it('should always return "a" (calling prev)', () => {
-    callPrev(hook);
-
-    const { state } = hook.result.current;
-    expect(state).toBe('a');
-  });
-});
-
-describe('with stateSet updates', () => {
-  const hook = renderHook(({ stateSet }) => useStateList(stateSet), {
-    initialProps: {
-      stateSet: ['a', 'c', 'b', 'f', 'g'],
-    },
-  });
-
-  it('should return the last element after updating with a shorter state set', () => {
-    // Go to the 4th state
-    callNext(hook); // c
-    callNext(hook); // b
-    callNext(hook); // f
-
-    // Update the state set with less elements
-    hook.rerender({
-      stateSet: ['a', 'c'],
+      act(() => {
+        hook.result.current.next();
+      });
+      expect(hook.result.current.state).toBe('c');
     });
 
-    const { state } = hook.result.current;
-    expect(state).toBe('c');
+    it('should on overflow should switch to first element (should be cycled)', () => {
+      const hook = getHook();
+
+      expect(hook.result.current.state).toBe('a');
+
+      act(() => {
+        hook.result.current.next();
+        hook.result.current.next();
+        hook.result.current.next();
+      });
+      expect(hook.result.current.state).toBe('a');
+    });
   });
 
-  it('should return the element in the same position after updating with a larger state set', () => {
-    hook.rerender({
-      stateSet: ['a', 'f', 'l'],
+  describe('prev()', () => {
+    it('should on overflow should switch to last element (should be cycled)', () => {
+      const hook = getHook();
+
+      expect(hook.result.current.state).toBe('a');
+
+      act(() => {
+        hook.result.current.prev();
+      });
+      expect(hook.result.current.state).toBe('c');
     });
 
-    const { state } = hook.result.current;
-    expect(state).toBe('f');
+    it('should switch states backward and cause re-render', () => {
+      const hook = getHook();
+
+      expect(hook.result.current.state).toBe('a');
+
+      act(() => {
+        hook.result.current.prev();
+      });
+      expect(hook.result.current.state).toBe('c');
+
+      act(() => {
+        hook.result.current.prev();
+      });
+      expect(hook.result.current.state).toBe('b');
+
+      act(() => {
+        hook.result.current.prev();
+      });
+      expect(hook.result.current.state).toBe('a');
+    });
+  });
+
+  describe('with empty states list', () => {
+    it('should have `undefined` state', () => {
+      expect(getHook([]).result.current.state).toBe(undefined);
+    });
+
+    it('should do nothing on next() call', () => {
+      const hook = getHook([]);
+      act(() => {
+        hook.result.current.next();
+      });
+
+      expect(hook.result.current.state).toBe(undefined);
+    });
+
+    it('should do nothing on prev() call', () => {
+      const hook = getHook([]);
+      act(() => {
+        hook.result.current.prev();
+      });
+
+      expect(hook.result.current.state).toBe(undefined);
+    });
+  });
+
+  describe('on state list shrink', () => {
+    it('should set last element as state if index was beyond new last element', () => {
+      const hook = getHook();
+      act(() => {
+        hook.result.current.prev();
+      });
+      expect(hook.result.current.state).toBe('c');
+
+      hook.rerender({ states: ['a', 'b'] });
+
+      expect(hook.result.current.state).toBe('b');
+    });
+
+    it('should so nothing if current index within new range', () => {
+      const hook = getHook();
+      act(() => {
+        hook.result.current.prev();
+      });
+      expect(hook.result.current.state).toBe('c');
+
+      hook.rerender({ states: ['a', 'b', 'c', 'd'] });
+
+      expect(hook.result.current.state).toBe('c');
+    });
+  });
+
+  describe('ou unmounted component', () => {
+    it('next() should not do anything', () => {
+      const hook = getHook();
+      const { next } = hook.result.current;
+
+      hook.unmount();
+      act(() => next());
+
+      expect(hook.result.current.state).toBe('a');
+    });
+
+    it('prev() should not do anything', () => {
+      const hook = getHook();
+      const { prev } = hook.result.current;
+
+      hook.unmount();
+      act(() => prev());
+
+      expect(hook.result.current.state).toBe('a');
+    });
   });
 });

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -10,7 +10,7 @@ interface Store<Action, State> {
 
 type Middleware<Action, State> = (store: Store<Action, State>) => (next: Dispatch<Action>) => (action: Action) => void;
 
-function composeMiddleware<Action, State>(chain: Array<Middleware<Action, State>>) {
+function composeMiddleware<Action, State>(chain: Middleware<Action, State>[]) {
   return (context: Store<Action, State>, dispatch: Dispatch<Action>) => {
     return chain.reduceRight((res, middleware) => {
       return middleware(context)(res);
@@ -18,7 +18,7 @@ function composeMiddleware<Action, State>(chain: Array<Middleware<Action, State>
   };
 }
 
-const createReducer = <Action, State>(...middlewares: Array<Middleware<Action, State>>) => {
+const createReducer = <Action, State>(...middlewares: Middleware<Action, State>[]) => {
   const composedMiddleware = composeMiddleware<Action, State>(middlewares);
 
   return (

--- a/src/useWindowSize.ts
+++ b/src/useWindowSize.ts
@@ -9,7 +9,7 @@ const useWindowSize = (initialWidth = Infinity, initialHeight = Infinity) => {
     height: isClient ? window.innerHeight : initialHeight,
   });
 
-  useEffect(() => {
+  useEffect((): (() => void) | void => {
     if (isClient) {
       const handler = () => {
         setState({
@@ -23,8 +23,6 @@ const useWindowSize = (initialWidth = Infinity, initialHeight = Infinity) => {
       return () => {
         window.removeEventListener('resize', handler);
       };
-    } else {
-      return undefined;
     }
   }, []);
 

--- a/src/util/parseTimeRanges.ts
+++ b/src/util/parseTimeRanges.ts
@@ -1,5 +1,5 @@
 const parseTimeRanges = ranges => {
-  const result: Array<{ start: number; end: number }> = [];
+  const result: { start: number; end: number }[] = [];
 
   for (let i = 0; i < ranges.length; i++) {
     result.push({


### PR DESCRIPTION
# Description

On previous version hook has several problems:
- Attempt to call `next()`/`prev()` on unmounted component caused errors.
- Consequal `next()`/`prev()` call withon a single render tic been causing only +/- 1 state step. 4ex: next test case would vail on previous implemntation. 
```javascript
const hook = renderHook( () => useStateList(['a', 'b', 'c']) );

expect(hook.result.current.state).toBe('a');

act(() => {
  hook.result.current.next();
  hook.result.current.next();
  hook.result.current.next();
});
expect(hook.result.current.state).toBe('a');
```

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
