### PR TITLE
fix: 🐛 check window.Event constructor exists in useLocation

### DIFF
--- a/src/useLocation.ts
+++ b/src/useLocation.ts
@@ -84,4 +84,6 @@ const useLocationBrowser = (): LocationSensorState => {
   return state;
 };
 
-export default isClient ? useLocationBrowser : useLocationServer;
+const hasEventConstructor = typeof Event === 'function';
+
+export default isClient && hasEventConstructor ? useLocationBrowser : useLocationServer;


### PR DESCRIPTION
IE does not have window.Event constructor.
