### PR TITLE
fix: useAsyncFn does not discard old promises and might produce races

### DIFF
--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -1,4 +1,4 @@
-import { DependencyList, useCallback, useState } from 'react';
+import { DependencyList, useCallback, useState, useRef } from 'react';
 import useMountedState from './useMountedState';
 
 export type AsyncState<T> =
@@ -28,21 +28,23 @@ export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
   deps: DependencyList = [],
   initialState: AsyncState<Result> = { loading: false }
 ): AsyncFn<Result, Args> {
+  const lastCallId = useRef(0);
   const [state, set] = useState<AsyncState<Result>>(initialState);
 
   const isMounted = useMountedState();
 
   const callback = useCallback((...args: Args | []) => {
+    const callId = ++lastCallId.current;
     set({ loading: true });
 
     return fn(...args).then(
       value => {
-        isMounted() && set({ value, loading: false });
+        isMounted() && callId === lastCallId.current && set({ value, loading: false });
 
         return value;
       },
       error => {
-        isMounted() && set({ error, loading: false });
+        isMounted() && callId === lastCallId.current && set({ error, loading: false });
 
         return error;
       }


### PR DESCRIPTION
# Description

The current implementation of `useAsyncFn` can cause race conditions between two Promises whenever the callback is called twice in a row as it never discard previous queries. The latest query is considered to be the results.

As consequence, we can leverage this bug in `useAsync` with this scenario:

- `<UserProfile userId={1} />` rendered - initial render
- `<UserProfile userId={2} />` rendered - props updated
- Query for userId=2 succeeds - we see the profile of 2
- Query for userId=1 succeeds - we replace the profile of 2 by the one of 1 while userId=2

```
function UserProfile({ userId }) {
  const {value} = useAsync(async () => await fetchUserInfo(userId));
  return <>{value}</>;
}
```

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
