### PR TITLE
fix: useUpdate hitting maxInt, failing to trigger rerender

### DIFF
--- a/src/useUpdate.ts
+++ b/src/useUpdate.ts
@@ -1,16 +1,9 @@
 import { useCallback, useState } from 'react';
 
-/**
- * MIN & MAX safe integers are literals due to no support in IE
- */
-const minInt = -1000000000
-const maxInt = 9007199254740991
-const incrementParameter = (num: number): number => {
-  return num !== maxInt ? (num += 1) : minInt;
-}
+const incrementParameter = (num: number): number => ++num % 1_000_000;
 
 const useUpdate = () => {
-  const [, setState] = useState(minInt);
+  const [, setState] = useState(0);
   // useCallback with empty deps as we only want to define updateCb once
   return useCallback(() => setState(incrementParameter), []);
 };

--- a/src/useUpdate.ts
+++ b/src/useUpdate.ts
@@ -1,9 +1,16 @@
 import { useCallback, useState } from 'react';
 
-const incrementParameter = (num: number): number => ++num;
+/**
+ * MIN & MAX safe integers are literals due to no support in IE
+ */
+const minInt = -1000000000
+const maxInt = 9007199254740991
+const incrementParameter = (num: number): number => {
+  return num !== maxInt ? (num += 1) : minInt;
+}
 
 const useUpdate = () => {
-  const [, setState] = useState(0);
+  const [, setState] = useState(minInt);
   // useCallback with empty deps as we only want to define updateCb once
   return useCallback(() => setState(incrementParameter), []);
 };


### PR DESCRIPTION
# Description

useUpdate hook can hit maxInt, failing to trigger rerender as the value we pass must always be different

## Type of change

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
