### PR TITLE
fix(useMap): methods with side effects should be stable across renders.

### DIFF
--- a/tests/useMap.test.ts
+++ b/tests/useMap.test.ts
@@ -121,3 +121,17 @@ it('should reset map to initial object provided', () => {
 
   expect(result.current[0]).toEqual({ foo: 'bar', a: 1 });
 });
+
+it('should memoize actions with side effects', () => {
+  const { result } = setUp({ foo: 'bar', a: 1 });
+  const [, utils] = result.current;
+  const { set, remove, reset } = utils;
+
+  act(() => {
+    set('foo', 'baz');
+  });
+
+  expect(result.current[1].set).toBe(set);
+  expect(result.current[1].remove).toBe(remove);
+  expect(result.current[1].reset).toBe(reset);
+});


### PR DESCRIPTION
# Description

Fixes #816 

Due a change in `useMap` fixing the `get` method using an outdated closure an error was introduced where the methods with side effects, i.e. `set`, `remove` and `reset` were no longer memoized properly and therefore not stable across renders. 

This PR memoizes the individual methods with side effects properly but *not* the entire `utils` object.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_
