### PR TITLE
refactor(useClickAway): useCallback instead of useRef & useEffect

### DIFF
--- a/src/useClickAway.ts
+++ b/src/useClickAway.ts
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useRef } from 'react';
+import { RefObject, useEffect, useCallback } from 'react';
 import { off, on } from './util';
 
 const defaultEvents = ['mousedown', 'touchstart'];
@@ -8,14 +8,12 @@ const useClickAway = (
   onClickAway: (event: KeyboardEvent) => void,
   events: string[] = defaultEvents
 ) => {
-  const savedCallback = useRef(onClickAway);
-  useEffect(() => {
-    savedCallback.current = onClickAway;
-  }, [onClickAway]);
+  const savedCallback = useCallback(onClickAway, [onClickAway]);
+
   useEffect(() => {
     const handler = event => {
       const { current: el } = ref;
-      el && !el.contains(event.target) && savedCallback.current(event);
+      el && !el.contains(event.target) && savedCallback(event);
     };
     for (const eventName of events) {
       on(document, eventName, handler);


### PR DESCRIPTION
# Description

I think the code should be more simpler. 
The following two pieces of code have the same effect：

```js
  const savedCallback = useRef(onClickAway);
  useEffect(() => {
    savedCallback.current = onClickAway;
  }, [onClickAway]);
```

```js
  const savedCallback = useCallback(onClickAway, [onClickAway]);
```

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).
