### PR TITLE
feat: useShallowCompareEffect and useCustomCompareEffect

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
   - [`useUnmount`](./docs/useUnmount.md) &mdash; calls `unmount` callbacks.
   - [`useUpdateEffect`](./docs/useUpdateEffect.md) &mdash; run an `effect` only on updates.
   - [`useIsomorphicLayoutEffect`](./docs/useIsomorphicLayoutEffect.md) &mdash; `useLayoutEffect` that does not show warning when server-side rendering.
-  - [`useDeepCompareEffect`](./docs/useDeepCompareEffect.md) &mdash; run an `effect` depending on deep comparison of its dependencies
+  - [`useDeepCompareEffect`](./docs/useDeepCompareEffect.md), [`useShallowCompareEffect`](./docs/useShallowCompareEffect.md), and [`useCustomCompareEffect`](./docs/useCustomCompareEffect.md) &mdash; run an `effect` depending on deep comparison of its dependencies
     <br/>
     <br/>
 - [**State**](./docs/State.md)

--- a/docs/useCustomCompareEffect.md
+++ b/docs/useCustomCompareEffect.md
@@ -1,0 +1,31 @@
+# `useCustomCompareEffect`
+
+A modified useEffect hook that accepts a comparator which is used for comparison on dependencies instead of reference equality.
+
+## Usage
+
+```jsx
+import {useCounter, useDeepCompareEffect} from 'react-use';
+import isEqual from 'lodash/isEqual';
+
+const Demo = () => {
+  const [count, {inc: inc}] = useCounter(0);
+  const options = { step: 2 };
+
+  useCustomCompareEffect(() => {
+    inc(options.step)
+  }, [options], (prevDeps, nextDeps) => isEqual(prevDeps, nextDeps));
+
+  return (
+    <div>
+      <p>useCustomCompareEffect with deep comparison: {count}</p>
+    </div>
+  );
+};
+```
+
+## Reference
+
+```ts
+useCustomCompareEffect(effect: () => void | (() => void | undefined), deps: any[], customCompareCb: (prevDeps: any[], nextDeps: any[]) => boolean);
+```

--- a/docs/useShallowCompareEffect.md
+++ b/docs/useShallowCompareEffect.md
@@ -1,0 +1,30 @@
+# `useShallowCompareEffect`
+
+A modified useEffect hook that is using shallow comparison on each of its dependencies instead of reference equality.
+
+## Usage
+
+```jsx
+import {useCounter, useShallowCompareEffect} from 'react-use';
+
+const Demo = () => {
+  const [count, {inc: inc}] = useCounter(0);
+  const options = { step: 2 };
+
+  useShallowCompareEffect(() => {
+    inc(options.step)
+  }, [options]);
+
+  return (
+    <div>
+      <p>useShallowCompareEffect: {count}</p>
+    </div>
+  );
+};
+```
+
+## Reference
+
+```ts
+useShallowCompareEffect(effect: () => void | (() => void | undefined), deps: any[]);
+```

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@xobotyi/scrollbar-width": "1.5.0",
     "copy-to-clipboard": "^3.2.0",
+    "fast-shallow-equal": "^0.1.1",
     "nano-css": "^5.2.1",
     "react-fast-compare": "^2.0.4",
     "resize-observer-polyfill": "^1.5.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { default as useClickAway } from './useClickAway';
 export { default as useCopyToClipboard } from './useCopyToClipboard';
 export { default as useCounter } from './useCounter';
 export { default as useCss } from './useCss';
+export { default as useCustomCompareEffect } from './useCustomCompareEffect';
 export { default as useDebounce } from './useDebounce';
 export { default as useDeepCompareEffect } from './useDeepCompareEffect';
 export { default as useDefault } from './useDefault';
@@ -70,6 +71,7 @@ export { default as useScroll } from './useScroll';
 export { default as useScrolling } from './useScrolling';
 export { default as useSessionStorage } from './useSessionStorage';
 export { default as useSetState } from './useSetState';
+export { default as useShallowCompareEffect } from './useShallowCompareEffect';
 export { default as useSize } from './useSize';
 export { default as useSpeech } from './useSpeech';
 // not exported because of peer dependency

--- a/src/useCustomCompareEffect.ts
+++ b/src/useCustomCompareEffect.ts
@@ -1,0 +1,33 @@
+import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
+
+const isPrimitive = (val: any) => val !== Object(val);
+
+type CompareCbType = (prevDeps: DependencyList, nextDeps: DependencyList) => boolean;
+
+const useCustomCompareEffect = (effect: EffectCallback, deps: DependencyList, customCompareCb: CompareCbType) => {
+  if (process.env.NODE_ENV !== 'production') {
+    if (!deps || !deps.length) {
+      console.warn('`useCustomCompareEffect` should not be used with no dependencies. Use React.useEffect instead.');
+    }
+
+    if (deps.every(isPrimitive)) {
+      console.warn(
+        '`useCustomCompareEffect` should not be used with dependencies that are all primitive values. Use React.useEffect instead.'
+      );
+    }
+
+    if (typeof customCompareCb !== 'function') {
+      console.warn('`useCustomCompareEffect` should be used with customCompare callback for comparing deps list');
+    }
+  }
+
+  const ref = useRef<DependencyList | undefined>(undefined);
+
+  if (!ref.current || !customCompareCb(deps, ref.current)) {
+    ref.current = deps;
+  }
+
+  useEffect(effect, ref.current);
+};
+
+export default useCustomCompareEffect;

--- a/src/useDeepCompareEffect.ts
+++ b/src/useDeepCompareEffect.ts
@@ -6,7 +6,7 @@ const isPrimitive = (val: any) => val !== Object(val);
 
 const useDeepCompareEffect = (effect: EffectCallback, deps: DependencyList) => {
   if (process.env.NODE_ENV !== 'production') {
-    if (!deps || !deps.length) {
+    if (!(deps instanceof Array) || !deps.length) {
       console.warn('`useDeepCompareEffect` should not be used with no dependencies. Use React.useEffect instead.');
     }
 

--- a/src/useShallowCompareEffect.ts
+++ b/src/useShallowCompareEffect.ts
@@ -1,10 +1,12 @@
 import { DependencyList, EffectCallback } from 'react';
-import isEqual from 'react-fast-compare';
+import { equal as isShallowEqual } from 'fast-shallow-equal';
 import useCustomCompareEffect from './useCustomCompareEffect';
 
 const isPrimitive = (val: any) => val !== Object(val);
+const shallowCompareDepsList = (depsListA: DependencyList, depsListB: DependencyList) =>
+  depsListA.some((dep, index) => isShallowEqual(dep, depsListB[index]));
 
-const useDeepCompareEffect = (effect: EffectCallback, deps: DependencyList) => {
+const useShallowCompareEffect = (effect: EffectCallback, deps: DependencyList) => {
   if (process.env.NODE_ENV !== 'production') {
     if (!deps || !deps.length) {
       console.warn('`useDeepCompareEffect` should not be used with no dependencies. Use React.useEffect instead.');
@@ -17,7 +19,7 @@ const useDeepCompareEffect = (effect: EffectCallback, deps: DependencyList) => {
     }
   }
 
-  useCustomCompareEffect(effect, deps, isEqual);
+  useCustomCompareEffect(effect, deps, shallowCompareDepsList);
 };
 
-export default useDeepCompareEffect;
+export default useShallowCompareEffect;

--- a/src/useShallowCompareEffect.ts
+++ b/src/useShallowCompareEffect.ts
@@ -4,7 +4,7 @@ import useCustomCompareEffect from './useCustomCompareEffect';
 
 const isPrimitive = (val: any) => val !== Object(val);
 const shallowCompareDepsList = (depsListA: DependencyList, depsListB: DependencyList) =>
-  depsListA.some((dep, index) => isShallowEqual(dep, depsListB[index]));
+  depsListA.every((dep, index) => isShallowEqual(dep, depsListB[index]));
 
 const useShallowCompareEffect = (effect: EffectCallback, deps: DependencyList) => {
   if (process.env.NODE_ENV !== 'production') {

--- a/src/useShallowCompareEffect.ts
+++ b/src/useShallowCompareEffect.ts
@@ -8,13 +8,13 @@ const shallowCompareDepsList = (depsListA: DependencyList, depsListB: Dependency
 
 const useShallowCompareEffect = (effect: EffectCallback, deps: DependencyList) => {
   if (process.env.NODE_ENV !== 'production') {
-    if (!deps || !deps.length) {
-      console.warn('`useDeepCompareEffect` should not be used with no dependencies. Use React.useEffect instead.');
+    if (!(deps instanceof Array) || !deps.length) {
+      console.warn('`useShallowCompareEffect` should not be used with no dependencies. Use React.useEffect instead.');
     }
 
     if (deps.every(isPrimitive)) {
       console.warn(
-        '`useDeepCompareEffect` should not be used with dependencies that are all primitive values. Use React.useEffect instead.'
+        '`useShallowCompareEffect` should not be used with dependencies that are all primitive values. Use React.useEffect instead.'
       );
     }
   }

--- a/stories/useCustomCompareEffect.story.tsx
+++ b/stories/useCustomCompareEffect.story.tsx
@@ -1,0 +1,38 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useCounter, useCustomCompareEffect } from '../src';
+import isDeepEqual from 'react-fast-compare';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const [countNormal, { inc: incNormal }] = useCounter(0);
+  const [countDeep, { inc: incDeep }] = useCounter(0);
+  const options = { max: 500 };
+
+  React.useEffect(() => {
+    if (countNormal < options.max) {
+      incNormal();
+    }
+  }, [options]);
+
+  useCustomCompareEffect(
+    () => {
+      if (countNormal < options.max) {
+        incDeep();
+      }
+    },
+    [options],
+    (prevDeps, nextDeps) => isDeepEqual(prevDeps, nextDeps)
+  );
+
+  return (
+    <div>
+      <p>useEffect: {countNormal}</p>
+      <p>useCustomCompareEffect: {countDeep}</p>
+    </div>
+  );
+};
+
+storiesOf('Lifecycle|useCustomCompareEffect', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useCustomCompareEffect.md')} />)
+  .add('Demo', () => <Demo />);

--- a/stories/useShallowCompareEffect.story.tsx
+++ b/stories/useShallowCompareEffect.story.tsx
@@ -1,0 +1,41 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useCounter, useShallowCompareEffect } from '../src';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const [countNormal, { inc: incNormal }] = useCounter(0);
+  const [countShallow, { inc: incShallow }] = useCounter(0);
+  const [countDeep, { inc: incDeep }] = useCounter(0);
+  const options = { nested: { max: 500 } };
+
+  React.useEffect(() => {
+    if (countNormal < options.nested.max) {
+      incNormal();
+    }
+  }, [options.nested]);
+
+  useShallowCompareEffect(() => {
+    if (countNormal < options.nested.max) {
+      incShallow();
+    }
+  }, [options.nested]);
+
+  useShallowCompareEffect(() => {
+    if (countNormal < options.nested.max) {
+      incDeep();
+    }
+  }, [options]);
+
+  return (
+    <div>
+      <p>useEffect: {countNormal}</p>
+      <p>useShallowCompareEffect 1st level change: {countShallow}</p>
+      <p>useShallowCompareEffect 2nd level change: {countDeep}</p>
+    </div>
+  );
+};
+
+storiesOf('Lifecycle|useShallowCompareEffect', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useShallowCompareEffect.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useCustomCompareEffect.test.ts
+++ b/tests/useCustomCompareEffect.test.ts
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useCustomCompareEffect } from '../src';
+import { useEffect } from 'react';
+import isEqual from 'react-fast-compare';
+
+let options = { max: 10 };
+const mockEffectNormal = jest.fn();
+const mockEffectDeep = jest.fn();
+const mockEffectCleanup = jest.fn();
+const mockEffectCallback = jest.fn().mockReturnValue(mockEffectCleanup);
+
+it('should run provided object once', () => {
+  const { rerender: rerenderNormal } = renderHook(() => useEffect(mockEffectNormal, [options]));
+  const { rerender: rerenderDeep } = renderHook(() => useCustomCompareEffect(mockEffectDeep, [options], isEqual));
+
+  expect(mockEffectNormal).toHaveBeenCalledTimes(1);
+  expect(mockEffectDeep).toHaveBeenCalledTimes(1);
+
+  options = { max: 10 };
+  rerenderDeep();
+  rerenderNormal();
+
+  expect(mockEffectNormal).toHaveBeenCalledTimes(2);
+  expect(mockEffectDeep).toHaveBeenCalledTimes(1);
+
+  options = { max: 10 };
+  rerenderNormal();
+  rerenderDeep();
+
+  expect(mockEffectNormal).toHaveBeenCalledTimes(3);
+  expect(mockEffectDeep).toHaveBeenCalledTimes(1);
+});
+
+it('should run clean-up provided on unmount', () => {
+  const { unmount } = renderHook(() => useCustomCompareEffect(mockEffectCallback, [options], isEqual));
+  expect(mockEffectCleanup).not.toHaveBeenCalled();
+
+  unmount();
+  expect(mockEffectCleanup).toHaveBeenCalledTimes(1);
+});

--- a/tests/useShallowCompareEffect.test.ts
+++ b/tests/useShallowCompareEffect.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useShallowCompareEffect } from '../src';
+import { useEffect } from 'react';
+
+let options = { max: 10, range: { from: 0, to: 10 } };
+const mockEffectNormal = jest.fn();
+const mockEffectShallow = jest.fn();
+const mockEffectCleanup = jest.fn();
+const mockEffectCallback = jest.fn().mockReturnValue(mockEffectCleanup);
+
+it('should shallow compare dependencies', () => {
+  const { rerender: rerenderNormal } = renderHook(() => useEffect(mockEffectNormal, [options]));
+  const { rerender: rerenderShallow } = renderHook(() => useShallowCompareEffect(mockEffectShallow, [options]));
+
+  expect(mockEffectNormal).toHaveBeenCalledTimes(1);
+  expect(mockEffectShallow).toHaveBeenCalledTimes(1);
+
+  options = { max: 10, range: options.range };
+  rerenderShallow();
+  rerenderNormal();
+
+  expect(mockEffectNormal).toHaveBeenCalledTimes(2);
+  expect(mockEffectShallow).toHaveBeenCalledTimes(1);
+
+  options = { max: 10, range: { from: 0, to: 10 } };
+  rerenderNormal();
+  rerenderShallow();
+
+  expect(mockEffectNormal).toHaveBeenCalledTimes(3);
+  expect(mockEffectShallow).toHaveBeenCalledTimes(2);
+});
+
+it('should run clean-up provided on unmount', () => {
+  const { unmount } = renderHook(() => useShallowCompareEffect(mockEffectCallback, [options]));
+  expect(mockEffectCleanup).not.toHaveBeenCalled();
+
+  unmount();
+  expect(mockEffectCleanup).toHaveBeenCalledTimes(1);
+});

--- a/tests/useShallowCompareEffect.test.ts
+++ b/tests/useShallowCompareEffect.test.ts
@@ -2,27 +2,30 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useShallowCompareEffect } from '../src';
 import { useEffect } from 'react';
 
-let options = { max: 10, range: { from: 0, to: 10 } };
+let options1 = { max: 10, range: { from: 0, to: 10 } };
+const options2 = { max: 10, range: { from: 0, to: 10 } };
 const mockEffectNormal = jest.fn();
 const mockEffectShallow = jest.fn();
 const mockEffectCleanup = jest.fn();
 const mockEffectCallback = jest.fn().mockReturnValue(mockEffectCleanup);
 
 it('should shallow compare dependencies', () => {
-  const { rerender: rerenderNormal } = renderHook(() => useEffect(mockEffectNormal, [options]));
-  const { rerender: rerenderShallow } = renderHook(() => useShallowCompareEffect(mockEffectShallow, [options]));
+  const { rerender: rerenderNormal } = renderHook(() => useEffect(mockEffectNormal, [options1, options2]));
+  const { rerender: rerenderShallow } = renderHook(() =>
+    useShallowCompareEffect(mockEffectShallow, [options1, options2])
+  );
 
   expect(mockEffectNormal).toHaveBeenCalledTimes(1);
   expect(mockEffectShallow).toHaveBeenCalledTimes(1);
 
-  options = { max: 10, range: options.range };
+  options1 = { max: 10, range: options1.range };
   rerenderShallow();
   rerenderNormal();
 
   expect(mockEffectNormal).toHaveBeenCalledTimes(2);
   expect(mockEffectShallow).toHaveBeenCalledTimes(1);
 
-  options = { max: 10, range: { from: 0, to: 10 } };
+  options1 = { max: 10, range: { from: 0, to: 10 } };
   rerenderNormal();
   rerenderShallow();
 
@@ -31,7 +34,7 @@ it('should shallow compare dependencies', () => {
 });
 
 it('should run clean-up provided on unmount', () => {
-  const { unmount } = renderHook(() => useShallowCompareEffect(mockEffectCallback, [options]));
+  const { unmount } = renderHook(() => useShallowCompareEffect(mockEffectCallback, [options1, options2]));
   expect(mockEffectCleanup).not.toHaveBeenCalled();
 
   unmount();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6376,6 +6376,11 @@ fast-levenshtein@~2.0.4:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-shallow-equal@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/fast-shallow-equal/-/fast-shallow-equal-0.1.1.tgz#44d01324d7fd31e00a67bb02b9396e283d526c22"
+  integrity sha512-XVP6nhaXLYOH6JZCWBcNaeEer9GJ5/8cJWUP+OLmgwWgEkJp5Kpl/fdpJ01zl0mpLxrk7f5J3hIv+GmjTCi7Mg==
+
 fastest-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fastest-stable-stringify/-/fastest-stable-stringify-1.0.1.tgz#9122d406d4c9d98bea644a6b6853d5874b87b028"
@@ -10116,7 +10121,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -10131,7 +10135,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.5"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -10150,14 +10153,8 @@ npm@^6.10.3:
     libnpx "^10.2.0"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
# Description

This pr adds 2 new hooks in addition to useDeepCompareEffect: 
* useShallowCompareEffect Hook
* useCustomCompareEffect Hook

Here is a use case which I bumped in, where I found useShallowCompareEffect useful: 

```
const Comp1 = (props) => {
 const { opt1, opt2, ...otherOptions } = props.options;

 useShallowCompareEffect(() => {
    dataService(otherOptions);
}, [otherOptions])

.....
}

```

In this case we want to call `dataService` only if something inside `otherOptions` has changed. As spread operator was used to create `otherOptions` object, reference to it is different on each rerender, so we can't use regular `useEffect` in this case.

I also added `useCustomCompareEffect` which allows to provide custom compare callback for more specific use cases.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage 
*`except inside dev mode code paths`
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).