### PR TITLE
fix: useUpdateEffect returns optional cleanup function

### DIFF
--- a/src/useUpdateEffect.ts
+++ b/src/useUpdateEffect.ts
@@ -5,7 +5,9 @@ const useUpdateEffect: typeof useEffect = (effect, deps) => {
   const isFirstMount = useFirstMountState();
 
   useEffect(() => {
-    !isFirstMount && effect();
+    if (!isFirstMount) {
+      return effect();
+    }
   }, deps);
 };
 

--- a/tests/useUpdateEffect.test.ts
+++ b/tests/useUpdateEffect.test.ts
@@ -1,13 +1,22 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useUpdateEffect } from '../src';
 
-const mockEffectCleanup = jest.fn();
-const mockEffectCallback = jest.fn().mockReturnValue(mockEffectCleanup);
-
 it('should run effect on update', () => {
-  const { rerender } = renderHook(() => useUpdateEffect(mockEffectCallback));
-  expect(mockEffectCallback).not.toHaveBeenCalled();
+  const effect = jest.fn();
+
+  const { rerender } = renderHook(() => useUpdateEffect(effect));
+  expect(effect).not.toHaveBeenCalled();
 
   rerender();
-  expect(mockEffectCallback).toHaveBeenCalledTimes(1);
+  expect(effect).toHaveBeenCalledTimes(1);
+});
+
+it('should run cleanup on unmount', () => {
+  const cleanup = jest.fn();
+  const hook = renderHook(() => useUpdateEffect(cleanup));
+
+  hook.rerender();
+  hook.unmount();
+
+  expect(cleanup).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
Fixes #863 

# Description
`useUpdateEffect` does not return the result of the `effect` passed, this results in cleanup function never being called on unmount. This PR fixes it by making `useUpdateEffect` return the result of the passed effect. 

## Type of change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).
