### PR TITLE
fix: useUpdateEffect test returning false positive

### DIFF
--- a/tests/useUpdateEffect.test.ts
+++ b/tests/useUpdateEffect.test.ts
@@ -13,7 +13,8 @@ it('should run effect on update', () => {
 
 it('should run cleanup on unmount', () => {
   const cleanup = jest.fn();
-  const hook = renderHook(() => useUpdateEffect(cleanup));
+  const effect = jest.fn().mockReturnValue(cleanup);
+  const hook = renderHook(() => useUpdateEffect(effect));
 
   hook.rerender();
   hook.unmount();


### PR DESCRIPTION
# Description
The test of my previous PR #864 is wrongly successful, I was testing that the effect was called, not the cleanup! This PR fixes it by testing that the cleanup effect was called on unmount, not the effect.


## Type of change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).