### PR TITLE
feat(useBeforeUnload): allow passing a dirty function (#842)

### DIFF
--- a/docs/useBeforeUnload.md
+++ b/docs/useBeforeUnload.md
@@ -5,12 +5,39 @@ React side-effect hook that shows browser alert when user try to reload or close
 
 ## Usage
 
+### Boolean check
+
 ```jsx
 import {useBeforeUnload} from 'react-use';
 
 const Demo = () => {
   const [dirty, toggleDirty] = useToggle(false);
   useBeforeUnload(dirty, 'You have unsaved changes, are you sure?');
+
+  return (
+    <div>
+      {dirty && <p>Try to reload or close tab</p>}
+      <button onClick={() => toggleDirty()}>{dirty ? 'Disable' : 'Enable'}</button>
+    </div>
+  );
+};
+```
+
+### Function check
+
+Note: Since every `dirtyFn` change registers a new callback, you should use
+[refs](https://reactjs.org/docs/hooks-faq.html#how-to-read-an-often-changing-value-from-usecallback)
+if your test value changes often.
+
+```jsx
+import {useBeforeUnload} from 'react-use';
+
+const Demo = () => {
+  const [dirty, toggleDirty] = useToggle(false);
+  const dirtyFn = useCallback(() => {
+    return dirty;
+  }, [dirty]);
+  useBeforeUnload(dirtyFn, 'You have unsaved changes, are you sure?');
 
   return (
     <div>

--- a/src/useBeforeUnload.ts
+++ b/src/useBeforeUnload.ts
@@ -1,12 +1,14 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
-const useBeforeUnload = (enabled: boolean = true, message?: string) => {
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
+const useBeforeUnload = (enabled: boolean | (() => boolean) = true, message?: string) => {
+  const handler = useCallback(
+    (event: BeforeUnloadEvent) => {
+      const finalEnabled = typeof enabled === 'function' ? enabled() : true;
 
-    const handler = (event: BeforeUnloadEvent) => {
+      if (!finalEnabled) {
+        return;
+      }
+
       event.preventDefault();
 
       if (message) {
@@ -14,12 +16,19 @@ const useBeforeUnload = (enabled: boolean = true, message?: string) => {
       }
 
       return message;
-    };
+    },
+    [enabled, message]
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
 
     window.addEventListener('beforeunload', handler);
 
     return () => window.removeEventListener('beforeunload', handler);
-  }, [message, enabled]);
+  }, [enabled, handler]);
 };
 
 export default useBeforeUnload;

--- a/stories/useBeforeUnload.story.tsx
+++ b/stories/useBeforeUnload.story.tsx
@@ -1,9 +1,9 @@
 import { storiesOf } from '@storybook/react';
-import * as React from 'react';
+import React, { useCallback } from 'react';
 import { useBeforeUnload, useToggle } from '../src';
 import ShowDocs from './util/ShowDocs';
 
-const Demo = () => {
+const DemoBool = () => {
   const [dirty, toggleDirty] = useToggle(false);
   useBeforeUnload(dirty, 'You have unsaved changes, are you sure?');
 
@@ -15,6 +15,22 @@ const Demo = () => {
   );
 };
 
+const DemoFunc = () => {
+  const [dirty, toggleDirty] = useToggle(false);
+  const dirtyFn = useCallback(() => {
+    return dirty;
+  }, [dirty]);
+  useBeforeUnload(dirtyFn, 'You have unsaved changes, are you sure?');
+
+  return (
+    <div>
+      {dirty && <p>Try to reload or close tab</p>}
+      <button onClick={() => toggleDirty()}>{dirty ? 'Disable' : 'Enable'}</button>
+    </div>
+  );
+};
+
 storiesOf('Side effects|useBeforeUnload', module)
   .add('Docs', () => <ShowDocs md={require('../docs/useBeforeUnload.md')} />)
-  .add('Demo', () => <Demo />);
+  .add('Demo (boolean)', () => <DemoBool />)
+  .add('Demo (function)', () => <DemoFunc />);


### PR DESCRIPTION
# Description

Allow passing a function as dirty flag to `useBeforeUnload` hook.
Link documentation of an example how to use this with fast-changing dirty functions.

Closes #842 

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] (n.a.) Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] (n.a.) Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
