### PR TITLE
refactor: use copy to clipboard

### DIFF
--- a/src/useCopyToClipboard.ts
+++ b/src/useCopyToClipboard.ts
@@ -22,7 +22,9 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
       return;
     }
     let noUserInteraction;
+    let normalizedValue;
     try {
+      // only strings and numbers casted to strings can be copied to clipboard
       if (typeof value !== 'string' && typeof value !== 'number') {
         const error = new Error(`Cannot copy typeof ${typeof value} to clipboard, must be a string`);
         if (process.env.NODE_ENV === 'development') console.error(error);
@@ -33,7 +35,18 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
         });
         return;
       }
-      const normalizedValue = value.toString();
+      // empty strings are also considered invalid
+      else if (value === '') {
+        const error = new Error(`Cannot copy empty string to clipboard.`);
+        if (process.env.NODE_ENV === 'development') console.error(error);
+        setState({
+          value,
+          error,
+          noUserInteraction: true,
+        });
+        return;
+      }
+      normalizedValue = value.toString();
       noUserInteraction = writeText(normalizedValue);
       setState({
         value: normalizedValue,
@@ -42,7 +55,7 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
       });
     } catch (error) {
       setState({
-        value,
+        value: normalizedValue,
         error,
         noUserInteraction,
       });

--- a/src/useCopyToClipboard.ts
+++ b/src/useCopyToClipboard.ts
@@ -18,31 +18,33 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
   });
 
   const copyToClipboard = useCallback(value => {
+    if (!isMounted()) {
+      return;
+    }
+    let noUserInteraction;
     try {
-      if (process.env.NODE_ENV === 'development') {
-        if (typeof value !== 'string') {
-          console.error(`Cannot copy typeof ${typeof value} to clipboard, must be a string`);
-        }
-      }
-
-      const noUserInteraction = writeText(value);
-
-      if (!isMounted()) {
+      if (typeof value !== 'string' && typeof value !== 'number') {
+        const error = new Error(`Cannot copy typeof ${typeof value} to clipboard, must be a string`);
+        if (process.env.NODE_ENV === 'development') console.error(error);
+        setState({
+          value,
+          error,
+          noUserInteraction: true,
+        });
         return;
       }
+      const normalizedValue = value.toString();
+      noUserInteraction = writeText(normalizedValue);
       setState({
-        value,
+        value: normalizedValue,
         error: undefined,
         noUserInteraction,
       });
     } catch (error) {
-      if (!isMounted()) {
-        return;
-      }
       setState({
-        value: undefined,
+        value,
         error,
-        noUserInteraction: true,
+        noUserInteraction,
       });
     }
   }, []);

--- a/tests/useCopyToClipboard.test.ts
+++ b/tests/useCopyToClipboard.test.ts
@@ -55,7 +55,7 @@ describe('useCopyToClipboard', () => {
     testValue = ''; // emtpy string is also invalid
     act(() => copyToClipboard(testValue));
     [state, copyToClipboard] = hook.result.current;
-    console.log(state);
+
     expect(writeText).not.toBeCalled();
     expect(state.value).toBe(testValue);
     expect(state.noUserInteraction).toBe(true);

--- a/tests/useCopyToClipboard.test.ts
+++ b/tests/useCopyToClipboard.test.ts
@@ -36,7 +36,7 @@ describe('useCopyToClipboard', () => {
     expect(state.error).not.toBeDefined();
   });
 
-  it('should only call writeText if passed a valid input and set state', () => {
+  it('should not call writeText if passed an invalid input and set state', () => {
     const testValue = {}; // invalid value
     let [state, copyToClipboard] = hook.result.current;
     act(() => copyToClipboard(testValue));
@@ -58,6 +58,7 @@ describe('useCopyToClipboard', () => {
     expect(state.noUserInteraction).not.toBeDefined();
     expect(state.error).toStrictEqual(new Error(valueToRaiseMockException));
   });
+
   it('should return initial state while unmounted', () => {
     hook.unmount();
     const [state, copyToClipboard] = hook.result.current;

--- a/tests/useCopyToClipboard.test.ts
+++ b/tests/useCopyToClipboard.test.ts
@@ -1,0 +1,41 @@
+import writeText from 'copy-to-clipboard';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useCopyToClipboard } from '../src';
+
+jest.mock('copy-to-clipboard', () => jest.fn().mockImplementation((value: any) => typeof value === 'string'));
+
+describe('useCopyToClipboard', () => {
+  let hook;
+
+  beforeEach(() => {
+    hook = renderHook(() => useCopyToClipboard());
+  });
+
+  it('should be defined ', () => {
+    expect(useCopyToClipboard).toBeDefined();
+  });
+
+  it('should pass a given value to copy to clipboard and update the state value if no error', () => {
+    const testValue = 'test';
+    let [state, copyToClipboard] = hook.result.current;
+    act(() => copyToClipboard(testValue));
+    [state, copyToClipboard] = hook.result.current;
+
+    expect(writeText).toBeCalled();
+    expect(state.value).toBe(testValue);
+    expect(state.noUserInteraction).toBe(true);
+    expect(state.error).not.toBeDefined();
+  });
+
+  it('should set the corresponding noUserInteraction value if returned from copy to clipboard', () => {
+    const testValue = {}; // invalid value
+    let [state, copyToClipboard] = hook.result.current;
+    act(() => copyToClipboard(testValue));
+    [state, copyToClipboard] = hook.result.current;
+
+    expect(writeText).toBeCalled();
+    expect(state.value).toBe(testValue);
+    expect(state.noUserInteraction).toBe(false);
+    expect(state.error).toBeDefined();
+  });
+});

--- a/tests/useCopyToClipboard.test.ts
+++ b/tests/useCopyToClipboard.test.ts
@@ -42,11 +42,20 @@ describe('useCopyToClipboard', () => {
   });
 
   it('should not call writeText if passed an invalid input and set state', () => {
-    const testValue = {}; // invalid value
+    let testValue = {}; // invalid value
     let [state, copyToClipboard] = hook.result.current;
     act(() => copyToClipboard(testValue));
     [state, copyToClipboard] = hook.result.current;
 
+    expect(writeText).not.toBeCalled();
+    expect(state.value).toBe(testValue);
+    expect(state.noUserInteraction).toBe(true);
+    expect(state.error).toBeDefined();
+
+    testValue = ''; // emtpy string is also invalid
+    act(() => copyToClipboard(testValue));
+    [state, copyToClipboard] = hook.result.current;
+    console.log(state);
     expect(writeText).not.toBeCalled();
     expect(state.value).toBe(testValue);
     expect(state.noUserInteraction).toBe(true);

--- a/tests/useCopyToClipboard.test.ts
+++ b/tests/useCopyToClipboard.test.ts
@@ -2,7 +2,16 @@ import writeText from 'copy-to-clipboard';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useCopyToClipboard } from '../src';
 
-jest.mock('copy-to-clipboard', () => jest.fn().mockImplementation((value: any) => typeof value === 'string'));
+const valueToRaiseMockException = 'fake input causing exception in copy to clipboard';
+
+jest.mock('copy-to-clipboard', () =>
+  jest.fn().mockImplementation(input => {
+    if (input === valueToRaiseMockException) {
+      throw new Error(input);
+    }
+    return true;
+  })
+);
 
 describe('useCopyToClipboard', () => {
   let hook;
@@ -15,7 +24,7 @@ describe('useCopyToClipboard', () => {
     expect(useCopyToClipboard).toBeDefined();
   });
 
-  it('should pass a given value to copy to clipboard and update the state value if no error', () => {
+  it('should pass a given value to copy to clipboard and set state', () => {
     const testValue = 'test';
     let [state, copyToClipboard] = hook.result.current;
     act(() => copyToClipboard(testValue));
@@ -27,15 +36,35 @@ describe('useCopyToClipboard', () => {
     expect(state.error).not.toBeDefined();
   });
 
-  it('should set the corresponding noUserInteraction value if returned from copy to clipboard', () => {
+  it('should only call writeText if passed a valid input and set state', () => {
     const testValue = {}; // invalid value
     let [state, copyToClipboard] = hook.result.current;
     act(() => copyToClipboard(testValue));
     [state, copyToClipboard] = hook.result.current;
 
-    expect(writeText).toBeCalled();
+    expect(writeText).not.toBeCalled();
     expect(state.value).toBe(testValue);
-    expect(state.noUserInteraction).toBe(false);
+    expect(state.noUserInteraction).toBe(true);
     expect(state.error).toBeDefined();
+  });
+
+  it('should catch exception thrown by copy-to-clipboard and set state', () => {
+    let [state, copyToClipboard] = hook.result.current;
+    act(() => copyToClipboard(valueToRaiseMockException));
+    [state, copyToClipboard] = hook.result.current;
+
+    expect(writeText).toBeCalledWith(valueToRaiseMockException);
+    expect(state.value).toBe(valueToRaiseMockException);
+    expect(state.noUserInteraction).not.toBeDefined();
+    expect(state.error).toStrictEqual(new Error(valueToRaiseMockException));
+  });
+  it('should return initial state while unmounted', () => {
+    hook.unmount();
+    const [state, copyToClipboard] = hook.result.current;
+
+    act(() => copyToClipboard('value'));
+    expect(state.value).not.toBeDefined();
+    expect(state.error).not.toBeDefined();
+    expect(state.noUserInteraction).toBe(true);
   });
 });

--- a/tests/useCopyToClipboard.test.ts
+++ b/tests/useCopyToClipboard.test.ts
@@ -12,12 +12,17 @@ jest.mock('copy-to-clipboard', () =>
     return true;
   })
 );
+jest.spyOn(global.console, 'error').mockImplementation(() => {});
 
 describe('useCopyToClipboard', () => {
   let hook;
 
   beforeEach(() => {
     hook = renderHook(() => useCopyToClipboard());
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
   });
 
   it('should be defined ', () => {
@@ -67,5 +72,23 @@ describe('useCopyToClipboard', () => {
     expect(state.value).not.toBeDefined();
     expect(state.error).not.toBeDefined();
     expect(state.noUserInteraction).toBe(true);
+  });
+
+  it('should console error if in dev environment', () => {
+    const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+    const testValue = {}; // invalid value
+
+    process.env.NODE_ENV = 'development';
+    let [state, copyToClipboard] = hook.result.current;
+    act(() => copyToClipboard(testValue));
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+
+    [state, copyToClipboard] = hook.result.current;
+
+    expect(writeText).not.toBeCalled();
+    expect(console.error).toBeCalled();
+    expect(state.value).toBe(testValue);
+    expect(state.noUserInteraction).toBe(true);
+    expect(state.error).toBeDefined();
   });
 });


### PR DESCRIPTION
# Description

Refactoring `useCopyToClipboard` to prevent invalid values to be passed to `copy-to-clipboard` helper. This prevent the helper from launching prompts and other weird behavior, also allows us to have a more relevant state, given the fact that the prompts seem to not copy anything to clipboard, see #898 

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_
- [x] Unit tests?

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
