### PR TITLE
docs: useCustomCompareEffect should import itself

### DIFF
--- a/docs/useCustomCompareEffect.md
+++ b/docs/useCustomCompareEffect.md
@@ -5,7 +5,7 @@ A modified useEffect hook that accepts a comparator which is used for comparison
 ## Usage
 
 ```jsx
-import {useCounter, useDeepCompareEffect} from 'react-use';
+import {useCounter, useCustomCompareEffect} from 'react-use';
 import isEqual from 'lodash/isEqual';
 
 const Demo = () => {


### PR DESCRIPTION
# Description

This PR makes `useCustomCompareEffect` example on docs properly import itself (instead of importing `useDeepCompareEffect`)


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
