### PR TITLE
Fixed link to useError.md

### DIFF
--- a/stories/useError.story.tsx
+++ b/stories/useError.story.tsx
@@ -38,7 +38,7 @@ const Demo = () => {
 };
 
 storiesOf('Side effects|useError', module)
-  .add('Docs', () => <ShowDocs md={require('../docs/useLocalStorage.md')} />)
+  .add('Docs', () => <ShowDocs md={require('../docs/useError.md')} />)
   .add('Demo', () => (
     <ErrorBoundary>
       <Demo />


### PR DESCRIPTION
# Description
Fixed link to useError.md

the [Storybook docs-page for `useError`](https://streamich.github.io/react-use/?path=/story/side-effects-useerror--docs) currently shows the docs for useLocalStorage. This fixes that.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [x] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
