### PR TITLE
useAsyncFn: keeping the previous state when start running the async function

### DIFF
--- a/docs/useAsyncFn.md
+++ b/docs/useAsyncFn.md
@@ -32,5 +32,5 @@ const Demo = ({url}) => {
 ## Reference
 
 ```ts
-useAsyncFn(fn, deps?: any[]);
+useAsyncFn<Result, Args>(fn, deps?: any[], initialState?: AsyncState<Result>);
 ```

--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -8,6 +8,11 @@ export type AsyncState<T> =
       value?: undefined;
     }
   | {
+      loading: true;
+      error?: Error | undefined;
+      value?: T;
+    }
+  | {
       loading: false;
       error: Error;
       value?: undefined;
@@ -35,7 +40,7 @@ export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
 
   const callback = useCallback((...args: Args | []) => {
     const callId = ++lastCallId.current;
-    set({ loading: true });
+    set(prevState => ({ ...prevState, loading: true }));
 
     return fn(...args).then(
       value => {

--- a/tests/useAsyncFn.test.tsx
+++ b/tests/useAsyncFn.test.tsx
@@ -126,4 +126,31 @@ describe('useAsyncFn', () => {
     await hook.waitForNextUpdate();
     expect(hook.result.current[0]).toEqual({ loading: false, value: 2 });
   });
+
+  it('should keeping value of initialState when loading', async () => {
+    const fetch = async () => 'new state';
+    const initialState = { loading: false, value: 'init state' };
+
+    const hook = renderHook<{ fn: () => Promise<string> }, [AsyncState<string>, () => Promise<string>]>(
+      ({ fn }) => useAsyncFn(fn, [fn], initialState),
+      {
+        initialProps: { fn: fetch },
+      }
+    );
+
+    const [state, callback] = hook.result.current;
+    expect(state.loading).toBe(false);
+    expect(state.value).toBe('init state');
+
+    act(() => {
+      callback();
+    });
+
+    expect(hook.result.current[0].loading).toBe(true);
+    expect(hook.result.current[0].value).toBe('init state');
+
+    await hook.waitForNextUpdate();
+    expect(hook.result.current[0].loading).toBe(false);
+    expect(hook.result.current[0].value).toBe('new state');
+  });
 });


### PR DESCRIPTION
# Description

`useAsyncFn` - keeping the previous state when start running the async function [#934]


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
