### PR TITLE
Set local storage directly in callback

### DIFF
--- a/tests/useLocalStorage.test.ts
+++ b/tests/useLocalStorage.test.ts
@@ -1,22 +1,22 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import { useLocalStorage } from '../src';
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useLocalStorage } from "../src";
 
 const STRINGIFIED_VALUE = '{"a":"b"}';
-const JSONIFIED_VALUE = { a: 'b' };
+const JSONIFIED_VALUE = { a: "b" };
 
 afterEach(() => {
   localStorage.clear();
   jest.clearAllMocks();
 });
 
-it('should return undefined if no initialValue provided and localStorage empty', () => {
-  const { result } = renderHook(() => useLocalStorage('some_key'));
+it("should return undefined if no initialValue provided and localStorage empty", () => {
+  const { result } = renderHook(() => useLocalStorage("some_key"));
 
   expect(result.current[0]).toBeUndefined();
 });
 
-it('should set the value from existing localStorage key', () => {
-  const key = 'some_key';
+it("should set the value from existing localStorage key", () => {
+  const key = "some_key";
   localStorage.setItem(key, STRINGIFIED_VALUE);
 
   const { result } = renderHook(() => useLocalStorage(key));
@@ -24,9 +24,9 @@ it('should set the value from existing localStorage key', () => {
   expect(result.current[0]).toEqual(JSONIFIED_VALUE);
 });
 
-it('should return initialValue if localStorage empty and set that to localStorage', () => {
-  const key = 'some_key';
-  const value = 'some_value';
+it("should return initialValue if localStorage empty and set that to localStorage", () => {
+  const key = "some_key";
+  const value = "some_value";
 
   const { result } = renderHook(() => useLocalStorage(key, value));
 
@@ -34,18 +34,18 @@ it('should return initialValue if localStorage empty and set that to localStorag
   expect(localStorage.__STORE__[key]).toBe(`"${value}"`);
 });
 
-it('should return the value from localStorage if exists even if initialValue provied', () => {
-  const key = 'some_key';
+it("should return the value from localStorage if exists even if initialValue provied", () => {
+  const key = "some_key";
   localStorage.setItem(key, STRINGIFIED_VALUE);
 
-  const { result } = renderHook(() => useLocalStorage(key, 'random_value'));
+  const { result } = renderHook(() => useLocalStorage(key, "random_value"));
 
   expect(result.current[0]).toEqual(JSONIFIED_VALUE);
 });
 
-it('should properly update the localStorage on change', () => {
-  const key = 'some_key';
-  const updatedValue = { b: 'a' };
+it("should properly update the localStorage on change", () => {
+  const key = "some_key";
+  const updatedValue = { b: "a" };
   const expectedValue = '{"b":"a"}';
 
   const { result } = renderHook(() => useLocalStorage(key));
@@ -58,18 +58,34 @@ it('should properly update the localStorage on change', () => {
   expect(localStorage.__STORE__[key]).toBe(expectedValue);
 });
 
-describe('Options with raw true', () => {
-  it('should set the value from existing localStorage key', () => {
-    const key = 'some_key';
+it("should properly update the localStorageOnChange when component unmounts", () => {
+  const key = "some_key";
+  const updatedValue = { b: "a" };
+  const expectedValue = '{"b":"a"}';
+
+  const { result, unmount } = renderHook(() => useLocalStorage(key));
+
+  unmount();
+
+  act(() => {
+    result.current[1](updatedValue);
+  });
+  console.log("assert");
+  expect(localStorage.__STORE__[key]).toBe(expectedValue);
+});
+
+describe("Options with raw true", () => {
+  it("should set the value from existing localStorage key", () => {
+    const key = "some_key";
     localStorage.setItem(key, STRINGIFIED_VALUE);
 
-    const { result } = renderHook(() => useLocalStorage(key, '', { raw: true }));
+    const { result } = renderHook(() => useLocalStorage(key, "", { raw: true }));
 
     expect(result.current[0]).toEqual(STRINGIFIED_VALUE);
   });
 
-  it('should return initialValue if localStorage empty and set that to localStorage', () => {
-    const key = 'some_key';
+  it("should return initialValue if localStorage empty and set that to localStorage", () => {
+    const key = "some_key";
 
     const { result } = renderHook(() => useLocalStorage(key, STRINGIFIED_VALUE, { raw: true }));
 
@@ -78,18 +94,18 @@ describe('Options with raw true', () => {
   });
 });
 
-describe('Options with raw false and provided serializer/deserializer', () => {
-  const serializer = (_: string) => '321';
-  const deserializer = (_: string) => '123';
+describe("Options with raw false and provided serializer/deserializer", () => {
+  const serializer = (_: string) => "321";
+  const deserializer = (_: string) => "123";
 
-  it('should return valid serialized value from existing localStorage key', () => {
-    const key = 'some_key';
+  it("should return valid serialized value from existing localStorage key", () => {
+    const key = "some_key";
     localStorage.setItem(key, STRINGIFIED_VALUE);
 
     const { result } = renderHook(() =>
       useLocalStorage(key, STRINGIFIED_VALUE, { raw: false, serializer, deserializer })
     );
 
-    expect(result.current[0]).toBe('123');
+    expect(result.current[0]).toBe("123");
   });
 });


### PR DESCRIPTION
When trying to set local storage in a situation where the component unmounts it never would get set in the useEffect.   This is because when the component unmounts no more renders occur.

# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
