### PR TITLE
Make useLocalStorage set local storage on unmount

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -49,7 +49,7 @@ const useLocalStorage = <T>(
     };
   });
 
-  const setItem = (newState: T) => {
+  const setLocalStorage = (newState: T) => {
     try {
       localStorage.setItem(key, serializer(newState));
     } catch {
@@ -59,14 +59,14 @@ const useLocalStorage = <T>(
   };
 
   useEffect(() => {
-    setItem(state);
+    setLocalStorage(state);
   }, [state]);
 
   const setLocalStorageValue: React.Dispatch<React.SetStateAction<T>> = newState => {
     const isMounted = isMountedRef.current;
     // if component unmounted set local storage directly
     if (!isMounted) {
-      setItem(newState as any);
+      setLocalStorage(newState as any);
       return;
     }
     setState(newState);

--- a/tests/useLocalStorage.test.ts
+++ b/tests/useLocalStorage.test.ts
@@ -1,22 +1,22 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import { useLocalStorage } from '../src';
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useLocalStorage } from "../src";
 
 const STRINGIFIED_VALUE = '{"a":"b"}';
-const JSONIFIED_VALUE = { a: 'b' };
+const JSONIFIED_VALUE = { a: "b" };
 
 afterEach(() => {
   localStorage.clear();
   jest.clearAllMocks();
 });
 
-it('should return undefined if no initialValue provided and localStorage empty', () => {
-  const { result } = renderHook(() => useLocalStorage('some_key'));
+it("should return undefined if no initialValue provided and localStorage empty", () => {
+  const { result } = renderHook(() => useLocalStorage("some_key"));
 
   expect(result.current[0]).toBeUndefined();
 });
 
-it('should set the value from existing localStorage key', () => {
-  const key = 'some_key';
+it("should set the value from existing localStorage key", () => {
+  const key = "some_key";
   localStorage.setItem(key, STRINGIFIED_VALUE);
 
   const { result } = renderHook(() => useLocalStorage(key));
@@ -24,9 +24,9 @@ it('should set the value from existing localStorage key', () => {
   expect(result.current[0]).toEqual(JSONIFIED_VALUE);
 });
 
-it('should return initialValue if localStorage empty and set that to localStorage', () => {
-  const key = 'some_key';
-  const value = 'some_value';
+it("should return initialValue if localStorage empty and set that to localStorage", () => {
+  const key = "some_key";
+  const value = "some_value";
 
   const { result } = renderHook(() => useLocalStorage(key, value));
 
@@ -34,18 +34,18 @@ it('should return initialValue if localStorage empty and set that to localStorag
   expect(localStorage.__STORE__[key]).toBe(`"${value}"`);
 });
 
-it('should return the value from localStorage if exists even if initialValue provied', () => {
-  const key = 'some_key';
+it("should return the value from localStorage if exists even if initialValue provied", () => {
+  const key = "some_key";
   localStorage.setItem(key, STRINGIFIED_VALUE);
 
-  const { result } = renderHook(() => useLocalStorage(key, 'random_value'));
+  const { result } = renderHook(() => useLocalStorage(key, "random_value"));
 
   expect(result.current[0]).toEqual(JSONIFIED_VALUE);
 });
 
-it('should properly update the localStorage on change', () => {
-  const key = 'some_key';
-  const updatedValue = { b: 'a' };
+it("should properly update the localStorage on change", () => {
+  const key = "some_key";
+  const updatedValue = { b: "a" };
   const expectedValue = '{"b":"a"}';
 
   const { result } = renderHook(() => useLocalStorage(key));
@@ -58,18 +58,34 @@ it('should properly update the localStorage on change', () => {
   expect(localStorage.__STORE__[key]).toBe(expectedValue);
 });
 
-describe('Options with raw true', () => {
-  it('should set the value from existing localStorage key', () => {
-    const key = 'some_key';
+it("should properly update the localStorageOnChange when component unmounts", () => {
+  const key = "some_key";
+  const updatedValue = { b: "a" };
+  const expectedValue = '{"b":"a"}';
+
+  const { result, unmount } = renderHook(() => useLocalStorage(key));
+
+  unmount();
+
+  act(() => {
+    result.current[1](updatedValue);
+  });
+  console.log("assert");
+  expect(localStorage.__STORE__[key]).toBe(expectedValue);
+});
+
+describe("Options with raw true", () => {
+  it("should set the value from existing localStorage key", () => {
+    const key = "some_key";
     localStorage.setItem(key, STRINGIFIED_VALUE);
 
-    const { result } = renderHook(() => useLocalStorage(key, '', { raw: true }));
+    const { result } = renderHook(() => useLocalStorage(key, "", { raw: true }));
 
     expect(result.current[0]).toEqual(STRINGIFIED_VALUE);
   });
 
-  it('should return initialValue if localStorage empty and set that to localStorage', () => {
-    const key = 'some_key';
+  it("should return initialValue if localStorage empty and set that to localStorage", () => {
+    const key = "some_key";
 
     const { result } = renderHook(() => useLocalStorage(key, STRINGIFIED_VALUE, { raw: true }));
 
@@ -78,18 +94,18 @@ describe('Options with raw true', () => {
   });
 });
 
-describe('Options with raw false and provided serializer/deserializer', () => {
-  const serializer = (_: string) => '321';
-  const deserializer = (_: string) => '123';
+describe("Options with raw false and provided serializer/deserializer", () => {
+  const serializer = (_: string) => "321";
+  const deserializer = (_: string) => "123";
 
-  it('should return valid serialized value from existing localStorage key', () => {
-    const key = 'some_key';
+  it("should return valid serialized value from existing localStorage key", () => {
+    const key = "some_key";
     localStorage.setItem(key, STRINGIFIED_VALUE);
 
     const { result } = renderHook(() =>
       useLocalStorage(key, STRINGIFIED_VALUE, { raw: false, serializer, deserializer })
     );
 
-    expect(result.current[0]).toBe('123');
+    expect(result.current[0]).toBe("123");
   });
 });

--- a/tests/useLocalStorage.test.ts
+++ b/tests/useLocalStorage.test.ts
@@ -70,7 +70,23 @@ it('should properly update the localStorageOnChange when component unmounts', ()
   act(() => {
     result.current[1](updatedValue);
   });
-  console.log('assert');
+
+  expect(localStorage.__STORE__[key]).toBe(expectedValue);
+});
+
+it('should properly update the localStorageOnChange when component unmounts and newState is set with a function', () => {
+  const key = 'some_key';
+  const updatedValue = { b: 'a' };
+  const expectedValue = '{"b":"a"}';
+
+  const { result, unmount } = renderHook(() => useLocalStorage(key));
+
+  unmount();
+
+  act(() => {
+    result.current[1](() => updatedValue);
+  });
+
   expect(localStorage.__STORE__[key]).toBe(expectedValue);
 });
 

--- a/tests/useLocalStorage.test.ts
+++ b/tests/useLocalStorage.test.ts
@@ -1,22 +1,22 @@
-import { renderHook, act } from "@testing-library/react-hooks";
-import { useLocalStorage } from "../src";
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useLocalStorage } from '../src';
 
 const STRINGIFIED_VALUE = '{"a":"b"}';
-const JSONIFIED_VALUE = { a: "b" };
+const JSONIFIED_VALUE = { a: 'b' };
 
 afterEach(() => {
   localStorage.clear();
   jest.clearAllMocks();
 });
 
-it("should return undefined if no initialValue provided and localStorage empty", () => {
-  const { result } = renderHook(() => useLocalStorage("some_key"));
+it('should return undefined if no initialValue provided and localStorage empty', () => {
+  const { result } = renderHook(() => useLocalStorage('some_key'));
 
   expect(result.current[0]).toBeUndefined();
 });
 
-it("should set the value from existing localStorage key", () => {
-  const key = "some_key";
+it('should set the value from existing localStorage key', () => {
+  const key = 'some_key';
   localStorage.setItem(key, STRINGIFIED_VALUE);
 
   const { result } = renderHook(() => useLocalStorage(key));
@@ -24,9 +24,9 @@ it("should set the value from existing localStorage key", () => {
   expect(result.current[0]).toEqual(JSONIFIED_VALUE);
 });
 
-it("should return initialValue if localStorage empty and set that to localStorage", () => {
-  const key = "some_key";
-  const value = "some_value";
+it('should return initialValue if localStorage empty and set that to localStorage', () => {
+  const key = 'some_key';
+  const value = 'some_value';
 
   const { result } = renderHook(() => useLocalStorage(key, value));
 
@@ -34,18 +34,18 @@ it("should return initialValue if localStorage empty and set that to localStorag
   expect(localStorage.__STORE__[key]).toBe(`"${value}"`);
 });
 
-it("should return the value from localStorage if exists even if initialValue provied", () => {
-  const key = "some_key";
+it('should return the value from localStorage if exists even if initialValue provied', () => {
+  const key = 'some_key';
   localStorage.setItem(key, STRINGIFIED_VALUE);
 
-  const { result } = renderHook(() => useLocalStorage(key, "random_value"));
+  const { result } = renderHook(() => useLocalStorage(key, 'random_value'));
 
   expect(result.current[0]).toEqual(JSONIFIED_VALUE);
 });
 
-it("should properly update the localStorage on change", () => {
-  const key = "some_key";
-  const updatedValue = { b: "a" };
+it('should properly update the localStorage on change', () => {
+  const key = 'some_key';
+  const updatedValue = { b: 'a' };
   const expectedValue = '{"b":"a"}';
 
   const { result } = renderHook(() => useLocalStorage(key));
@@ -58,9 +58,9 @@ it("should properly update the localStorage on change", () => {
   expect(localStorage.__STORE__[key]).toBe(expectedValue);
 });
 
-it("should properly update the localStorageOnChange when component unmounts", () => {
-  const key = "some_key";
-  const updatedValue = { b: "a" };
+it('should properly update the localStorageOnChange when component unmounts', () => {
+  const key = 'some_key';
+  const updatedValue = { b: 'a' };
   const expectedValue = '{"b":"a"}';
 
   const { result, unmount } = renderHook(() => useLocalStorage(key));
@@ -70,22 +70,22 @@ it("should properly update the localStorageOnChange when component unmounts", ()
   act(() => {
     result.current[1](updatedValue);
   });
-  console.log("assert");
+  console.log('assert');
   expect(localStorage.__STORE__[key]).toBe(expectedValue);
 });
 
-describe("Options with raw true", () => {
-  it("should set the value from existing localStorage key", () => {
-    const key = "some_key";
+describe('Options with raw true', () => {
+  it('should set the value from existing localStorage key', () => {
+    const key = 'some_key';
     localStorage.setItem(key, STRINGIFIED_VALUE);
 
-    const { result } = renderHook(() => useLocalStorage(key, "", { raw: true }));
+    const { result } = renderHook(() => useLocalStorage(key, '', { raw: true }));
 
     expect(result.current[0]).toEqual(STRINGIFIED_VALUE);
   });
 
-  it("should return initialValue if localStorage empty and set that to localStorage", () => {
-    const key = "some_key";
+  it('should return initialValue if localStorage empty and set that to localStorage', () => {
+    const key = 'some_key';
 
     const { result } = renderHook(() => useLocalStorage(key, STRINGIFIED_VALUE, { raw: true }));
 
@@ -94,18 +94,18 @@ describe("Options with raw true", () => {
   });
 });
 
-describe("Options with raw false and provided serializer/deserializer", () => {
-  const serializer = (_: string) => "321";
-  const deserializer = (_: string) => "123";
+describe('Options with raw false and provided serializer/deserializer', () => {
+  const serializer = (_: string) => '321';
+  const deserializer = (_: string) => '123';
 
-  it("should return valid serialized value from existing localStorage key", () => {
-    const key = "some_key";
+  it('should return valid serialized value from existing localStorage key', () => {
+    const key = 'some_key';
     localStorage.setItem(key, STRINGIFIED_VALUE);
 
     const { result } = renderHook(() =>
       useLocalStorage(key, STRINGIFIED_VALUE, { raw: false, serializer, deserializer })
     );
 
-    expect(result.current[0]).toBe("123");
+    expect(result.current[0]).toBe('123');
   });
 });


### PR DESCRIPTION
# Description

useLocalStorage updates local storage within the react lifecycle with a useEffect.  This works well since
the update will happen immediately and the more expensive task of writing to local storage is done after the component already updates to reflect the change.

The problem is when a component unmounts,local storage does not get written to.  One common example of this happening is if we try to write to local storage while also going to a different page in our app.

This change makes the hook aware of whether it has unmounted or not and if it has unmounts, it will go ahead and write directly to local storage.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
