### PR TITLE
feat(useSet): add toggle a method

### DIFF
--- a/docs/useSet.md
+++ b/docs/useSet.md
@@ -8,7 +8,7 @@ React state hook that tracks a [Set](https://developer.mozilla.org/en-US/docs/We
 import {useSet} from 'react-use';
 
 const Demo = () => {
-  const [set, { add, has, remove, reset }] = useSet(new Set(['hello']));
+  const [set, { add, has, remove, toggle, reset }] = useSet(new Set(['hello']));
 
   return (
     <div>
@@ -17,6 +17,7 @@ const Demo = () => {
       <button onClick={() => remove('hello')} disabled={!has('hello')}>
         Remove 'hello'
       </button>
+      <button onClick={() => toggle('hello')}>{has('hello') ? 'Remove' : 'Add'} hello</button>
       <pre>{JSON.stringify(Array.from(set), null, 2)}</pre>
     </div>
   );

--- a/docs/useSet.md
+++ b/docs/useSet.md
@@ -17,7 +17,7 @@ const Demo = () => {
       <button onClick={() => remove('hello')} disabled={!has('hello')}>
         Remove 'hello'
       </button>
-      <button onClick={() => toggle('hello')}>{has('hello') ? 'Remove' : 'Add'} hello</button>
+      <button onClick={() => toggle('hello')}>Toggle hello</button>
       <pre>{JSON.stringify(Array.from(set), null, 2)}</pre>
     </div>
   );

--- a/src/useSet.ts
+++ b/src/useSet.ts
@@ -3,6 +3,7 @@ import { useState, useMemo, useCallback } from 'react';
 export interface StableActions<K> {
   add: (key: K) => void;
   remove: (key: K) => void;
+  toggle: (key: K) => void;
   reset: () => void;
 }
 
@@ -13,14 +14,13 @@ export interface Actions<K> extends StableActions<K> {
 const useSet = <K>(initialSet = new Set<K>()): [Set<K>, Actions<K>] => {
   const [set, setSet] = useState(initialSet);
 
-  const stableActions = useMemo<StableActions<K>>(
-    () => ({
-      add: item => setSet(prevSet => new Set([...Array.from(prevSet), item])),
-      remove: item => setSet(prevSet => new Set(Array.from(prevSet).filter(i => i !== item))),
-      reset: () => setSet(initialSet),
-    }),
-    [setSet]
-  );
+  const stableActions = useMemo<StableActions<K>>(() => {
+    const add = (item: K) => setSet(prevSet => new Set([...Array.from(prevSet), item]));
+    const remove = (item: K) => setSet(prevSet => new Set(Array.from(prevSet).filter(i => i !== item)));
+    const toggle = (item: K) => (set.has(item) ? remove : add)(item);
+
+    return { add, remove, toggle, reset: () => setSet(initialSet) };
+  }, [setSet]);
 
   const utils = {
     has: useCallback(item => set.has(item), [set]),

--- a/src/useSet.ts
+++ b/src/useSet.ts
@@ -17,7 +17,12 @@ const useSet = <K>(initialSet = new Set<K>()): [Set<K>, Actions<K>] => {
   const stableActions = useMemo<StableActions<K>>(() => {
     const add = (item: K) => setSet(prevSet => new Set([...Array.from(prevSet), item]));
     const remove = (item: K) => setSet(prevSet => new Set(Array.from(prevSet).filter(i => i !== item)));
-    const toggle = (item: K) => (set.has(item) ? remove : add)(item);
+    const toggle = (item: K) =>
+      setSet(prevSet =>
+        prevSet.has(item)
+          ? new Set(Array.from(prevSet).filter(i => i !== item))
+          : new Set([...Array.from(prevSet), item])
+      );
 
     return { add, remove, toggle, reset: () => setSet(initialSet) };
   }, [setSet]);

--- a/stories/useSet.story.tsx
+++ b/stories/useSet.story.tsx
@@ -4,7 +4,7 @@ import { useSet } from '../src';
 import ShowDocs from './util/ShowDocs';
 
 const Demo = () => {
-  const [set, { add, has, remove, reset }] = useSet(new Set(['hello']));
+  const [set, { add, has, remove, reset, toggle }] = useSet(new Set(['hello']));
 
   return (
     <div>
@@ -13,6 +13,7 @@ const Demo = () => {
       <button onClick={() => remove('hello')} disabled={!has('hello')}>
         Remove 'hello'
       </button>
+      <button onClick={() => toggle('hello')}>{has('hello') ? 'Remove' : 'Add'} 'hello'</button>
       <pre>{JSON.stringify(Array.from(set), null, 2)}</pre>
     </div>
   );

--- a/stories/useSet.story.tsx
+++ b/stories/useSet.story.tsx
@@ -13,7 +13,7 @@ const Demo = () => {
       <button onClick={() => remove('hello')} disabled={!has('hello')}>
         Remove 'hello'
       </button>
-      <button onClick={() => toggle('hello')}>{has('hello') ? 'Remove' : 'Add'} 'hello'</button>
+      <button onClick={() => toggle('hello')}>Toggle 'hello'</button>
       <pre>{JSON.stringify(Array.from(set), null, 2)}</pre>
     </div>
   );

--- a/tests/useSet.test.ts
+++ b/tests/useSet.test.ts
@@ -148,7 +148,7 @@ it('should reset to initial set provided', () => {
 it('should memoized its utils methods', () => {
   const { result } = setUp(new Set(['a', 'b']));
   const [, utils] = result.current;
-  const { add, remove, reset } = utils;
+  const { add, remove, reset, toggle } = utils;
 
   act(() => {
     add('foo');
@@ -156,5 +156,6 @@ it('should memoized its utils methods', () => {
 
   expect(result.current[1].add).toBe(add);
   expect(result.current[1].remove).toBe(remove);
+  expect(result.current[1].toggle).toBe(toggle);
   expect(result.current[1].reset).toBe(reset);
 });

--- a/tests/useSet.test.ts
+++ b/tests/useSet.test.ts
@@ -12,6 +12,7 @@ it('should init set and utils', () => {
     has: expect.any(Function),
     add: expect.any(Function),
     remove: expect.any(Function),
+    toggle: expect.any(Function),
     reset: expect.any(Function),
   });
 });
@@ -92,6 +93,28 @@ it('should remove existing key', () => {
   });
 
   expect(result.current[0]).toEqual(new Set([1]));
+});
+
+it('should remove an existing key on toggle', () => {
+  const { result } = setUp(new Set([1, 2]));
+  const [, utils] = result.current;
+
+  act(() => {
+    utils.toggle(2);
+  });
+
+  expect(result.current[0]).toEqual(new Set([1]));
+});
+
+it('should add a new key on toggle', () => {
+  const { result } = setUp(new Set([1]));
+  const [, utils] = result.current;
+
+  act(() => {
+    utils.toggle(2);
+  });
+
+  expect(result.current[0]).toEqual(new Set([1, 2]));
 });
 
 it('should do nothing if removing non-existing key', () => {


### PR DESCRIPTION
# Description

This adds a `toggle` method to the `useSet` hook. It creates a handy wrapper on top of `add` and `remove`.


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
