### PR TITLE
Improves typings for useAsync hook

### DIFF
--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -4,7 +4,7 @@ import useMountedState from './useMountedState';
 
 export type AsyncState<T> =
   | {
-      loading: boolean;
+      loading: true;
       error?: undefined;
       value?: undefined;
     }
@@ -27,7 +27,7 @@ export type AsyncFn<Result = any, Args extends any[] = any[]> = [
 export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
   fn: (...args: Args | []) => Promise<Result>,
   deps: DependencyList = [],
-  initialState: AsyncState<Result> = { loading: false }
+  initialState: AsyncState<Result> = { loading: true }
 ): AsyncFn<Result, Args> {
   const lastCallId = useRef(0);
   const [state, set] = useState<AsyncState<Result>>(initialState);
@@ -36,7 +36,10 @@ export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
 
   const callback = useCallback((...args: Args | []) => {
     const callId = ++lastCallId.current;
-    set({ loading: true });
+
+    if (!state.loading) {
+      set({ loading: true });
+    }
 
     return fn(...args).then(
       value => {

--- a/tests/useAsyncFn.test.tsx
+++ b/tests/useAsyncFn.test.tsx
@@ -68,7 +68,7 @@ describe('useAsyncFn', () => {
       const [state] = hook.result.current;
 
       expect(state.value).toEqual(undefined);
-      expect(state.loading).toEqual(false);
+      expect(state.loading).toEqual(true);
       expect(state.error).toEqual(undefined);
       expect(callCount).toEqual(0);
     });


### PR DESCRIPTION
# Description

The main reason for this PR is sounder type checking when using useAsync hook, example:
`
const state = useAsync(somePromise)

if (!state.loading && !state.error) {
  // state.value should be of type T here, but instead it's still T | undefined
}
`
For this to work i had the change the default initialState.loading in useAsyncFn to true, i don't think it will change anything because it's already being set to true from useAsync in the first place, but i might be wrong

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).
