### PR TITLE
--escape double quote in lint script to properly find the correct fil…

### DIFF
--- a/docs/useSessionStorage.md
+++ b/docs/useSessionStorage.md
@@ -16,6 +16,7 @@ const Demo = () => {
       <div>Value: {value}</div>
       <button onClick={() => setValue('bar')}>bar</button>
       <button onClick={() => setValue('baz')}>baz</button>
+        <button onClick={() => remove()}>Remove</button>
     </div>
   );
 };
@@ -24,12 +25,20 @@ const Demo = () => {
 
 ## Reference
 
+
 ```js
 useSessionStorage(key);
 useSessionStorage(key, initialValue);
-useSessionStorage(key, initialValue, raw);
+useSessionStorage(key, initialValue, { raw: true });
+useSessionStorage(key, initialValue, {
+  raw: false,
+  serializer: (value: T) => string,
+  deserializer: (value: string) => T,
+});
 ```
 
 - `key` &mdash; `sessionStorage` key to manage.
 - `initialValue` &mdash; initial value to set, if value in `sessionStorage` is empty.
 - `raw` &mdash; boolean, if set to `true`, hook will not attempt to JSON serialize stored values.
+- `serializer` &mdash; custom serializer (defaults to `JSON.stringify`)
+- `deserializer` &mdash; custom deserializer (defaults to `JSON.parse`)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "jest --maxWorkers 2",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "lint": "eslint '{src,tests}/**/*.{ts,tsx}'",
+    "lint": "eslint \"{src,tests}/**/*.{ts,tsx}\"",
     "lint:fix": "yarn lint --fix",
     "lint:types": "tsc --noEmit",
     "build:cjs": "tsc",

--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -1,88 +1,13 @@
 /* eslint-disable */
-import { useState, useCallback, Dispatch, SetStateAction } from 'react';
-import { isClient } from './util';
-
-type parserOptions<T> =
-  | {
-      raw: true;
-    }
-  | {
-      raw: false;
-      serializer: (value: T) => string;
-      deserializer: (value: string) => T;
-    };
-
-const noop = () => {};
+import { Dispatch, SetStateAction } from 'react';
+import useStorage, { parserOptions } from './useStorage';
 
 const useLocalStorage = <T>(
   key: string,
   initialValue?: T,
   options?: parserOptions<T>
 ): [T | undefined, Dispatch<SetStateAction<T | undefined>>, () => void] => {
-  if (!isClient) {
-    return [initialValue as T, noop, noop];
-  }
-  if (!key) {
-    throw new Error('useLocalStorage key may not be falsy');
-  }
-
-  const deserializer = options ? (options.raw ? value => value : options.deserializer) : JSON.parse;
-
-  const [state, setState] = useState<T | undefined>(() => {
-    try {
-      const serializer = options ? (options.raw ? String : options.serializer) : JSON.stringify;
-
-      const localStorageValue = localStorage.getItem(key);
-      if (localStorageValue !== null) {
-        return deserializer(localStorageValue);
-      } else {
-        initialValue && localStorage.setItem(key, serializer(initialValue));
-        return initialValue;
-      }
-    } catch {
-      // If user is in private mode or has storage restriction
-      // localStorage can throw. JSON.parse and JSON.stringify
-      // can throw, too.
-      return initialValue;
-    }
-  });
-
-  const set: Dispatch<SetStateAction<T | undefined>> = useCallback(
-    valOrFunc => {
-      try {
-        const newState = typeof valOrFunc === 'function' ? (valOrFunc as Function)(state) : valOrFunc;
-        if (typeof newState === 'undefined') return;
-        let value: string;
-
-        if (options)
-          if (options.raw)
-            if (typeof newState === 'string') value = newState;
-            else value = JSON.stringify(newState);
-          else if (options.serializer) value = options.serializer(newState);
-          else value = JSON.stringify(newState);
-        else value = JSON.stringify(newState);
-
-        localStorage.setItem(key, value);
-        setState(deserializer(value));
-      } catch {
-        // If user is in private mode or has storage restriction
-        // localStorage can throw. Also JSON.stringify can throw.
-      }
-    },
-    [key, setState]
-  );
-
-  const remove = useCallback(() => {
-    try {
-      localStorage.removeItem(key);
-      setState(undefined);
-    } catch {
-      // If user is in private mode or has storage restriction
-      // localStorage can throw.
-    }
-  }, [key, setState]);
-
-  return [state, set, remove];
+  return useStorage('localStorage', key, initialValue, options);
 };
 
 export default useLocalStorage;

--- a/src/useSessionStorage.ts
+++ b/src/useSessionStorage.ts
@@ -1,40 +1,13 @@
 /* eslint-disable */
-import { useEffect, useState } from 'react';
-import { isClient } from './util';
+import { Dispatch, SetStateAction } from 'react';
+import useStorage, { parserOptions } from './useStorage';
 
-const useSessionStorage = <T>(key: string, initialValue?: T, raw?: boolean): [T, (value: T) => void] => {
-  if (!isClient) {
-    return [initialValue as T, () => {}];
-  }
-
-  const [state, setState] = useState<T>(() => {
-    try {
-      const sessionStorageValue = sessionStorage.getItem(key);
-      if (typeof sessionStorageValue !== 'string') {
-        sessionStorage.setItem(key, raw ? String(initialValue) : JSON.stringify(initialValue));
-        return initialValue;
-      } else {
-        return raw ? sessionStorageValue : JSON.parse(sessionStorageValue || 'null');
-      }
-    } catch {
-      // If user is in private mode or has storage restriction
-      // sessionStorage can throw. JSON.parse and JSON.stringify
-      // cat throw, too.
-      return initialValue;
-    }
-  });
-
-  useEffect(() => {
-    try {
-      const serializedState = raw ? String(state) : JSON.stringify(state);
-      sessionStorage.setItem(key, serializedState);
-    } catch {
-      // If user is in private mode or has storage restriction
-      // sessionStorage can throw. Also JSON.stringify can throw.
-    }
-  });
-
-  return [state, setState];
+const useSessionStorage = <T>(
+  key: string,
+  initialValue?: T,
+  options?: parserOptions<T>
+): [T | undefined, Dispatch<SetStateAction<T | undefined>>, () => void] => {
+  return useStorage('sessionStorage', key, initialValue, options);
 };
 
 export default useSessionStorage;

--- a/src/useStorage.ts
+++ b/src/useStorage.ts
@@ -1,0 +1,96 @@
+/* eslint-disable */
+import { useState, useCallback, Dispatch, SetStateAction, useMemo } from 'react';
+import { isClient } from './util';
+
+export type parserOptions<T> =
+  | {
+      raw: true;
+    }
+  | {
+      raw: false;
+      serializer: (value: T) => string;
+      deserializer: (value: string) => T;
+    };
+
+const noop = () => {};
+
+const useStorage = <T>(
+  storageType: string,
+  key: string,
+  initialValue?: T,
+  options?: parserOptions<T>
+): [T | undefined, Dispatch<SetStateAction<T | undefined>>, () => void] => {
+  if (!isClient) {
+    return [initialValue as T, noop, noop];
+  }
+  if (!key) {
+    throw new Error('Storage key may not be falsy');
+  }
+  //default to localStorage
+
+  let storage = useMemo(() => {
+    if (storageType == 'sessionStorage') return sessionStorage;
+    //defaults to localStorage what ever the key was used
+    else return localStorage;
+  }, [storageType]);
+
+  const deserializer = options ? (options.raw ? value => value : options.deserializer) : JSON.parse;
+
+  const [state, setState] = useState<T | undefined>(() => {
+    try {
+      const serializer = options ? (options.raw ? String : options.serializer) : JSON.stringify;
+
+      const storageValue = storage.getItem(key);
+      if (storageValue !== null) {
+        return deserializer(storageValue);
+      } else {
+        initialValue && storage.setItem(key, serializer(initialValue));
+        return initialValue;
+      }
+    } catch {
+      // If user is in private mode or has storage restriction
+      // storage can throw. JSON.parse and JSON.stringify
+      // can throw, too.
+      return initialValue;
+    }
+  });
+
+  const set: Dispatch<SetStateAction<T | undefined>> = useCallback(
+    valOrFunc => {
+      try {
+        const newState = typeof valOrFunc === 'function' ? (valOrFunc as Function)(state) : valOrFunc;
+        if (typeof newState === 'undefined') return;
+        let value: string;
+
+        if (options)
+          if (options.raw)
+            if (typeof newState === 'string') value = newState;
+            else value = JSON.stringify(newState);
+          else if (options.serializer) value = options.serializer(newState);
+          else value = JSON.stringify(newState);
+        else value = JSON.stringify(newState);
+
+        storage.setItem(key, value);
+        setState(deserializer(value));
+      } catch {
+        // If user is in private mode or has storage restriction
+        // storage can throw. Also JSON.stringify can throw.
+      }
+    },
+    [key, setState]
+  );
+
+  const remove = useCallback(() => {
+    try {
+      storage.removeItem(key);
+      setState(undefined);
+    } catch {
+      // If user is in private mode or has storage restriction
+      // storage can throw.
+    }
+  }, [key, setState]);
+
+  return [state, set, remove];
+};
+
+export default useStorage;

--- a/stories/useSessionStorage.story.tsx
+++ b/stories/useSessionStorage.story.tsx
@@ -4,13 +4,14 @@ import { useSessionStorage } from '../src';
 import ShowDocs from './util/ShowDocs';
 
 const Demo = () => {
-  const [value, setValue] = useSessionStorage('hello-key', 'foo');
+  const [value, setValue, remove] = useSessionStorage('hello-key', 'foo');
 
   return (
     <div>
       <div>Value: {value}</div>
       <button onClick={() => setValue('bar')}>bar</button>
       <button onClick={() => setValue('baz')}>baz</button>
+      <button onClick={() => remove()}>Remove</button>
     </div>
   );
 };

--- a/tests/useSessionStorage.test.ts
+++ b/tests/useSessionStorage.test.ts
@@ -1,0 +1,237 @@
+/* eslint-disable */
+import useSessionStorage from '../src/useSessionStorage';
+import 'jest-localStorage-mock';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+describe(useSessionStorage, () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('retrieves an existing value from sessionStorage', () => {
+    sessionStorage.setItem('foo', '"bar"');
+    const { result } = renderHook(() => useSessionStorage('foo'));
+    const [state] = result.current;
+    expect(state).toEqual('bar');
+  });
+
+  it('should return initialValue if sessionStorage empty and set that to sessionStorage', () => {
+    const { result } = renderHook(() => useSessionStorage('foo', 'bar'));
+    const [state] = result.current;
+    expect(state).toEqual('bar');
+    expect(sessionStorage.__STORE__.foo).toEqual('"bar"');
+  });
+
+  it('prefers existing value over initial state', () => {
+    sessionStorage.setItem('foo', '"bar"');
+    const { result } = renderHook(() => useSessionStorage('foo', 'baz'));
+    const [state] = result.current;
+    expect(state).toEqual('bar');
+  });
+
+  it('does not clobber existing sessionStorage with initialState', () => {
+    sessionStorage.setItem('foo', '"bar"');
+    const { result } = renderHook(() => useSessionStorage('foo', 'buzz'));
+    result.current; // invoke current to make sure things are set
+    expect(sessionStorage.__STORE__.foo).toEqual('"bar"');
+  });
+
+  it('correctly updates sessionStorage', () => {
+    const { result, rerender } = renderHook(() => useSessionStorage('foo', 'bar'));
+
+    const [, setFoo] = result.current;
+    act(() => setFoo('baz'));
+    rerender();
+
+    expect(sessionStorage.__STORE__.foo).toEqual('"baz"');
+  });
+
+  it('should return undefined if no initialValue provided and sessionStorage empty', () => {
+    const { result } = renderHook(() => useSessionStorage('some_key'));
+
+    expect(result.current[0]).toBeUndefined();
+  });
+
+  it('returns and allow setting null', () => {
+    sessionStorage.setItem('foo', 'null');
+    const { result, rerender } = renderHook(() => useSessionStorage('foo'));
+
+    const [foo1, setFoo] = result.current;
+    act(() => setFoo(null));
+    rerender();
+
+    const [foo2] = result.current;
+    expect(foo1).toEqual(null);
+    expect(foo2).toEqual(null);
+  });
+
+  it('sets initialState if initialState is an object', () => {
+    renderHook(() => useSessionStorage('foo', { bar: true }));
+    expect(sessionStorage.__STORE__.foo).toEqual('{"bar":true}');
+  });
+
+  it('correctly and promptly returns a new value', () => {
+    const { result, rerender } = renderHook(() => useSessionStorage('foo', 'bar'));
+
+    const [, setFoo] = result.current;
+    act(() => setFoo('baz'));
+    rerender();
+
+    const [foo] = result.current;
+    expect(foo).toEqual('baz');
+  });
+
+  /*
+  it('keeps multiple hooks accessing the same key in sync', () => {
+    sessionStorage.setItem('foo', 'bar');
+    const { result: r1, rerender: rerender1 } = renderHook(() => useSessionStorage('foo'));
+    const { result: r2, rerender: rerender2 } = renderHook(() => useSessionStorage('foo'));
+
+    const [, setFoo] = r1.current;
+    act(() => setFoo('potato'));
+    rerender1();
+    rerender2();
+
+    const [val1] = r1.current;
+    const [val2] = r2.current;
+
+    expect(val1).toEqual(val2);
+    expect(val1).toEqual('potato');
+    expect(val2).toEqual('potato');
+  });
+  */
+
+  it('parses out objects from sessionStorage', () => {
+    sessionStorage.setItem('foo', JSON.stringify({ ok: true }));
+    const { result } = renderHook(() => useSessionStorage<{ ok: boolean }>('foo'));
+    const [foo] = result.current;
+    expect(foo!.ok).toEqual(true);
+  });
+
+  it('safely initializes objects to sessionStorage', () => {
+    const { result } = renderHook(() => useSessionStorage<{ ok: boolean }>('foo', { ok: true }));
+    const [foo] = result.current;
+    expect(foo!.ok).toEqual(true);
+  });
+
+  it('safely sets objects to sessionStorage', () => {
+    const { result, rerender } = renderHook(() => useSessionStorage<{ ok: any }>('foo', { ok: true }));
+
+    const [, setFoo] = result.current;
+    act(() => setFoo({ ok: 'bar' }));
+    rerender();
+
+    const [foo] = result.current;
+    expect(foo!.ok).toEqual('bar');
+  });
+
+  it('safely returns objects from updates', () => {
+    const { result, rerender } = renderHook(() => useSessionStorage<{ ok: any }>('foo', { ok: true }));
+
+    const [, setFoo] = result.current;
+    act(() => setFoo({ ok: 'bar' }));
+    rerender();
+
+    const [foo] = result.current;
+    expect(foo).toBeInstanceOf(Object);
+    expect(foo!.ok).toEqual('bar');
+  });
+
+  it('sets sessionStorage from the function updater', () => {
+    const { result, rerender } = renderHook(() =>
+      useSessionStorage<{ foo: string; fizz?: string }>('foo', { foo: 'bar' })
+    );
+
+    const [, setFoo] = result.current;
+    act(() => setFoo(state => ({ ...state!, fizz: 'buzz' })));
+    rerender();
+
+    const [value] = result.current;
+    expect(value!.foo).toEqual('bar');
+    expect(value!.fizz).toEqual('buzz');
+  });
+
+  it('rejects nullish or undefined keys', () => {
+    const { result } = renderHook(() => useSessionStorage(null as any));
+    try {
+      result.current;
+      fail('hook should have thrown');
+    } catch (e) {
+      expect(String(e)).toMatch(/key may not be/i);
+    }
+  });
+
+  /* Enforces proper eslint react-hooks/rules-of-hooks usage */
+  describe('eslint react-hooks/rules-of-hooks', () => {
+    it('memoizes an object between rerenders', () => {
+      const { result, rerender } = renderHook(() => useSessionStorage('foo', { ok: true }));
+
+      result.current; // if sessionStorage isn't set then r1 and r2 will be different
+      rerender();
+      const [r2] = result.current;
+      rerender();
+      const [r3] = result.current;
+      expect(r2).toBe(r3);
+    });
+
+    it('memoizes an object immediately if sessionStorage is already set', () => {
+      sessionStorage.setItem('foo', JSON.stringify({ ok: true }));
+      const { result, rerender } = renderHook(() => useSessionStorage('foo', { ok: true }));
+
+      const [r1] = result.current; // if sessionStorage isn't set then r1 and r2 will be different
+      rerender();
+      const [r2] = result.current;
+      expect(r1).toBe(r2);
+    });
+
+    it('memoizes the setState function', () => {
+      sessionStorage.setItem('foo', JSON.stringify({ ok: true }));
+      const { result, rerender } = renderHook(() => useSessionStorage('foo', { ok: true }));
+      const [, s1] = result.current;
+      rerender();
+      const [, s2] = result.current;
+      expect(s1).toBe(s2);
+    });
+  });
+
+  describe('Options: raw', () => {
+    it('returns a string when sessionStorage is a stringified object', () => {
+      sessionStorage.setItem('foo', JSON.stringify({ fizz: 'buzz' }));
+      const { result } = renderHook(() => useSessionStorage('foo', null, { raw: true }));
+      const [foo] = result.current;
+      expect(typeof foo).toBe('string');
+    });
+
+    it('returns a string after an update', () => {
+      sessionStorage.setItem('foo', JSON.stringify({ fizz: 'buzz' }));
+      const { result, rerender } = renderHook(() => useSessionStorage('foo', null, { raw: true }));
+
+      const [, setFoo] = result.current;
+
+      act(() => setFoo({ fizz: 'bang' } as any));
+      rerender();
+
+      const [foo] = result.current;
+      expect(typeof foo).toBe('string');
+
+      expect(JSON.parse(foo!)).toBeInstanceOf(Object);
+
+      // expect(JSON.parse(foo!).fizz).toEqual('bang');
+    });
+
+    it('still forces setState to a string', () => {
+      sessionStorage.setItem('foo', JSON.stringify({ fizz: 'buzz' }));
+      const { result, rerender } = renderHook(() => useSessionStorage('foo', null, { raw: true }));
+
+      const [, setFoo] = result.current;
+
+      act(() => setFoo({ fizz: 'bang' } as any));
+      rerender();
+
+      const [value] = result.current;
+
+      expect(JSON.parse(value!).fizz).toEqual('bang');
+    });
+  });
+});


### PR DESCRIPTION
# Description

sessionStorage and localStorage should have similar behavior, their only difference is where the data is being stored and it's persistence which should be abstracted for this library.



## Type of change
- [ ] **Breaking change**, The signature/arguments follows the useLocalStorage, this is breaking changes, because the previous last argument is just a boolean "raw", which i change it to object "options"
- [ ] New feature, added the useStorage, as the base for sessionStorage, localStorage, or even  "whatEverStorage" that follows the signature of localStorage
- [ ] New feature, Added the sessionStorage unit test
- [ ] New feature, Update the docs that describe about the config changes, for raw, serializer, de-serializer
- [ ] Bug fix, Removed the single-quote in lint script, to properly find the correct files and folder, this is not related to the changes, but the lint command does not find the files with single qoute, i tried with bash and command terminals both does not work there (we can discuss more on this if there is a need to)

 
# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

