### PR TITLE
Fix typings for useAsyncFn and useAsync hooks

### DIFF
--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -3,11 +3,11 @@ import useAsyncFn from './useAsyncFn';
 
 export { AsyncState, AsyncFn } from './useAsyncFn';
 
-export default function useAsync<Result = any, Args extends any[] = any[]>(
-  fn: (...args: Args | []) => Promise<Result>,
+export default function useAsync<Result = any>(
+  fn: () => Promise<Result>,
   deps: DependencyList = []
 ) {
-  const [state, callback] = useAsyncFn<Result, Args>(fn, deps, {
+  const [state, callback] = useAsyncFn<Result>(fn, deps, {
     loading: true,
   });
 

--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -21,11 +21,11 @@ export type AsyncState<T> =
 
 export type AsyncFn<Result = any, Args extends any[] = any[]> = [
   AsyncState<Result>,
-  (...args: Args | []) => Promise<Result>
+  (...args: Args) => Promise<Result>
 ];
 
 export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
-  fn: (...args: Args | []) => Promise<Result>,
+  fn: (...args: Args) => Promise<Result>,
   deps: DependencyList = [],
   initialState: AsyncState<Result> = { loading: false }
 ): AsyncFn<Result, Args> {
@@ -34,7 +34,7 @@ export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
 
   const isMounted = useMountedState();
 
-  const callback = useCallback((...args: Args | []) => {
+  const callback = useCallback((...args: Args) => {
     const callId = ++lastCallId.current;
     set({ loading: true });
 


### PR DESCRIPTION
# Description

`useAsyncFn` can not work well in typescript when the async fn has arguments. For examples:
```typescript
const [state, add] = useAsyncFn(async (a: number, b: number) => a + b, [])
add(1, 2)
```
code above produces typings below, the arguments `a` and `b` have wrong typings.
```typescript
const add: (...args: [] | [number, number]) => Promise<number>
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
Correct typings should be:
```
const add: (a: number, b: number) => Promise<number>
                   ^^^^^^^^^^^^^^^^^^^^^^
```
The reason lead to the wrong typings is because the `useAsyncFn` typings has a redundant type definition.
```
export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
  fn: (...args: Args | []) => Promise<Result>,
                                ^^^
  deps: DependencyList = [],
  initialState: AsyncState<Result> = { loading: false }
): AsyncFn<Result, Args> {
    // ...
}
```

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [] Comment the code, particularly in hard-to-understand areas
- [] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
