### PR TITLE
fix useAudio src change

### DIFF
--- a/src/util/createHTMLMediaHook.ts
+++ b/src/util/createHTMLMediaHook.ts
@@ -206,7 +206,9 @@ const createHTMLMediaHook = (tag: 'audio' | 'video') => {
         return;
       }
 
+      // In Safari, change src, onTimeUpdate not trigger 
       setState({
+        time: 0,
         volume: el.volume,
         muted: el.muted,
         paused: el.paused,


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
Safari browser, audio src change, not trigger timeUpdate event

```jsx
// src change a.mp3 -> b.mp3
// if a.mp3 time is 3
// first render b.mp3, time is 3
// click play, time is 0
function LetterAudio({ src = '' }) {
  const [audio, { time }] = useAudio({ src });
  console.log('time: ', time);
  return (
    <div>
      {audio}
      {time}
    </div>
  );
}
```

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)

- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
