### PR TITLE
feat: Adds useDebounceFn hook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,10 @@ This library is a collection of React hooks so a proposal for a new hook will ne
 
 ### Creating a new hook
 
-1. Create `src/useYourHookName.ts` and `src/__stories__/useYourHookName.story.tsx`, run `yarn start` to start the storybook development server and start coding your hook
-1. Create `src/__tests__/useYourHookName.test.ts`, run `yarn test:watch` to start the test runner in watch mode and start writing tests for your hook
-1. Create `src/docs/useYourHookName.md` and create documentation for your hook
-1. Export your hook from `src/index.ts` and add your hook to `README.md`
+1. Create `src/useYourHookName.ts` and `stories/useYourHookName.story.tsx`, run `yarn start` to start the storybook development server and start coding your hook
+2. Create `tests/useYourHookName.test.ts`, run `yarn test:watch` to start the test runner in watch mode and start writing tests for your hook
+3. Create `docs/useYourHookName.md` and create documentation for your hook
+4. Export your hook from `src/index.ts` and add your hook to `README.md`
 
 You can also write your tests first if you prefer [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development).
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@
   - [`useRaf`](./docs/useRaf.md) &mdash; re-renders component on each `requestAnimationFrame`.
   - [`useInterval`](./docs/useInterval.md) and [`useHarmonicIntervalFn`](./docs/useHarmonicIntervalFn.md) &mdash; re-renders component on a set interval using `setInterval`.
   - [`useSpring`](./docs/useSpring.md) &mdash; interpolates number over time according to spring dynamics.
-  - [`useTimeout`](./docs/useTimeout.md) &mdash; re-renders component after a timeout.
-  - [`useTimeoutFn`](./docs/useTimeoutFn.md) &mdash; calls given function after a timeout. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/animation-usetimeoutfn--demo)
   - [`useTween`](./docs/useTween.md) &mdash; re-renders component, while tweening a number from 0 to 1. [![][img-demo]](https://codesandbox.io/s/52990wwzyl)
   - [`useUpdate`](./docs/useUpdate.md) &mdash; returns a callback, which re-renders component when called.
     <br/>
@@ -105,6 +103,8 @@
   - [`useRafLoop`](./docs/useRafLoop.md) &mdash; calls given function inside the RAF loop.
   - [`useSessionStorage`](./docs/useSessionStorage.md) &mdash; manages a value in `sessionStorage`.
   - [`useThrottle` and `useThrottleFn`](./docs/useThrottle.md) &mdash; throttles a function. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/side-effects-usethrottle--demo)
+  - [`useTimeout`](./docs/useTimeout.md) &mdash; re-renders component after a timeout.
+  - [`useTimeoutFn and useDebounceFn`](./docs/useTimeoutFn.md) &mdash; calls given function after a timeout. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/animation-usetimeoutfn--demo)
   - [`useTitle`](./docs/useTitle.md) &mdash; sets title of the page.
   - [`usePermission`](./docs/usePermission.md) &mdash; query permission status for browser APIs.
     <br/>

--- a/docs/useTimeoutFn.md
+++ b/docs/useTimeoutFn.md
@@ -7,7 +7,9 @@ Several thing about it's work:
 - automatically cancel timeout on cancel;
 - automatically reset timeout on delay change;
 - reset function call will cancel previous timeout;
-- timeout will NOT be reset on function change. It will be called within the timeout, you have to reset it on your own when needed. 
+- timeout will NOT be reset on function change. It will be called within the timeout, you have to reset it on your own when needed.
+
+`useDebounceFn` is an alias for `useTimeoutFn`.
 
 ## Usage
 
@@ -49,7 +51,7 @@ const Demo = () => {
 
 ## Reference
 
-```ts 
+```ts
 const [
     isReady: () => boolean | null,
     cancel: () => void,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { default as useCounter } from './useCounter';
 export { default as useCss } from './useCss';
 export { default as useCustomCompareEffect } from './useCustomCompareEffect';
 export { default as useDebounce } from './useDebounce';
+export { default as useDebounceFn } from './useDebounceFn';
 export { default as useDeepCompareEffect } from './useDeepCompareEffect';
 export { default as useDefault } from './useDefault';
 export { default as useDrop } from './useDrop';

--- a/src/useDebounceFn.ts
+++ b/src/useDebounceFn.ts
@@ -1,0 +1,3 @@
+import useDebounceFn from './useTimeoutFn';
+
+export default useDebounceFn;

--- a/stories/useDebounceFn.story.tsx
+++ b/stories/useDebounceFn.story.tsx
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { useCallback } from 'react';
-import { useTimeoutFn } from '../src';
+import { useDebounceFn } from '../src';
 import ShowDocs from './util/ShowDocs';
 
 const Demo = () => {
@@ -11,7 +11,7 @@ const Demo = () => {
     setState(`called at ${Date.now()}`);
   }
 
-  const [isReady, cancel, reset] = useTimeoutFn(fn, 5000);
+  const [isReady, cancel, reset] = useDebounceFn(fn, 5000);
   const cancelButtonClick = useCallback(() => {
     if (isReady() === false) {
       cancel();
@@ -35,6 +35,6 @@ const Demo = () => {
   );
 };
 
-storiesOf('Side-effects|useTimeoutFn', module)
+storiesOf('Side-effects|useDebounceFn', module)
   .add('Docs', () => <ShowDocs md={require('../docs/useTimeoutFn.md')} />)
   .add('Demo', () => <Demo />);

--- a/stories/useTimeout.story.tsx
+++ b/stories/useTimeout.story.tsx
@@ -24,6 +24,6 @@ const Demo = () => {
   );
 };
 
-storiesOf('Animation|useTimeout', module)
+storiesOf('Side-effects|useTimeout', module)
   .add('Docs', () => <ShowDocs md={require('../docs/useTimeout.md')} />)
   .add('Demo', () => <Demo />);

--- a/tests/useDebounceFn.test.ts
+++ b/tests/useDebounceFn.test.ts
@@ -1,0 +1,6 @@
+import useDebounceFn from '../src/useDebounceFn';
+import useTimeoutFn from '../src/useTimeoutFn';
+
+it('should be an alias for useTimeoutFn ', () => {
+  expect(useDebounceFn).toBe(useTimeoutFn);
+});


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

As a user of `react-use`,  I needed to perform logic - canceling an API request - before using a function within `useDebounce`. Since `useDebounce` uses `useEffect`, this would call for a `useDebounceFn` hook, but it looked as though `react-use` did not have the hook available. After digging, it seems as though `useTimeoutFn` (that is classified under `Animations` for some reason) is actually what I needed.

This PR creates the `useDebounceFn` alias of `useTimeoutFn` and moves the classification of `useTimeout` and `useTimeoutFn` from `Animations` to `Side-effects`. This PR also fixes the [CONTRIBUTIONS.md](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md) file references since they seemed to point to the wrong paths.

## Type of change

<!-- Check all relevant options. -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [X] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [X] Perform a code self-review
- [X] Comment the code, particularly in hard-to-understand areas
- [X] Add documentation
- [X] Add hook's story at Storybook
- [X] Cover changes with tests
- [X] Ensure the test suite passes (`yarn test`)
- [X] Provide 100% tests coverage
- [X] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [X] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
