### PR TITLE
feat: remove warning from `useDeepCompareEffect`

### DIFF
--- a/src/useCustomCompareEffect.ts
+++ b/src/useCustomCompareEffect.ts
@@ -1,19 +1,11 @@
 import { DependencyList, EffectCallback, useEffect, useRef } from 'react';
 
-const isPrimitive = (val: any) => val !== Object(val);
-
 type DepsEqualFnType = (prevDeps: DependencyList, nextDeps: DependencyList) => boolean;
 
 const useCustomCompareEffect = (effect: EffectCallback, deps: DependencyList, depsEqual: DepsEqualFnType) => {
   if (process.env.NODE_ENV !== 'production') {
     if (!(deps instanceof Array) || !deps.length) {
       console.warn('`useCustomCompareEffect` should not be used with no dependencies. Use React.useEffect instead.');
-    }
-
-    if (deps.every(isPrimitive)) {
-      console.warn(
-        '`useCustomCompareEffect` should not be used with dependencies that are all primitive values. Use React.useEffect instead.'
-      );
     }
 
     if (typeof depsEqual !== 'function') {

--- a/src/useDeepCompareEffect.ts
+++ b/src/useDeepCompareEffect.ts
@@ -2,18 +2,10 @@ import { DependencyList, EffectCallback } from 'react';
 import { isDeepEqual } from './util';
 import useCustomCompareEffect from './useCustomCompareEffect';
 
-const isPrimitive = (val: any) => val !== Object(val);
-
 const useDeepCompareEffect = (effect: EffectCallback, deps: DependencyList) => {
   if (process.env.NODE_ENV !== 'production') {
     if (!(deps instanceof Array) || !deps.length) {
       console.warn('`useDeepCompareEffect` should not be used with no dependencies. Use React.useEffect instead.');
-    }
-
-    if (deps.every(isPrimitive)) {
-      console.warn(
-        '`useDeepCompareEffect` should not be used with dependencies that are all primitive values. Use React.useEffect instead.'
-      );
     }
   }
 


### PR DESCRIPTION
It is common for state to be in either a nil or non-nil state where the non-nil state is not a primitive. This PR removes the warning that is fired in such an event.

```
import React from "react";
import { useDeepCompareEffect } from "react-use";

export const useObjectDidChange = <T extends any>(didChange: () => void, dep: T) => {
   useDeepCompareEffect(() => {
    didChange();
   }, [dep]);
}

function App = () => {
  const [obj, setObj] = useState<object | undefined>(undefined);
  useObjectDidChange(() => console.log("obj changed"), obj);
  
  return <div />;
}
```

# Description

As discussed in #755, `useDeepCompareEffect` fires a warning for primitives being compared. Given that there are more complex state interactions where primitives such as `undefined` and `null` are acceptable, this warning should be removed.

## Type of change

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist

- [X] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [X] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).