### PR TITLE
fix: useHoverDirty eslint fix

### DIFF
--- a/src/useHoverDirty.ts
+++ b/src/useHoverDirty.ts
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import { useEffect, useState } from 'react';
+import { RefObject, useEffect, useState } from 'react';
 
 // kudos: https://usehooks.com/
-const useHoverDirty = (ref, enabled: boolean = true) => {
+const useHoverDirty = (ref: RefObject<Element>, enabled: boolean = true) => {
   if (process.env.NODE_ENV === 'development') {
     if (typeof ref !== 'object' || typeof ref.current === 'undefined') {
       console.error('useHoverDirty expects a single ref argument.');
@@ -20,10 +19,13 @@ const useHoverDirty = (ref, enabled: boolean = true) => {
       ref.current.addEventListener('mouseout', onMouseOut);
     }
 
+    // fixes react-hooks/exhaustive-deps warning about stale ref elements
+    const { current } = ref;
+
     return () => {
-      if (enabled && ref && ref.current) {
-        ref.current.removeEventListener('mouseover', onMouseOver);
-        ref.current.removeEventListener('mouseout', onMouseOut);
+      if (enabled && current) {
+        current.removeEventListener('mouseover', onMouseOver);
+        current.removeEventListener('mouseout', onMouseOut);
       }
     };
   }, [enabled, ref]);


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
Fixes `/* eslint-disable */ for `useHoverDirty` per https://github.com/streamich/react-use/issues/947

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
