### PR TITLE
fix: SSR useEffect warning in createGlobalState hook

### DIFF
--- a/src/createGlobalState.ts
+++ b/src/createGlobalState.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
-import { useLayoutEffect, useState } from 'react';
+import { useState } from 'react';
 import useEffectOnce from './useEffectOnce';
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 
 export function createGlobalState<S = any>(initialState?: S) {
   const store: { state: S | undefined; setState: (state: S) => void; setters: any[] } = {
@@ -19,7 +20,7 @@ export function createGlobalState<S = any>(initialState?: S) {
       store.setters = store.setters.filter(setter => setter !== stateSetter);
     });
 
-    useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
       if (!store.setters.includes(stateSetter)) {
         store.setters.push(stateSetter);
       }


### PR DESCRIPTION
#662 Description

createGlobalState uses useLayoutEffect which can't run on the server due to there being no DOM. This results in a warning that I have fixed by using useIsomorphicLayoutEffect.
This PR fixes #956 

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
