### PR TITLE
Refactor (useToggle): useReducer optimization and less hooks usage

### DIFF
--- a/src/useToggle.ts
+++ b/src/useToggle.ts
@@ -1,10 +1,9 @@
 import { useReducer, Reducer } from 'react';
 
+const toggleReducer = (state: boolean, nextValue?: any) => (typeof nextValue === 'boolean' ? nextValue : !state);
+
 const useToggle = (initialValue: boolean): [boolean, (nextValue?: any) => void] => {
-  return useReducer<Reducer<boolean, any>>(
-    (state: boolean, nextValue?: any) => (typeof nextValue === 'boolean' ? nextValue : !state),
-    initialValue
-  );
+  return useReducer<Reducer<boolean, any>>(toggleReducer, initialValue);
 };
 
 export default useToggle;

--- a/src/useToggle.ts
+++ b/src/useToggle.ts
@@ -1,20 +1,10 @@
-import { useCallback, useState } from 'react';
+import { useReducer, Reducer } from 'react';
 
 const useToggle = (initialValue: boolean): [boolean, (nextValue?: any) => void] => {
-  const [value, setValue] = useState<boolean>(initialValue);
-
-  const toggle = useCallback(
-    (nextValue?: any) => {
-      if (typeof nextValue === 'boolean') {
-        setValue(nextValue);
-      } else {
-        setValue(currentValue => !currentValue);
-      }
-    },
-    [setValue]
+  return useReducer<Reducer<boolean, any>>(
+    (state: boolean, nextValue?: any) => (typeof nextValue === 'boolean' ? nextValue : !state),
+    initialValue
   );
-
-  return [value, toggle];
 };
 
 export default useToggle;


### PR DESCRIPTION
# Description

This refactor to the useToggle hook switch the internal logic to a single useReducer instead of the useState and useCallback hooks, since the dispatch function will have the same reference on every rerender, removing the need to implemente a memoized function.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).