### PR TITLE
feat: add useFocus hook 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
   - [`useMeasure`](./docs/useMeasure.md) &mdash; tracks an HTML element's dimensions using the Resize Observer API.[![][img-demo]](https://streamich.github.io/react-use/?path=/story/sensors-usemeasure--demo)
   - [`createBreakpoint`](./docs/createBreakpoint.md) &mdash; tracks `innerWidth`
   - [`useScrollbarWidth`](./docs/useScrollbarWidth.md) &mdash; detects browser's native scrollbars width. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/sensors-usescrollbarwidth--demo)
+  - [`useFocus`](./docs/useFocus.md) &mdash; tracks focus state of some element.
     <br/>
     <br/>
 - [**UI**](./docs/UI.md)

--- a/docs/useFocus.md
+++ b/docs/useFocus.md
@@ -1,0 +1,33 @@
+# `useFocus`
+
+React UI sensor hooks that track if an element is focused. `useFocus` accepts a React element and sets its `onFocus` and `onBlur` events.
+
+## Usage
+
+```jsx
+import {useFocus} from 'react-use';
+
+const Demo = () => {
+  const element = (focused) => (
+    <div>
+      <label htmlFor="useFocus" style={{fontWeight: focused ? 'bold' : 'normal'}}>Click here</label>
+      <input type="text" id="useFocus" value="Focus here" />
+    </div>
+  );
+
+  const [input, focused] = useFocus(element);
+
+  return (
+    <div>
+      {input}
+      <div>{focused ? 'Input is on focus!' : ''}</div>
+    </div>
+  );
+};
+```
+
+## Examples
+
+```js
+const [el, focused] = useFocus(element)
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export { default as useEnsuredForwardedRef, ensuredForwardRef } from './useEnsur
 export { default as useEvent } from './useEvent';
 export { default as useError } from './useError';
 export { default as useFavicon } from './useFavicon';
+export { default as useFocus } from './useFocus';
 export { default as useFullscreen } from './useFullscreen';
 export { default as useGeolocation } from './useGeolocation';
 export { default as useGetSet } from './useGetSet';

--- a/src/useFocus.ts
+++ b/src/useFocus.ts
@@ -1,0 +1,34 @@
+  
+import * as React from 'react';
+
+const { useState } = React;
+
+const noop = () => {};
+
+export type Element = ((state: boolean) => React.ReactElement<any>) | React.ReactElement<any>;
+
+const useFocus = (element: Element): [React.ReactElement<any>, boolean] => {
+  const [state, setState] = useState(false);
+
+  const onFocus = (originalOnFocus?: any) => (event: any) => {
+    (originalOnFocus || noop)(event);
+    setState(true);
+  };
+  const onBlur = (originalOnBlur?: any) => (event: any) => {
+    (originalOnBlur || noop)(event);
+    setState(false);
+  };
+
+  if (typeof element === 'function') {
+    element = element(state);
+  }
+
+  const el = React.cloneElement(element, {
+    onFocus: onFocus(element.props.onFocus),
+    onBlur: onBlur(element.props.onBlur),
+  });
+
+  return [el, state];
+};
+
+export default useFocus;

--- a/stories/useFocus.story.tsx
+++ b/stories/useFocus.story.tsx
@@ -1,0 +1,26 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useFocus } from '../src';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const element = (focused: boolean) => (
+    <div>
+      <label htmlFor="useFocus" style={{fontWeight: focused ? 'bold' : 'normal'}}>Click here</label>
+      <input type="text" id="useFocus" value="Focus here" />
+    </div>
+  );
+
+  const [input, focused] = useFocus(element);
+
+  return (
+    <div>
+      {input}
+      <div>{focused ? 'Input is on focus!' : ''}</div>
+    </div>
+  );
+};
+
+storiesOf('Sensors|useFocus', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useFocus.md')} />)
+  .add('Demo', () => <Demo />)

--- a/tests/useFocus.test.tsx
+++ b/tests/useFocus.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { renderHook, act } from '@testing-library/react-hooks';
+import useFocus from '../src/useFocus';
+
+it('should be defined', () => {
+  expect(useFocus).toBeDefined();
+});
+
+it('should return an element (object) and a boolean', () => {
+  const element = () => (<label htmlFor="foo">Foo<input id="foo" type="text" value="foo"/></label>)
+  const { result } = renderHook(() => useFocus(element))
+
+  expect(result.current.length).toBe(2);
+  expect(typeof result.current[0]).toBe('object');
+  expect(typeof result.current[1]).toBe('boolean');
+});
+
+it('should change focused to true when calling onFocus', () => {
+  const element = () => (<label id="labelFoo" htmlFor="foo">Foo<input id="foo" type="text"/></label>)
+  const { result } = renderHook(() => useFocus(element))
+  
+  const component = result.current[0]
+
+  expect(result.current[1]).toBe(false)
+
+  act(() => {
+    component.props.onFocus()
+  })
+
+  expect(result.current[1]).toBe(true)
+});

--- a/tests/useFocus.test.tsx
+++ b/tests/useFocus.test.tsx
@@ -15,7 +15,7 @@ it('should return an element (object) and a boolean', () => {
   expect(typeof result.current[1]).toBe('boolean');
 });
 
-it('should change focused to true when calling onFocus', () => {
+it('should change focused to true when calling onFocus and to false when calling onBlur', () => {
   const element = () => (<label id="labelFoo" htmlFor="foo">Foo<input id="foo" type="text"/></label>)
   const { result } = renderHook(() => useFocus(element))
   
@@ -28,4 +28,10 @@ it('should change focused to true when calling onFocus', () => {
   })
 
   expect(result.current[1]).toBe(true)
+
+  act(() => {
+    component.props.onBlur()
+  })
+
+  expect(result.current[1]).toBe(false)  
 });


### PR DESCRIPTION
# Description

Adds useFocus hook. The hook returns an element and a boolean control variable.

Also, it's my first contribution here, even after reading the Contributing Guidelines I might have missed something, sorry in advance! 

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
