### PR TITLE
fix: type lazy init for useSet

### DIFF
--- a/src/useSet.ts
+++ b/src/useSet.ts
@@ -12,7 +12,7 @@ export interface Actions<K> extends StableActions<K> {
   has: (key: K) => boolean;
 }
 
-const useSet = <K>(initialSet = new Set<K>()): [Set<K>, Actions<K>] => {
+const useSet = <K>(initialSet: Set<K> | (() => Set<K> = new Set<K>()): [Set<K>, Actions<K>] => {
   const [set, setSet] = useState(initialSet);
 
   const stableActions = useMemo<StableActions<K>>(() => {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
`useSet` uses state internally to instantiate its Set, so it should also allow for a lazy initializer to prevent a new Set from being created on every render. This was already possible but this change types it correctly.


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
