### PR TITLE
Make sure hook won't break when using SSR

### DIFF
--- a/src/useIdle.ts
+++ b/src/useIdle.ts
@@ -6,7 +6,7 @@ const defaultEvents = ['mousemove', 'mousedown', 'resize', 'keydown', 'touchstar
 const oneMinute = 60e3;
 
 // Make sure hook won't break when using SSR
-const isBrowser = (typeof window === 'undefined' ? 'undefined' : typeof window) === 'object'
+const isBrowser = typeof window !== 'undefined'
 const documentElement = isBrowser ? document : {}
 const windowElement = isBrowser ? window : {}
 


### PR DESCRIPTION
# Description

- Add fallbacks for window and document when your app is using SSR, for example a NextJS app 
- Remove boolean typecheck, because typescript says its already derived from default value
- Remove eslint-disable, don't know why it was there?
- Add state to return cleanup, because now linter want me to add that

## Type of change
- [x] Bug fix _(non-breaking change which fixes an issue)_

