### PR TITLE
refactor: moved line of 'noUserInteraction' variable in useCopyClipboard.ts

### DIFF
--- a/src/useCopyToClipboard.ts
+++ b/src/useCopyToClipboard.ts
@@ -26,11 +26,12 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
         }
       }
 
-      const noUserInteraction = writeText(value);
-
       if (!isMounted()) {
         return;
       }
+
+      const noUserInteraction = writeText(value);
+
       setState({
         value,
         error: undefined,


### PR DESCRIPTION
# Description

I Moved line of 'noUserInteraction' variable, because it does not have to exist before if condition.

If !isMounted() is true, copyToClipboard function will be returned and the function(= writeText(value)) assigned to 'noUserInteraction' variable becomes unnecessary.


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
