### PR TITLE
Support an array of refs when using useClickAway

### DIFF
--- a/docs/useClickAway.md
+++ b/docs/useClickAway.md
@@ -25,10 +25,40 @@ const Demo = () => {
 };
 ```
 
+Alternatively, an array of refs can be used
+```jsx
+import {useClickAway} from 'react-use';
+
+const Demo = () => {
+  const refOne = useRef(null);
+  const refTwo = useRef(null);
+
+  useClickAway([refOne, refTwo], () => {
+    console.log('OUTSIDE CLICKED');
+  });
+
+  return (
+    <React.Fragment>
+      <div ref={refOne} style={{
+        width: 200,
+        height: 200,
+        background: 'red',
+      }} />
+      <div ref={refTwo} style={{
+        width: 200,
+        height: 200,
+        background: 'blue',
+      }} />
+    </React.Fragment>
+  );
+};
+```
+
 ## Reference
 
 ```js
 useClickAway(ref, onMouseEvent)
+useClickAway([refOne, refTwo], onMouseEvent)
 useClickAway(ref, onMouseEvent, ['click'])
 useClickAway(ref, onMouseEvent, ['mousedown', 'touchstart'])
 ```

--- a/src/useClickAway.ts
+++ b/src/useClickAway.ts
@@ -4,7 +4,7 @@ import { off, on } from './util';
 const defaultEvents = ['mousedown', 'touchstart'];
 
 const useClickAway = <E extends Event = Event>(
-  ref: RefObject<HTMLElement | null>,
+  ref: RefObject<HTMLElement | null> | RefObject<HTMLElement | null>[],
   onClickAway: (event: E) => void,
   events: string[] = defaultEvents
 ) => {
@@ -13,9 +13,21 @@ const useClickAway = <E extends Event = Event>(
     savedCallback.current = onClickAway;
   }, [onClickAway]);
   useEffect(() => {
+    const refArray = Array.isArray(ref) ? ref : [ref];
+
     const handler = event => {
-      const { current: el } = ref;
-      el && !el.contains(event.target) && savedCallback.current(event);
+      let clickedAway = true;
+
+      refArray.forEach(ref => {
+        const { current: el } = ref;
+        if (el && el.contains(event.target)) {
+          clickedAway = false;
+        }
+      });
+
+      if (clickedAway) {
+        savedCallback.current(event);
+      }
     };
     for (const eventName of events) {
       on(document, eventName, handler);

--- a/stories/useClickAway.story.tsx
+++ b/stories/useClickAway.story.tsx
@@ -21,6 +21,35 @@ const Demo = () => {
   );
 };
 
+const RefArrayDemo = () => {
+  const refOne = useRef(null);
+  const refTwo = useRef(null);
+
+  useClickAway<MouseEvent>([refOne, refTwo], action('outside clicked'));
+
+  return (
+    <React.Fragment>
+    <div
+      ref={refOne}
+      style={{
+        width: 200,
+        height: 200,
+        background: 'red',
+      }}
+    />
+    <div
+      ref={refTwo}
+      style={{
+        width: 200,
+        height: 200,
+        background: 'blue',
+      }}
+    />
+    </React.Fragment>
+  );
+};
+
 storiesOf('UI|useClickAway', module)
   .add('Docs', () => <ShowDocs md={require('../docs/useClickAway.md')} />)
-  .add('Demo', () => <Demo />);
+  .add('Demo', () => <Demo />)
+  .add('Ref Array Demo', () => <RefArrayDemo />);


### PR DESCRIPTION
Note: this change is backwards compatible, as we convert a single ref into an array with a single ref in it.
```jsx
const refArray = Array.isArray(ref) ? ref : [ref];
```

# Description
Allow passing an array of refs. This is particularly useful when using portals, where the child falls outside of the default "contains" query used in `useClickAway`.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
Whoops, I did not read the note about commit message appended with "feat" in time
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [ ] Cover changes with tests
It looks like there were no tests for the standard `useClickAway` hook
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
