### PR TITLE
fix: keyboardJs.bind is not a function

### DIFF
--- a/src/useKeyboardJs.ts
+++ b/src/useKeyboardJs.ts
@@ -6,7 +6,7 @@ const useKeyboardJs = (combination: string | string[]) => {
   const [keyboardJs, setKeyboardJs] = useState<any>(null);
 
   useMount(() => {
-    import('keyboardjs').then(setKeyboardJs);
+    import('keyboardjs').then(res => setKeyboardJs(res.default));
   });
 
   useEffect(() => {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
Fixed the error: ```keyboardJs.bind is not a function``` for ```useKeyboardJs```.
Issue: https://github.com/streamich/react-use/issues/877
Reproduced at: https://streamich.github.io/react-use/?path=/story/sensors-usekeyboardjs--demo

Fix: The ```keyboardjs``` package was exporting it self as default. So we need to use the ```.default``` instead of directly importing and setting it to the state. 

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
