### PR TITLE
fix: Demo: useKeyPressEvent is decrementing ('[') twice

### DIFF
--- a/stories/useKeyPressEvent.story.tsx
+++ b/stories/useKeyPressEvent.story.tsx
@@ -17,7 +17,7 @@ const Demo = () => {
   const reset = () => setCount(() => 0);
 
   useKeyPressEvent(']', increment);
-  useKeyPressEvent('[', decrement, decrement);
+  useKeyPressEvent('[', decrement);
   useKeyPressEvent('r', reset);
 
   return (


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
Reported at: https://github.com/streamich/react-use/issues/1131
At https://streamich.github.io/react-use/?path=/story/sensors-usekeypressevent--demo
When we try to decrement the count by pressing [ key. It decrements the count by two, instead of one.
Fix: Removed the extra decrement call.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
