### PR TITLE
feat:add useRafFn hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
     <br/>
     <br/>
 - [**Animations**](./docs/Animations.md)
-  - [`useRaf`](./docs/useRaf.md) &mdash; re-renders component on each `requestAnimationFrame`.
+  - [`useRaf`](./docs/useRaf.md) and [`useRafFn`](./docs/useRafFn.md) &mdash; re-renders component on each `requestAnimationFrame`.
   - [`useInterval`](./docs/useInterval.md) and [`useHarmonicIntervalFn`](./docs/useHarmonicIntervalFn.md) &mdash; re-renders component on a set interval using `setInterval`.
   - [`useSpring`](./docs/useSpring.md) &mdash; interpolates number over time according to spring dynamics.
   - [`useTimeout`](./docs/useTimeout.md) &mdash; re-renders component after a timeout.

--- a/docs/useRafFn.md
+++ b/docs/useRafFn.md
@@ -1,0 +1,70 @@
+# `useRafFn`
+
+React animation hook that based on `requestAnimationFrame` encapsulates a series of methods for controlling the operation of animation.
+
+## Usage
+
+```jsx
+import { useRafFn } from 'react-use';
+
+const Demo = () => {
+  const [elapsed, rafProps] = useRafFn(5000);
+
+  rafProps.useOnComplete(() => {
+    console.log('animate completed');
+  })
+
+  return (
+    <div>
+      <div
+        style={{
+          width: 50,
+          height: 50,
+          backgroundColor: '#3cf',
+          transform: `translateX(${elapsed * 500}px)`
+        }} />
+      <ul>
+        <li>elapsed: {elapsed}</li>
+        <li>paused: {rafProps.paused.toString()}</li>
+        <li>completed: {rafProps.completed.toString()}</li>
+      </ul>
+      <div>
+        <input
+          type="range"
+          min={0} max={1} step={0.01}
+          value={elapsed}
+          onChange={e => rafProps.seek(+e.target.value)}
+        />
+      </div>
+      <button onClick={rafProps.play}>play</button>
+      <button onClick={rafProps.pause}>pause</button>
+      <button onClick={rafProps.stop}>stop</button>
+      <button onClick={rafProps.restart}>restart</button>
+      <button onClick={rafProps.reverse}>reverse</button>
+    </div>
+  );
+};
+```
+
+## Reference
+
+```ts
+const [
+  elapsed: number,
+  {
+    play: () => void,
+    pause: () => void,
+    restart: () => void,
+    stop: () => void,
+    seek: (currentElapsed: number) => void,
+    reverse: () => void,
+    completed: boolean,
+    paused: boolean,
+    useOnComplete: (fn: () => void) => void
+  }
+] = useRafFn(ms?: number, autoPlay?: boolean);
+
+```
+
+- `ms` &mdash; milliseconds for how long to keep re-rendering component, defaults to `1000`.
+- `autoPlay` &mdash; Whether to automatically run animation, defaults to `false`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export { default as usePreviousDistinct } from './usePreviousDistinct';
 export { default as usePromise } from './usePromise';
 export { default as useQueue } from './useQueue';
 export { default as useRaf } from './useRaf';
+export { default as useRafFn } from './useRafFn';
 export { default as useRafLoop } from './useRafLoop';
 export { default as useRafState } from './useRafState';
 export { default as useSearchParam } from './useSearchParam';

--- a/src/useRafFn.ts
+++ b/src/useRafFn.ts
@@ -1,0 +1,126 @@
+import { useLayoutEffect, useState, useRef } from 'react';
+
+type rafPropType = {
+  play: () => void,
+  pause: () => void,
+  restart: () => void,
+  stop: () => void,
+  seek: (currentElapsed: number) => void,
+  reverse: () => void,
+  completed: boolean,
+  paused: boolean,
+  useOnComplete: (fn: () => void) => void
+};
+
+const useRafFn = (ms: number = 1e3, autoPlay: boolean = false): [number, rafPropType] => {
+  const [elapsed, setElapsed] = useState<number>(0);
+  const [completed, setCompleted] = useState<boolean>(false);
+  const [paused, setPaused] = useState<boolean>(!autoPlay);
+  const raf = useRef<number | null>(null);
+  const tmpElapsed = useRef<number>(0);     // Used to record the value of elapsed when paused
+  const startTime = useRef<number>(0);
+  const reversed = useRef<boolean>(false);
+
+  const setRaf = (onFrame: () => void) => {
+    raf.current = requestAnimationFrame(onFrame);
+  };
+  const clearRaf = () => {
+    raf.current && cancelAnimationFrame(raf.current);
+  };
+
+  const onFrame = () => {
+    const pauseElapsed = reversed.current ? 1 - tmpElapsed.current : tmpElapsed.current;
+    const currElapsed = Math.min(1, (Date.now() - startTime.current) / ms + pauseElapsed);
+
+    setElapsed(reversed.current ? 1 - currElapsed : currElapsed);
+    if (currElapsed === 1) {
+      clearRaf();
+      setCompleted(true);
+      setPaused(true);
+      tmpElapsed.current = +reversed.current;
+    } else {
+      setRaf(onFrame);
+    }
+  };
+
+  const run = () => {
+    clearRaf();
+    setPaused(false);
+    setCompleted(false);
+    startTime.current = Date.now();
+    setRaf(onFrame);
+  };
+
+  const start = (isReverse: boolean) => {
+    // do the reverse during the motion
+    if (reversed.current !== isReverse) {
+      reversed.current = isReverse;
+      tmpElapsed.current = elapsed;
+      run();
+    } else if (paused) {
+      run();
+    }
+  }
+  const play = () => {
+    start(false);
+  };
+
+  const reverse = () => {
+    start(true);
+  };
+
+  const pause = () => {
+    if ([0, 1].includes(elapsed)) {
+      return;
+    }
+    clearRaf();
+    tmpElapsed.current = elapsed;
+    setPaused(true);
+  };
+
+  const restart = () => {
+    setElapsed(0);
+    reversed.current = false;
+    tmpElapsed.current = 0;
+    run();
+  };
+
+  const stop = () => {
+    clearRaf();
+    tmpElapsed.current = 0;
+    reversed.current = false;
+    setElapsed(0);
+    setPaused(true);
+    setCompleted(false);
+  };
+
+  const seek = (currElapsed : number) => {
+    const _currElapsed = Math.max(Math.min(currElapsed, 1), 0);
+    const _completed = _currElapsed === +!reversed.current;
+
+    // reversed and completed  => 0
+    // !reversed and completed => 1
+    // !completed            => _currElapsed
+    tmpElapsed.current = _completed ? +reversed.current : _currElapsed;
+
+    clearRaf();
+    setElapsed(_currElapsed);
+    setPaused(true);
+    setCompleted(_completed);
+  };
+
+  const useOnComplete = (fn: () => void) => {
+    useLayoutEffect(() => {
+      completed && fn && fn();
+    }, [completed]);  // eslint-disable-line
+  }
+
+  useLayoutEffect(() => {
+    autoPlay && run();
+    return clearRaf;
+  }, []);  // eslint-disable-line
+
+  return [elapsed, { play, pause, restart, stop, seek, reverse, paused, completed, useOnComplete }];
+};
+
+export default useRafFn;

--- a/stories/useRafFn.story.tsx
+++ b/stories/useRafFn.story.tsx
@@ -1,0 +1,46 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import useRafFn from '../src/useRafFn';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const [elapsed, rafProps] = useRafFn(5000);
+
+  rafProps.useOnComplete(() => {
+    console.log('animate completed');
+  })
+
+  return (
+    <div>
+      <div
+        style={{
+          width: 50,
+          height: 50,
+          backgroundColor: '#3cf',
+          transform: `translateX(${elapsed * 500}px)`
+        }} />
+      <ul>
+        <li>elapsed: {elapsed}</li>
+        <li>paused: {rafProps.paused.toString()}</li>
+        <li>completed: {rafProps.completed.toString()}</li>
+      </ul>
+      <div>
+        <input
+          type="range"
+          min={0} max={1} step={0.01}
+          value={elapsed}
+          onChange={e => rafProps.seek(+e.target.value)}
+        />
+      </div>
+      <button onClick={rafProps.play}>play</button>
+      <button onClick={rafProps.pause}>pause</button>
+      <button onClick={rafProps.stop}>stop</button>
+      <button onClick={rafProps.restart}>restart</button>
+      <button onClick={rafProps.reverse}>reverse</button>
+    </div>
+  );
+};
+
+storiesOf('Animation|useRafFn', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useRafFn.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useRafFn.test.ts
+++ b/tests/useRafFn.test.ts
@@ -1,0 +1,633 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { replaceRaf } from 'raf-stub';
+import useRafFn from '../src/useRafFn';
+
+/**
+ * New requestAnimationFrame after being replaced with raf-stub for testing purposes.
+ */
+interface RequestAnimationFrame {
+  reset(): void;
+
+  step(): void;
+}
+
+declare var requestAnimationFrame: RequestAnimationFrame;
+
+replaceRaf();
+const fixedStart = 1564949709496;
+const spyDateNow = jest.spyOn(Date, 'now').mockImplementation(() => fixedStart);
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  requestAnimationFrame.reset();
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  requestAnimationFrame.reset();
+});
+
+it('should init percentage of time elapsed', () => {
+  const { result } = renderHook(() => useRafFn());
+  const [timeElapsed] = result.current;
+
+  expect(timeElapsed).toBe(0);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+});
+
+it('should init no animation', () => {
+  const { result } = renderHook(() => useRafFn());
+
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+});
+
+it('should init percentage of time elapsed for execute play method', () => {
+  const { result } = renderHook(() => useRafFn());
+
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].play();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5); // 50%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3); // 100%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+});
+
+it('should return corresponding percentage of time elapsed for default ms', () => {
+  const { result } = renderHook(() => useRafFn());
+
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].play();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.25); // 25%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.25);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5); // 50%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.75); // 75%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.75);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3); // 100%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+});
+
+it('should return corresponding percentage of time elapsed for custom ms', () => {
+  const customMs = 2000;
+  const { result } = renderHook(() => useRafFn(customMs));
+
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+  
+  act(() => {
+    result.current[1].play();
+    spyDateNow.mockImplementationOnce(() => fixedStart + customMs * 0.25); // 25%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.25);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + customMs * 0.5); // 50%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + customMs * 0.75); // 75%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.75);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + customMs); // 100%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+});
+
+it('should automatically run animation for set autoplay to true', () => {
+  const { result } = renderHook(() => useRafFn(1e3, true));
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5); // 50%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3); // 100%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+});
+
+it('should return always 1 after corresponding ms reached', () => {
+  const { result } = renderHook(() => useRafFn());
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].play();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3); // 100%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 1.1); // 110%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 3); // 300%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+});
+
+it('should clear pending timers on unmount', () => {
+  const spyRafStop = jest.spyOn(global, 'cancelAnimationFrame' as any);
+  const { unmount } = renderHook(() => useRafFn());
+
+  expect(spyRafStop).not.toHaveBeenCalled();
+
+  unmount();
+
+  expect(spyRafStop).toHaveBeenCalledTimes(0);
+});
+
+it('should stop animation for execute pause method', () => {
+  const { result } = renderHook(() => useRafFn());
+  const [elapsed, { play, paused, completed }] = result.current;
+
+  expect(elapsed).toBe(0);
+  expect(paused).toBe(true);
+  expect(completed).toBe(false);
+
+  act(() => {
+    play()
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.25); // 25%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.25);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5); // 50%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].pause();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.75); // 75%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 3); // 100%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+});
+
+it('should start or continue animation when play is in paused status', () => {
+  const { result } = renderHook(() => useRafFn());
+  const [elapsed, { play, paused, completed }] = result.current;
+  let tmpNum = 0
+
+  expect(elapsed).toBe(0);
+  expect(paused).toBe(true);
+  expect(completed).toBe(false);
+
+  act(() => {
+    play()
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.25); // 25%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.25);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].pause();
+    tmpNum = 1e3 * 0.25;
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5); // 50%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.25);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.75); // 75%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.25);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].play();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0 + tmpNum); // 100%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.25 + tmpNum); // 125%
+    requestAnimationFrame.step();
+    tmpNum = 0;
+  });
+  expect(result.current[0]).toBe(0.75);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+});
+
+it('should restart animation when restart is in playing status', () => {
+  const { result } = renderHook(() => useRafFn());
+  const [elapsed, { play, paused, completed }] = result.current;
+
+  expect(elapsed).toBe(0);
+  expect(paused).toBe(true);
+  expect(completed).toBe(false);
+
+  act(() => {
+    play();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5); // 50%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].restart();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0); // 50%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5 ); // 100%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 1); // 150%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+});
+
+it('should restart animation when restart is in paused status ', () => {
+  const { result } = renderHook(() => useRafFn());
+  const [elapsed, { play, paused, completed }] = result.current;
+
+  expect(elapsed).toBe(0);
+  expect(paused).toBe(true);
+  expect(completed).toBe(false);
+
+  act(() => {
+    play();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].pause();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].restart();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0 );
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 1);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+});
+
+it('should restart animation when play is in after corresponding ms reached', () => {
+  const { result } = renderHook(() => useRafFn());
+  const [elapsed, { play, paused, completed }] = result.current;
+
+  expect(elapsed).toBe(0);
+  expect(paused).toBe(true);
+  expect(completed).toBe(false);
+
+  act(() => {
+    play();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+
+  act(() => {
+    result.current[1].play();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5); // 50%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 1 ); // 100%
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+});
+
+it('should be able to pause animation for set autoplay to true', () => {
+  const { result } = renderHook(() => useRafFn(1e3, true));
+  const [elapsed, { paused, completed}] = result.current;
+  expect(elapsed).toBe(0);
+  expect(paused).toBe(false);
+  expect(completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].pause()
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+});
+
+it('should be able to pause animation for after restart animation', () => {
+  const { result } = renderHook(() => useRafFn());
+  const [elapsed, { play, paused, completed }] = result.current;
+
+  expect(elapsed).toBe(0);
+  expect(paused).toBe(true);
+  expect(completed).toBe(false);
+
+  act(() => {
+    play();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].restart();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0 );
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].pause();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 1);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+});
+
+it('should be back to the original position for execute stop', () => {
+  const { result } = renderHook(() => useRafFn(1e3, true));
+  const [elapsed, { paused, completed }] = result.current;
+
+  expect(elapsed).toBe(0);
+  expect(paused).toBe(false);
+  expect(completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].stop();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+});
+
+it('should be jump to the specified position for execute seek', () => {
+  const { result } = renderHook(() => useRafFn(1e3, true));
+  const [elapsed, { paused, completed }] = result.current;
+
+  expect(elapsed).toBe(0);
+  expect(paused).toBe(false);
+  expect(completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].seek(0.3);
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.3);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+
+  // Minimum of 0
+  act(() => {
+    result.current[1].seek(-3);
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 1.1);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(false);
+
+  // Maximum of 1
+  act(() => {
+    result.current[1].seek(5);
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 1.3);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(1);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+});
+
+it('should reverse run animate for execute reverse', () => {
+  const { result } = renderHook(() => useRafFn(1e3, true));
+  const [elapsed, { paused, completed }] = result.current;
+
+  expect(elapsed).toBe(0);
+  expect(paused).toBe(false);
+  expect(completed).toBe(false);
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0.5);
+  expect(result.current[1].paused).toBe(false);
+  expect(result.current[1].completed).toBe(false);
+
+  act(() => {
+    result.current[1].reverse();
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3);
+    requestAnimationFrame.step();
+  });
+  expect(result.current[0]).toBe(0);
+  expect(result.current[1].paused).toBe(true);
+  expect(result.current[1].completed).toBe(true);
+});
+
+it('should triggered the callback function for the animation is complete', () => {
+  const effect = jest.fn();
+  const { result } = renderHook(() => useRafFn(1e3, true));
+  const { rerender } = renderHook(() => result.current[1].useOnComplete(effect))
+  
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3 * 0.5);
+    requestAnimationFrame.step();
+  });
+  rerender();
+  expect(effect).not.toHaveBeenCalled();
+
+  act(() => {
+    spyDateNow.mockImplementationOnce(() => fixedStart + 1e3);
+    requestAnimationFrame.step();
+  });
+  rerender();
+  expect(effect).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
# Description

Recently, I was developing a large screen project for data visualization, and I used a lot of animation. I used `useRaf` and `useTween` and found it particularly useful, but Sometimes don't want to run the animation right away, but trigger some conditions to run the animation, so I couldn't set the delay to meet my requirements.

So I looked up the source code of `useRaf` and found that I could pass in the state as an argument and change the state to get what I wanted but there was always a problem.Later, I decided to write a hook by myself.

`useRafFn` provides play, pause, restart, stop, reverse, seek methods and completed, paused property. Also added a very simple but very common animation completion event

## Type of change

- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist

- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).