### PR TITLE
docs(useUnmountPromise): don't pass Promise to useEffect

### DIFF
--- a/docs/useUnmountPromise.md
+++ b/docs/useUnmountPromise.md
@@ -10,8 +10,10 @@ import useUnmountPromise from 'react-use/lib/useUnmountPromise';
 
 const Demo = () => {
   const mounted = useUnmountPromise();
-  useEffect(async () => {
-    await mounted(someFunction()); // Will not resolve if component un-mounts.
+  useEffect(() => {
+    (async () => {
+      await mounted(someFunction()); // Will not resolve if component un-mounts.
+    })();
   });
 };
 ```


### PR DESCRIPTION
# Description

This PR changes only `docs/useUnmountPromise.md`.
The current example code passes `Promise` to `useEffect`, but it causes a warning, so I'd like to fix the doc.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
