### PR TITLE
fix: Slightly enhanced the typing of createGlobalState

### DIFF
--- a/src/createGlobalState.ts
+++ b/src/createGlobalState.ts
@@ -2,6 +2,15 @@
 import { useLayoutEffect, useState } from 'react';
 import useEffectOnce from './useEffectOnce';
 
+export function createGlobalState<S = any>(): () => [
+  S | undefined,
+  (state: S) => void
+];
+
+export function createGlobalState<S = any>(
+  initialState: S
+): () => [S, (state: S) => void];
+
 export function createGlobalState<S = any>(initialState?: S) {
   const store: { state: S | undefined; setState: (state: S) => void; setters: any[] } = {
     state: initialState,


### PR DESCRIPTION
# Description

Enhanced the type definition of `createGlobalState` to condition the state value's type to not be `undefined` in the case an initial value was passed in.


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
