### PR TITLE
fix: useCookie delete different subdomain cookie

### DIFF
--- a/src/useCookie.ts
+++ b/src/useCookie.ts
@@ -3,7 +3,11 @@ import Cookies from 'js-cookie';
 
 const useCookie = (
   cookieName: string
-): [string | null, (newValue: string, options?: Cookies.CookieAttributes) => void, () => void] => {
+): [
+  string | null,
+  (newValue: string, options?: Cookies.CookieAttributes) => void,
+  (options?: Cookies.CookieAttributes) => void
+] => {
   const [value, setValue] = useState<string | null>(() => Cookies.get(cookieName) || null);
 
   const updateCookie = useCallback(
@@ -14,10 +18,13 @@ const useCookie = (
     [cookieName]
   );
 
-  const deleteCookie = useCallback(() => {
-    Cookies.remove(cookieName);
-    setValue(null);
-  }, [cookieName]);
+  const deleteCookie = useCallback(
+    (options?: Cookies.CookieAttributes) => {
+      Cookies.remove(cookieName, options);
+      setValue(null);
+    },
+    [cookieName]
+  );
 
   return [value, updateCookie, deleteCookie];
 };

--- a/tests/useCookie.test.tsx
+++ b/tests/useCookie.test.tsx
@@ -60,7 +60,7 @@ it('should delete the cookie on call to deleteCookie', () => {
 
   expect(result.current[0]).toBeNull();
   expect(spy).toHaveBeenCalledTimes(1);
-  expect(spy).toHaveBeenLastCalledWith(cookieName);
+  expect(spy).toHaveBeenLastCalledWith(cookieName, undefined);
 
   // cleanup
   spy.mockRestore();


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

Fix `deleteCookie` for `useCookie`, when delete a `different sub domain cookie`, we should specify the `domain` form `Cookies.remove()`.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
