### PR TITLE
Improve TS typings on useAsyncFn

### DIFF
--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -3,7 +3,7 @@ import useAsyncFn from './useAsyncFn';
 
 export { AsyncState, AsyncFn } from './useAsyncFn';
 
-export default function useAsync<Result = any>(
+export default function useAsync<Result>(
   fn: () => Promise<Result>,
   deps: DependencyList = []
 ) {

--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -3,11 +3,11 @@ import useAsyncFn from './useAsyncFn';
 
 export { AsyncState, AsyncFn } from './useAsyncFn';
 
-export default function useAsync<Result = any, Args extends any[] = any[]>(
-  fn: (...args: Args | []) => Promise<Result>,
+export default function useAsync<Result = any>(
+  fn: () => Promise<Result>,
   deps: DependencyList = []
 ) {
-  const [state, callback] = useAsyncFn<Result, Args>(fn, deps, {
+  const [state, callback] = useAsyncFn<Result, []>(fn, deps, {
     loading: true,
   });
 

--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -19,13 +19,13 @@ export type AsyncState<T> =
       value: T;
     };
 
-export type AsyncFn<Result = any, Args extends any[] = any[]> = [
+export type AsyncFn<Result, Args extends unknown[]> = [
   AsyncState<Result>,
-  (...args: Args | []) => Promise<Result>
+  (...args: Args) => Promise<Result>
 ];
 
-export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
-  fn: (...args: Args | []) => Promise<Result>,
+export default function useAsyncFn<Result, Args extends unknown[]>(
+  fn: (...args: Args) => Promise<Result>,
   deps: DependencyList = [],
   initialState: AsyncState<Result> = { loading: false }
 ): AsyncFn<Result, Args> {
@@ -34,7 +34,7 @@ export default function useAsyncFn<Result = any, Args extends any[] = any[]>(
 
   const isMounted = useMountedState();
 
-  const callback = useCallback((...args: Args | []) => {
+  const callback = useCallback((...args: Args) => {
     const callId = ++lastCallId.current;
     set({ loading: true });
 


### PR DESCRIPTION
# Description

This PR improves overall TS typings on `useAsyncFn` as well as fix this particular issue:

```ts
const [, fn] = useAsyncFn((num: number) => Promise.resolve(num + 1));;
fn() // This should error, but doesn't with the current typings.
```

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation (Should be transparent to user)
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests (No dtslint or tsd tests yet to test errors 😢)
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
