### PR TITLE
feat(createBreakpoint): Add more restrictive types

### DIFF
--- a/src/createBreakpoint.ts
+++ b/src/createBreakpoint.ts
@@ -1,8 +1,14 @@
 /* eslint-disable */
 import { useEffect, useState, useMemo } from 'react';
 
-const createBreakpoint = (
-  breakpoints: { [name: string]: number } = { laptopL: 1440, laptop: 1024, tablet: 768 }
+type Breakpoint = Record<string, number>;
+
+const defaultBreakpoint = { laptopL: 1440, laptop: 1024, tablet: 768 };
+
+const createBreakpoint: <A extends Breakpoint = typeof defaultBreakpoint>(
+	breakpoints?: A
+) => () => keyof A = (
+  breakpoints: Breakpoint = defaultBreakpoint
 ) => () => {
   const [screen, setScreen] = useState(0);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": false,
     "strict": true,
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
# Description

createBreakpoint currently just creates a hook that returns any string, but we can do a little better and determine the type as one of the keys of the provided breakpoints.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [X] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [X] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [X] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
