### PR TITLE
simplify code contributions by fully automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+tasks:
+  - name: Storybook
+    init: yarn install && gp sync-done install
+    command: yarn run start
+  - name: Tests
+    init: gp sync-await install
+    command: yarn test:watch
+ports:
+  - port: 6008
+    onOpen: open-preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,12 @@ Thanks for being willing to contribute 🙌 If you contribute to this project, y
 > can make all of your pull request branches based on this `master` branch.
 > Whenever you want to update your version of `master`, do a regular `git pull`.
 
+## Online one-click setup for contributing
+
+Contribute to react-use using a fully featured online development environment that will automatically: clone the repo, install the dependencies, start the webserver and run the tests in watch mode.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## Development
 
 This library is a collection of React hooks so a proposal for a new hook will need to utilize the [React Hooks API](https://reactjs.org/docs/hooks-reference.html) internally to be taken into consideration.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
     <a href="http://streamich.github.io/react-use">
       <img src="https://img.shields.io/badge/demos-🚀-yellow.svg" alt="demos" />
     </a>
+    <a href="https://gitpod.io/#https://github.com/streamich/react-use">
+      <img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code">
+    </a>
     <br />
     Collection of essential <a href="https://reactjs.org/docs/hooks-intro.html">React Hooks</a>.</em>
     <em>Port of</em> <a href="https://github.com/streamich/libreact"><code>libreact</code></a>.


### PR DESCRIPTION
Hi! 

This Pr simplifies code contributions by fully automating the dev setup with Gitpod(An online VS Code-like IDE). With a single click, it'll launch a workspace and automatically:

- clone the `react-use` repo.
- install the dependencies.
- run `yarn run start`.
- run `yarn test watch`.

So that anyone interested in contributing can start straight away without any friction.

You can give it a try on my fork of the repo: 

https://gitpod.io/#https://github.com/nisarhassan12/react-use

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/80702534-abfa8300-8afa-11ea-8528-f287a201f367.png)

