### PR TITLE
Fix `useHoverDirty` returning incorrectly true

### DIFF
--- a/src/useHoverDirty.ts
+++ b/src/useHoverDirty.ts
@@ -17,6 +17,7 @@ const useHoverDirty = (ref: RefObject<Element>, enabled: boolean = true) => {
     if (enabled && ref && ref.current) {
       ref.current.addEventListener('mouseover', onMouseOver);
       ref.current.addEventListener('mouseout', onMouseOut);
+      ref.current.addEventListener('mouseleave', onMouseOut);
     }
 
     // fixes react-hooks/exhaustive-deps warning about stale ref elements
@@ -26,6 +27,7 @@ const useHoverDirty = (ref: RefObject<Element>, enabled: boolean = true) => {
       if (enabled && current) {
         current.removeEventListener('mouseover', onMouseOver);
         current.removeEventListener('mouseout', onMouseOut);
+        current.removeEventListener('mouseleave', onMouseOut);
       }
     };
   }, [enabled, ref]);


### PR DESCRIPTION
Fix #1192

# Description

This commit fix a bug on Firefox where `mouseout` is not always fired.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
