### PR TITLE
useLongPress cancelable event and perform clear upon callback

### DIFF
--- a/src/useLongPress.ts
+++ b/src/useLongPress.ts
@@ -13,7 +13,7 @@ const isTouchEvent = (event: Event): event is TouchEvent => {
 const preventDefault = (event: Event) => {
   if (!isTouchEvent(event)) return;
 
-  if (event.touches.length < 2 && event.preventDefault) {
+  if (event.touches.length < 2 && event.cancelable && event.preventDefault) {
     event.preventDefault();
   }
 };
@@ -32,7 +32,10 @@ const useLongPress = (
         event.target.addEventListener('touchend', preventDefault, { passive: false });
         target.current = event.target;
       }
-      timeout.current = setTimeout(() => callback(event), delay);
+      timeout.current = setTimeout(() => {
+        clear();
+        callback(event);
+      }, delay);
     },
     [callback, delay]
   );


### PR DESCRIPTION
# Description

- Add `event.cancelable` check before performing `event.preventDefault()`. This solves the following error when trying to cancel event while scrolling.
```
[Intervention] Ignored attempt to cancel a touchend event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.
```

- Perform clearing of timeout and event listener as soon as the long press callback is triggered. 

## Type of change

<!-- Check all relevant options. -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
