### PR TITLE
fix: 🐛 correct useMeasure typings

### DIFF
--- a/src/useMeasure.ts
+++ b/src/useMeasure.ts
@@ -6,8 +6,8 @@ export type UseMeasureRect = Pick<
   DOMRectReadOnly,
   'x' | 'y' | 'top' | 'left' | 'right' | 'bottom' | 'height' | 'width'
 >;
-export type UseMeasureRef = (element: HTMLElement) => void;
-export type UseMeasureResult = [UseMeasureRef, UseMeasureRect];
+export type UseMeasureRef<E extends HTMLElement = HTMLElement> = (element: E) => void;
+export type UseMeasureResult<E extends HTMLElement = HTMLElement> = [UseMeasureRef<E>, UseMeasureRect];
 
 const defaultState: UseMeasureRect = {
   x: 0,
@@ -20,8 +20,8 @@ const defaultState: UseMeasureRect = {
   right: 0,
 };
 
-const useMeasure = (): UseMeasureResult => {
-  const [element, ref] = useState<HTMLElement | null>(null);
+const useMeasure = <E extends HTMLElement = HTMLElement>(): UseMeasureResult<E> => {
+  const [element, ref] = useState<E | null>(null);
   const [rect, setRect] = useState<UseMeasureRect>(defaultState);
 
   const observer = useMemo(
@@ -46,6 +46,6 @@ const useMeasure = (): UseMeasureResult => {
   return [ref, rect];
 };
 
-const useMeasureMock = () => [() => {}, defaultState];
+const useMeasureMock: typeof useMeasure = () => [() => {}, defaultState];
 
 export default (isClient && !!(window as any).ResizeObserver) ? useMeasure : useMeasureMock;


### PR DESCRIPTION
When upgrading to v15, I discovered some issues with `useMeasure` forcing me to downgrade to v14. Hopefully these changes fixes those issues...

* It was no longer possible to define the ref type, meaning components requiring a certain type of ref would reject it. Fixed this by making the function generic again.
* Previously you _had to_ define the ref type, while in v15 you _couldn't_. Fixed this by giving the generic type a default type of `HTMLElement`.
* The implicit typing of `useMeasureMock` combined with the ternary default export statement made the imported type of `useMeasure` very messy. Fixed this by making the type of `useMeasureMock` explicitly match `useMeasure`.

# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Ensure the test suite passes (`yarn test`)
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
