### PR TITLE
Fix docs for `useKeyPressEvent` not mirroring storybook

### DIFF
--- a/docs/useKeyPressEvent.md
+++ b/docs/useKeyPressEvent.md
@@ -18,7 +18,7 @@ const Demo = () => {
   const decrement = () => setCount(count => --count);
   const reset = () => setCount(count => 0);
 
-  useKeyPressEvent(']', increment, increment);
+  useKeyPressEvent(']', increment);
   useKeyPressEvent('[', decrement, decrement);
   useKeyPressEvent('r', reset);
 


### PR DESCRIPTION
In the actual story code (see here https://github.com/streamich/react-use/blob/master/stories/useKeyPressEvent.story.tsx#L19-L21) the `increment` is only called once, but in the docs it's shown twice.

(Removed checklists since it's only a doc change and none of the checkboxes apply.)