### PR TITLE
feat: ability to reset useCopyToClipboard hook

### DIFF
--- a/docs/useCopyToClipboard.md
+++ b/docs/useCopyToClipboard.md
@@ -7,26 +7,27 @@ Copy text to a user's clipboard.
 ```jsx
 const Demo = () => {
   const [text, setText] = React.useState('');
-  const [state, copyToClipboard] = useCopyToClipboard();
+  const [state, copyToClipboard, reset] = useCopyToClipboard();
 
   return (
     <div>
       <input value={text} onChange={e => setText(e.target.value)} />
-      <button type="button" onClick={() => copyToClipboard(text)}>copy text</button>
-      {state.error
-        ? <p>Unable to copy value: {state.error.message}</p>
-        : state.value && <p>Copied {state.value}</p>}
+      <button type="button" onClick={() => copyToClipboard(text)} onMouseOut={reset}>
+        copy text
+      </button>
+      {state.error ? <p>Unable to copy value: {state.error.message}</p> : state.value && <p>Copied {state.value}</p>}
     </div>
-  )
-}
+  );
+};
 ```
 
 ## Reference
 
 ```js
-const [{value, error, noUserInteraction}, copyToClipboard] = useCopyToClipboard();
+const [{ value, error, noUserInteraction }, copyToClipboard, reset] = useCopyToClipboard();
 ```
 
 - `value` &mdash; value that was copied to clipboard, undefined when nothing was copied.
 - `error` &mdash; caught error when trying to copy to clipboard.
 - `noUserInteraction` &mdash; boolean indicating if user interaction was required to copy the value to clipboard to expose full API from underlying [`copy-to-clipboard`](https://github.com/sudodoki/copy-to-clipboard) library.
+- `reset` &mdash; function to reset the hook to its initial state.

--- a/src/useCopyToClipboard.ts
+++ b/src/useCopyToClipboard.ts
@@ -10,13 +10,19 @@ export interface CopyToClipboardState {
   error?: Error;
 }
 
-const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] => {
+const initial = {
+  value: undefined,
+  error: undefined,
+  noUserInteraction: true,
+};
+
+const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void, () => void] => {
   const isMounted = useMountedState();
-  const [state, setState] = useSetState<CopyToClipboardState>({
-    value: undefined,
-    error: undefined,
-    noUserInteraction: true,
-  });
+  const [state, setState] = useSetState<CopyToClipboardState>(initial);
+
+  const resetState = useCallback(() => {
+    setState(initial);
+  }, [setState]);
 
   const copyToClipboard = useCallback(value => {
     if (!isMounted()) {
@@ -63,7 +69,7 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
     }
   }, []);
 
-  return [state, copyToClipboard];
+  return [state, copyToClipboard, resetState];
 };
 
 export default useCopyToClipboard;

--- a/stories/useCopyToClipboard.story.tsx
+++ b/stories/useCopyToClipboard.story.tsx
@@ -5,13 +5,16 @@ import ShowDocs from './util/ShowDocs';
 
 const Demo = () => {
   const [text, setText] = React.useState('');
-  const [state, copyToClipboard] = useCopyToClipboard();
+  const [state, copyToClipboard, reset] = useCopyToClipboard();
 
   return (
     <div>
       <input value={text} onChange={e => setText(e.target.value)} />
       <button type="button" onClick={() => copyToClipboard(text)}>
         copy text
+      </button>
+      <button type="button" disabled={state.value === undefined} onClick={reset}>
+        reset
       </button>
       {state.error ? (
         <p>Unable to copy value: {state.error.message}</p>

--- a/tests/useCopyToClipboard.test.ts
+++ b/tests/useCopyToClipboard.test.ts
@@ -41,6 +41,23 @@ describe('useCopyToClipboard', () => {
     expect(state.error).not.toBeDefined();
   });
 
+  it('should reset state if reset function called', () => {
+    const testValue = 'test';
+    let [state, copyToClipboard, reset] = hook.result.current;
+    act(() => copyToClipboard(testValue));
+
+    [state, copyToClipboard, reset] = hook.result.current;
+    expect(writeText).toBeCalled();
+    expect(state.value).toBe(testValue);
+
+    act(() => reset());
+    [state, copyToClipboard, reset] = hook.result.current;
+
+    expect(state.value).not.toBeDefined();
+    expect(state.noUserInteraction).toBe(true);
+    expect(state.error).not.toBeDefined();
+  });
+
   it('should not call writeText if passed an invalid input and set state', () => {
     let testValue = {}; // invalid value
     let [state, copyToClipboard] = hook.result.current;


### PR DESCRIPTION
# Description

Closes #1265
The motivation is explained in #1265.

This is a backwards-compatible change that adds a `reset` function to the values returned by the `useCopyToClipboard` hook. When `reset` is called, the hook is set back to its initial state.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
