### PR TITLE
Incorrect value when using callback for set

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -69,7 +69,7 @@ const useLocalStorage = <T>(
         // localStorage can throw. Also JSON.stringify can throw.
       }
     },
-    [key, setState]
+    [key, state, setState]
   );
 
   const remove = useCallback(() => {


### PR DESCRIPTION
# Description
Basically when you do
```js
let newNum = 4
const [nums, setNums] = useLocalStorage('nums', [1,2,3])

const onClick = e => {
  setNums(nums => {
    // 1st click: nums = [1,2,3]
	// 2nd click: nums = [1,2,3] even though you would expect it to be [1,2,3,4]
    return [...nums, newNum++]
  })
}
```
This is because you forgot to include the `state` in your `useCallback`. Because of this, your `useCallback` holds a stale value. Unfortunately I don't have time right now to write a test, but it should be trivial.