### PR TITLE
fix: repair useKeyboardJs hook

### DIFF
--- a/src/useKeyboardJs.ts
+++ b/src/useKeyboardJs.ts
@@ -6,7 +6,7 @@ const useKeyboardJs = (combination: string | string[]) => {
   const [keyboardJs, setKeyboardJs] = useState<any>(null);
 
   useMount(() => {
-    import('keyboardjs').then(setKeyboardJs);
+    import('keyboardjs').then(k => setKeyboardJs(k.default || k));
   });
 
   useEffect(() => {
@@ -16,7 +16,7 @@ const useKeyboardJs = (combination: string | string[]) => {
 
     const down = event => set([true, event]);
     const up = event => set([false, event]);
-    keyboardJs.bind(combination, down, up);
+    keyboardJs.bind(combination, down, up, true);
 
     return () => {
       keyboardJs.unbind(combination, down, up);


### PR DESCRIPTION
# Description

Fixed the importing of the KeyboardJS library with backward compatibility. Updated how bindings are set to prevent KeyboardJS from calling handlers repeatedly while holding keys.


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
