### PR TITLE
feat: add useImage hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
   - [`useCss`](./docs/useCss.md) &mdash; dynamically adjusts CSS.
   - [`useDrop` and `useDropArea`](./docs/useDrop.md) &mdash; tracks file, link and copy-paste drops.
   - [`useFullscreen`](./docs/useFullscreen.md) &mdash; display an element or video full-screen. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/ui-usefullscreen--demo)
+  - [`useImage`](./docs/useImage.md) &mdash; loads an image and provides various information, e.g. whether the image has been loaded. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/ui-useimage--demo)
   - [`useSlider`](./docs/useSlider.md) &mdash; provides slide behavior over any HTML element. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/ui-useslider--demo)
   - [`useSpeech`](./docs/useSpeech.md) &mdash; synthesizes speech from a text string. [![][img-demo]](https://codesandbox.io/s/n090mqz69m)
   - [`useVibrate`](./docs/useVibrate.md) &mdash; provide physical feedback using the [Vibration API](https://developer.mozilla.org/en-US/docs/Web/API/Vibration_API). [![][img-demo]](https://streamich.github.io/react-use/?path=/story/ui-usevibrate--demo)

--- a/docs/useImage.md
+++ b/docs/useImage.md
@@ -1,0 +1,34 @@
+# `useImage`
+
+Hook that loads an image and provides various information, e.g. whether the image has been loaded.
+
+## Usage
+
+```jsx
+const Demo = () => {
+  const imageSrc = 'https://via.placeholder.com/150';
+
+  const { hasLoaded, hasError } = useImage(imageSrc);
+
+  if (hasError) {
+    return null;
+  }
+
+  return (
+    <div>
+      {!hasLoaded && <>Loading...</>}
+      {hasLoaded && <img src={imageSrc} />}
+    </div>
+  );
+};
+```
+
+## Reference
+
+```typescript
+const {
+    hasLoaded: boolean,
+    hasError: boolean,
+    hasStartedInitialFetch: boolean
+} = useFetchImage(imageSrc: string);
+```

--- a/docs/useImage.md
+++ b/docs/useImage.md
@@ -30,5 +30,5 @@ const {
     hasLoaded: boolean,
     hasError: boolean,
     hasStartedInitialFetch: boolean
-} = useFetchImage(imageSrc: string);
+} = useImage(imageSrc: string);
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,3 +114,4 @@ export { useFirstMountState } from './useFirstMountState';
 export { default as useSet } from './useSet';
 export { createGlobalState } from './createGlobalState';
 export { useHash } from './useHash';
+export { useImage } from './useImage';

--- a/src/useImage.tsx
+++ b/src/useImage.tsx
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+
+export const useImage = (src: string) => {
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [hasStartedInitialFetch, setHasStartedInitialFetch] = useState(false);
+
+  useEffect(() => {
+    if (src) {
+      setHasStartedInitialFetch(true);
+      setHasLoaded(false);
+      setHasError(false);
+
+      const image = new Image();
+      image.src = src;
+
+      const handleError = () => {
+        setHasError(true);
+      };
+
+      const handleLoad = () => {
+        setHasLoaded(true);
+        setHasError(false);
+      };
+
+      image.onerror = handleError;
+      image.onload = handleLoad;
+
+      return () => {
+        image.removeEventListener('error', handleError);
+        image.removeEventListener('load', handleLoad);
+      };
+    }
+
+    return;
+  }, [src]);
+
+  return { hasLoaded, hasError, hasStartedInitialFetch };
+};

--- a/stories/useImage.story.tsx
+++ b/stories/useImage.story.tsx
@@ -1,0 +1,25 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useImage } from '../src';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const imageSrc = 'https://via.placeholder.com/150';
+
+  const { hasLoaded, hasError } = useImage(imageSrc);
+
+  if (hasError) {
+    return null;
+  }
+
+  return (
+    <div>
+      {!hasLoaded && <>Loading...</>}
+      {hasLoaded && <img src={imageSrc} />}
+    </div>
+  );
+};
+
+storiesOf('UI|useImage', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useImage.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useImage.test.tsx
+++ b/tests/useImage.test.tsx
@@ -1,0 +1,15 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useImage } from '../src';
+
+describe('useFavicon', () => {
+  it('should be defined', () => {
+    expect(useImage).toBeDefined();
+  });
+
+  it('should have started fetching', async () => {
+    const { result } = renderHook(() => useImage('https://via.placeholder.com/150'));
+
+    expect(result.current.hasStartedInitialFetch).toBe(true);
+  });
+});


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
The `useImage` hook loads an image in parallel or before it is loaded by an img element. However, the image is never loaded twice. 

The purpose of this hook is to better track events, such as when an image has finished loading or if there has been an error. This in turn allows you to easily include loading indicators that are shown until the image is loaded.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
