### PR TITLE
[Fix] common misspelling errors

### DIFF
--- a/tests/useCopyToClipboard.test.ts
+++ b/tests/useCopyToClipboard.test.ts
@@ -52,7 +52,7 @@ describe('useCopyToClipboard', () => {
     expect(state.noUserInteraction).toBe(true);
     expect(state.error).toBeDefined();
 
-    testValue = ''; // emtpy string is also invalid
+    testValue = ''; // empty string is also invalid
     act(() => copyToClipboard(testValue));
     [state, copyToClipboard] = hook.result.current;
 


### PR DESCRIPTION
For reference: https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines