### PR TITLE
fix: createFactory is deprecated

### DIFF
--- a/src/createReducerContext.ts
+++ b/src/createReducerContext.ts
@@ -1,15 +1,14 @@
-import { createFactory, createContext, useContext, useReducer } from 'react';
+import { createElement, createContext, useContext, useReducer } from 'react';
 
 const createReducerContext = <R extends React.Reducer<any, any>>(
   reducer: R,
   defaultInitialState: React.ReducerState<R>
 ) => {
   const context = createContext<[React.ReducerState<R>, React.Dispatch<React.ReducerAction<R>>] | undefined>(undefined);
-  const providerFactory = createFactory(context.Provider);
 
   const ReducerProvider: React.FC<{ initialState?: React.ReducerState<R> }> = ({ children, initialState }) => {
     const state = useReducer<R>(reducer, initialState !== undefined ? initialState : defaultInitialState);
-    return providerFactory({ value: state }, children);
+    return createElement(context.Provider, { value: state }, children);
   };
 
   const useReducerContext = () => {

--- a/src/createStateContext.ts
+++ b/src/createStateContext.ts
@@ -1,12 +1,11 @@
-import { createFactory, createContext, useContext, useState } from 'react';
+import { createElement, createContext, useContext, useState } from 'react';
 
 const createStateContext = <T>(defaultInitialValue: T) => {
   const context = createContext<[T, React.Dispatch<React.SetStateAction<T>>] | undefined>(undefined);
-  const providerFactory = createFactory(context.Provider);
 
   const StateProvider: React.FC<{ initialValue?: T }> = ({ children, initialValue }) => {
     const state = useState<T>(initialValue !== undefined ? initialValue : defaultInitialValue);
-    return providerFactory({ value: state }, children);
+    return createElement(context.Provider, { value: state }, children);
   };
 
   const useStateContext = () => {


### PR DESCRIPTION
# Description

> Warning: React.createFactory() is deprecated and will be removed in a future major release. Consider using JSX or use React.createElement() directly instead.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
