### PR TITLE
Add flush method to timeout hooks

### DIFF
--- a/docs/useDebounce.md
+++ b/docs/useDebounce.md
@@ -12,7 +12,7 @@ const Demo = () => {
   const [val, setVal] = React.useState('');
   const [debouncedValue, setDebouncedValue] = React.useState('');
 
-  const [, cancel] = useDebounce(
+  const [, cancel, flush] = useDebounce(
     () => {
       setState('Typing stopped');
       setDebouncedValue(val);
@@ -36,6 +36,7 @@ const Demo = () => {
       <div>
         Debounced value: {debouncedValue}
         <button onClick={cancel}>Cancel debounce</button>
+        <button onClick={flush}>Flush debounce</button>
       </div>
     </div>
   );

--- a/docs/useTimeout.md
+++ b/docs/useTimeout.md
@@ -1,6 +1,6 @@
 # `useTimeout`
 
-Re-renders the component after a specified number of milliseconds.  
+Re-renders the component after a specified number of milliseconds.
 Provides handles to cancel and/or reset the timeout.
 
 ## Usage
@@ -10,12 +10,13 @@ import { useTimeout } from 'react-use';
 
 function TestComponent(props: { ms?: number } = {}) {
   const ms = props.ms || 5000;
-  const [isReady, cancel] = useTimeout(ms);
+  const [isReady, cancel,, flush] = useTimeout(ms);
 
   return (
     <div>
       { isReady() ? 'I\'m reloaded after timeout' : `I will be reloaded after ${ ms / 1000 }s` }
       { isReady() === false ? <button onClick={ cancel }>Cancel</button> : '' }
+      { isReady() === false ? <button onClick={flush}>Flush</button> : '' }
     </div>
   );
 }
@@ -32,7 +33,7 @@ const Demo = () => {
 
 ## Reference
 
-```ts 
+```ts
 const [
     isReady: () => boolean | null,
     cancel: () => void,

--- a/docs/useTimeoutFn.md
+++ b/docs/useTimeoutFn.md
@@ -7,7 +7,7 @@ Several thing about it's work:
 - automatically cancel timeout on cancel;
 - automatically reset timeout on delay change;
 - reset function call will cancel previous timeout;
-- timeout will NOT be reset on function change. It will be called within the timeout, you have to reset it on your own when needed. 
+- timeout will NOT be reset on function change. It will be called within the timeout, you have to reset it on your own when needed.
 
 ## Usage
 
@@ -22,7 +22,7 @@ const Demo = () => {
     setState(`called at ${Date.now()}`);
   }
 
-  const [isReady, cancel, reset] = useTimeoutFn(fn, 5000);
+  const [isReady, cancel, reset, flush] = useTimeoutFn(fn, 5000);
   const cancelButtonClick = useCallback(() => {
     if (isReady() === false) {
       cancel();
@@ -32,6 +32,10 @@ const Demo = () => {
       setState('Not called yet');
     }
   }, []);
+  const flushButtonClick = useCallback(() => {
+    flush();
+    setState('flushed');
+  }, []);
 
   const readyState = isReady();
 
@@ -39,6 +43,7 @@ const Demo = () => {
     <div>
       <div>{readyState !== null ? 'Function will be called in 5 seconds' : 'Timer cancelled'}</div>
       <button onClick={cancelButtonClick}> {readyState === false ? 'cancel' : 'restart'} timeout</button>
+      <button onClick={flushButtonClick} disabled={readyState !== false}>flush</button>
       <br />
       <div>Function state: {readyState === false ? 'Pending' : readyState ? 'Called' : 'Cancelled'}</div>
       <div>{state}</div>
@@ -49,7 +54,7 @@ const Demo = () => {
 
 ## Reference
 
-```ts 
+```ts
 const [
     isReady: () => boolean | null,
     cancel: () => void,

--- a/src/useDebounce.ts
+++ b/src/useDebounce.ts
@@ -1,12 +1,12 @@
 import { DependencyList, useEffect } from 'react';
 import useTimeoutFn from './useTimeoutFn';
 
-export type UseDebounceReturn = [() => boolean | null, () => void];
+export type UseDebounceReturn = [() => boolean | null, () => void, () => void];
 
 export default function useDebounce(fn: Function, ms: number = 0, deps: DependencyList = []): UseDebounceReturn {
-  const [isReady, cancel, reset] = useTimeoutFn(fn, ms);
+  const [isReady, cancel, reset, flush] = useTimeoutFn(fn, ms);
 
   useEffect(reset, deps);
 
-  return [isReady, cancel];
+  return [isReady, cancel, flush];
 }

--- a/src/useTimeout.ts
+++ b/src/useTimeout.ts
@@ -1,7 +1,7 @@
 import useTimeoutFn from './useTimeoutFn';
 import useUpdate from './useUpdate';
 
-export type UseTimeoutReturn = [() => boolean | null, () => void, () => void];
+export type UseTimeoutReturn = [() => boolean | null, () => void, () => void, () => void];
 
 export default function useTimeout(ms: number = 0): UseTimeoutReturn {
   const update = useUpdate();

--- a/src/useTimeoutFn.ts
+++ b/src/useTimeoutFn.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import { useCallback, useEffect, useRef } from 'react';
 
-export type UseTimeoutFnReturn = [() => boolean | null, () => void, () => void];
+export type UseTimeoutFnReturn = [() => boolean | null, () => void, () => void, () => void];
 
 export default function useTimeoutFn(fn: Function, ms: number = 0): UseTimeoutFnReturn {
   const ready = useRef<boolean | null>(false);
@@ -25,6 +25,12 @@ export default function useTimeoutFn(fn: Function, ms: number = 0): UseTimeoutFn
     timeout.current && clearTimeout(timeout.current);
   }, []);
 
+  const flush = useCallback(() => {
+    ready.current = true;
+    timeout.current && clearTimeout(timeout.current);
+    callback.current();
+  }, []);
+
   // update ref when function changes
   useEffect(() => {
     callback.current = fn;
@@ -37,5 +43,5 @@ export default function useTimeoutFn(fn: Function, ms: number = 0): UseTimeoutFn
     return clear;
   }, [ms]);
 
-  return [isReady, clear, set];
+  return [isReady, clear, set, flush];
 }

--- a/stories/useDebounce.story.tsx
+++ b/stories/useDebounce.story.tsx
@@ -8,7 +8,7 @@ const Demo = () => {
   const [val, setVal] = React.useState('');
   const [debouncedValue, setDebouncedValue] = React.useState('');
 
-  const [, cancel] = useDebounce(
+  const [, cancel, flush] = useDebounce(
     () => {
       setState('Typing stopped');
       setDebouncedValue(val);
@@ -32,6 +32,7 @@ const Demo = () => {
       <div>
         Debounced value: {debouncedValue}
         <button onClick={cancel}>Cancel debounce</button>
+        <button onClick={flush}>Flush debounce</button>
       </div>
     </div>
   );

--- a/stories/useTimeout.story.tsx
+++ b/stories/useTimeout.story.tsx
@@ -5,12 +5,13 @@ import ShowDocs from './util/ShowDocs';
 
 function TestComponent(props: { ms?: number } = {}) {
   const ms = props.ms || 5000;
-  const [isReady, cancel] = useTimeout(ms);
+  const [isReady, cancel,, flush] = useTimeout(ms);
 
   return (
     <div>
       {isReady() ? "I'm reloaded after timeout" : `I will be reloaded after ${ms / 1000}s`}
       {isReady() === false ? <button onClick={cancel}>Cancel</button> : ''}
+      {isReady() === false ? <button onClick={flush}>Flush</button> : ''}
     </div>
   );
 }

--- a/stories/useTimeoutFn.story.tsx
+++ b/stories/useTimeoutFn.story.tsx
@@ -11,7 +11,7 @@ const Demo = () => {
     setState(`called at ${Date.now()}`);
   }
 
-  const [isReady, cancel, reset] = useTimeoutFn(fn, 5000);
+  const [isReady, cancel, reset, flush] = useTimeoutFn(fn, 5000);
   const cancelButtonClick = useCallback(() => {
     if (isReady() === false) {
       cancel();
@@ -21,6 +21,10 @@ const Demo = () => {
       setState('Not called yet');
     }
   }, []);
+  const flushButtonClick = useCallback(() => {
+    flush();
+    setState('flushed');
+  }, []);
 
   const readyState = isReady();
 
@@ -28,6 +32,7 @@ const Demo = () => {
     <div>
       <div>{readyState !== null ? 'Function will be called in 5 seconds' : 'Timer cancelled'}</div>
       <button onClick={cancelButtonClick}> {readyState === false ? 'cancel' : 'restart'} timeout</button>
+      <button onClick={flushButtonClick} disabled={readyState !== false}>flush</button>
       <br />
       <div>Function state: {readyState === false ? 'Pending' : readyState ? 'Called' : 'Cancelled'}</div>
       <div>{state}</div>

--- a/tests/useDebounce.test.ts
+++ b/tests/useDebounce.test.ts
@@ -23,9 +23,10 @@ describe('useDebounce', () => {
   it('should return three functions', () => {
     const hook = renderHook(() => useDebounce(() => {}, 5));
 
-    expect(hook.result.current.length).toBe(2);
+    expect(hook.result.current.length).toBe(3);
     expect(typeof hook.result.current[0]).toBe('function');
     expect(typeof hook.result.current[1]).toBe('function');
+    expect(typeof hook.result.current[2]).toBe('function');
   });
 
   function getHook(
@@ -89,6 +90,22 @@ describe('useDebounce', () => {
 
     expect(spy).not.toHaveBeenCalled();
     expect(isReady()).toBe(null);
+  });
+
+  it('third function should flush debounce', () => {
+    const [spy, hook] = getHook();
+    const [isReady,, flush] = hook.result.current;
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(isReady()).toBe(false);
+
+    act(() => {
+      flush();
+    });
+    jest.advanceTimersByTime(5);
+
+    expect(spy).toHaveBeenCalled();
+    expect(isReady()).toBe(true);
   });
 
   it('should reset timeout on delay change', () => {

--- a/tests/useTimeout.test.ts
+++ b/tests/useTimeout.test.ts
@@ -18,13 +18,14 @@ it('should be defined', () => {
   expect(useTimeout).toBeDefined();
 });
 
-it('should return three functions', () => {
+it('should return four functions', () => {
   const hook = renderHook(() => useTimeout(5));
 
-  expect(hook.result.current.length).toBe(3);
+  expect(hook.result.current.length).toBe(4);
   expect(typeof hook.result.current[0]).toBe('function');
   expect(typeof hook.result.current[1]).toBe('function');
   expect(typeof hook.result.current[2]).toBe('function');
+  expect(typeof hook.result.current[3]).toBe('function');
 });
 
 function getHook(ms: number = 5): [jest.Mock, RenderHookResult<{ delay: number }, UseTimeoutReturn>] {
@@ -114,6 +115,33 @@ it('third function should reset timeout', done => {
 
   hook.waitForNextUpdate().then(() => {
     expect(spy).toHaveBeenCalledTimes(2);
+    expect(isReady()).toBe(true);
+
+    done();
+  });
+  jest.advanceTimersByTime(5);
+});
+
+it('fourth function should flush timeout', done => {
+  const [spy, hook] = getHook();
+  const [isReady,, reset, flush] = hook.result.current;
+
+  expect(isReady()).toBe(false);
+
+  act(() => {
+    flush();
+  });
+  jest.advanceTimersByTime(5);
+
+  expect(isReady()).toBe(true);
+
+  act(() => {
+    reset();
+  });
+  expect(isReady()).toBe(false);
+
+  hook.waitForNextUpdate().then(() => {
+    expect(spy).toHaveBeenCalledTimes(3);
     expect(isReady()).toBe(true);
 
     done();

--- a/tests/useTimeoutFn.test.ts
+++ b/tests/useTimeoutFn.test.ts
@@ -19,13 +19,14 @@ describe('useTimeoutFn', () => {
     expect(useTimeoutFn).toBeDefined();
   });
 
-  it('should return three functions', () => {
+  it('should return four functions', () => {
     const hook = renderHook(() => useTimeoutFn(() => {}, 5));
 
-    expect(hook.result.current.length).toBe(3);
+    expect(hook.result.current.length).toBe(4);
     expect(typeof hook.result.current[0]).toBe('function');
     expect(typeof hook.result.current[1]).toBe('function');
     expect(typeof hook.result.current[2]).toBe('function');
+    expect(typeof hook.result.current[3]).toBe('function');
   });
 
   function getHook(
@@ -103,6 +104,30 @@ describe('useTimeoutFn', () => {
     jest.advanceTimersByTime(5);
 
     expect(spy).toHaveBeenCalledTimes(1);
+    expect(isReady()).toBe(true);
+  });
+
+  it('fourth function should flush timeout', () => {
+    const [spy, hook] = getHook();
+    const [isReady,, reset, flush] = hook.result.current;
+
+    expect(isReady()).toBe(false);
+
+    act(() => {
+      flush();
+    });
+    jest.advanceTimersByTime(5);
+
+    expect(isReady()).toBe(true);
+
+    act(() => {
+      reset();
+    });
+    expect(isReady()).toBe(false);
+
+    jest.advanceTimersByTime(5);
+
+    expect(spy).toHaveBeenCalledTimes(2);
     expect(isReady()).toBe(true);
   });
 


### PR DESCRIPTION
# Description

Returning an extra method from useTimeout, useTimeoutFn and useDebounce to clear the timeout and trigger the callback immediately.

Closes #401

## Type of change

- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas **(Not relevant for this change I think...)**
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage **(Not sure I understand what 100% means in this case?)**
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`). **(Got some unrelated errors on this one from node_modules/nano-css...)**
