### PR TITLE
Fix useIntersection not updating state on fast scroll

### DIFF
--- a/src/useIntersection.ts
+++ b/src/useIntersection.ts
@@ -10,7 +10,7 @@ const useIntersection = (
   useEffect(() => {
     if (ref.current && typeof IntersectionObserver === 'function') {
       const handler = (entries: IntersectionObserverEntry[]) => {
-        setIntersectionObserverEntry(entries[0]);
+        setIntersectionObserverEntry(entries[entries.length - 1]); // sometimes, IntersectionObserver returns multiple entries, in that case, only the latest in the list contains the latest state
       };
 
       const observer = new IntersectionObserver(handler, options);


### PR DESCRIPTION
# Description

`useIntersection` doesn't update on fast scroll as observer returns multiple entries in that case and only the last item in the array of observer entries contains the latest state.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
