### PR TITLE
Fix title of useStateWithHistory documentation

### DIFF
--- a/docs/useStateWithHistory.md
+++ b/docs/useStateWithHistory.md
@@ -1,4 +1,4 @@
-# `useStateHistory`
+# `useStateWithHistory`
 
 Stores defined amount of previous state values and provides handles to travel through them.
 


### PR DESCRIPTION
# Description

It's a simple documentation fix. `useStateHistory` doesn't exist, and it should be changed to `useState`**`With`**`History`.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist

I think I'm fine without checking all boxes.

- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
