### PR TITLE
fix(useUnmountPromise): Keep working after initial render

### DIFF
--- a/src/useUnmountPromise.ts
+++ b/src/useUnmountPromise.ts
@@ -6,7 +6,7 @@ const useUnmountPromise = (): Race => {
   const refUnmounted = useRef(false);
   useEffect(() => () => {
     refUnmounted.current = true;
-  });
+  }, []);
 
   const wrapper = useMemo(() => {
     const race = <P extends Promise<any>, E>(promise: P, onError?: (error: E) => void) => {

--- a/tests/useUnmountPromise.test.ts
+++ b/tests/useUnmountPromise.test.ts
@@ -15,10 +15,14 @@ describe('useUnmountPromise', () => {
   it('when component is mounted function should resolve with wrapped promises', async () => {
     const hook = renderHook(() => useUnmountPromise());
 
-    const mounted = hook.result.current;
-    const res = await mounted(new Promise(r => setTimeout(() => r(25), 10)));
+    const res1 = await hook.result.current(new Promise(r => setTimeout(() => r(25), 10)));
+    expect(res1).toBe(25);
 
-    expect(res).toBe(25);
+    // FIXME: Ensure the useEffect() hook has executed before triggering next;
+    // using hook.waitForNextUpdate() doesn't work
+
+    const res2 = await hook.result.current(new Promise(r => setTimeout(() => r(10), 10)));
+    expect(res2).toBe(10);
   });
 
   it('when component is unmounted promise never resolves', async () => {


### PR DESCRIPTION
# Description

The function returned from `useUnmountPromise` currently doesn't resolve promises passed after the initial render. This happens due to the `useEffect` mount check missing a dependency array, which causes the hook to consider the component unmounted right after mounting.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas - not necessary in this case
- [x] Add documentation - not necessary in this case
- [x] Add hook's story at Storybook - not necessary in this case
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
