### PR TITLE
fix (documentation): Rename useEffectOnce to useLifecycles on documentation example

### DIFF
--- a/docs/useMount.md
+++ b/docs/useMount.md
@@ -1,6 +1,6 @@
 # `useMount`
 
-React lifecycle hook that calls a function after the component is mounted. Use `useEffectOnce` if you need both a mount and unmount function.
+React lifecycle hook that calls a function after the component is mounted. Use `useLifecycles` if you need both a mount and unmount function.
 
 ## Usage
 

--- a/docs/useUnmount.md
+++ b/docs/useUnmount.md
@@ -1,6 +1,6 @@
 # `useUnmount`
 
-React lifecycle hook that calls a function when the component will unmount. Use `useEffectOnce` if you need both a mount and unmount function.
+React lifecycle hook that calls a function when the component will unmount. Use `useLifecycles` if you need both a mount and unmount function.
 
 ## Usage
 


### PR DESCRIPTION
# Description

Reading the documentation, I think the `useLifecycles` hook fits better on both situations.

Documentation for both:
useLifecycles — calls mount and unmount callbacks.
useEffectOnce — a modified useEffect hook that only runs once.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
