### PR TITLE
feat: `combineRefs` utility for combining multiple refs into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@
     <br/>
 - [**Miscellaneous**]()
   - [`useEnsuredForwardedRef`](./docs/useEnsuredForwardedRef.md) and [`ensuredForwardRef`](./docs/useEnsuredForwardedRef.md) &mdash; use a React.forwardedRef safely. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-useensuredforwardedref--demo)
+- [`combineRefs`](./docs/combineRefs.md) &mdash; combine multiple refs into one.
 
 <br />
 <br />

--- a/docs/combineRefs.md
+++ b/docs/combineRefs.md
@@ -1,0 +1,26 @@
+# `combineRefs`
+
+A utility to combine two refs together, particularly useful when you have hooks that provide refs to you, but you want to target the same DOM element
+
+## Usage
+
+```jsx
+import { useMeasure, useScroll, combineRefs } from "react-use";
+
+const Demo = () => {
+  const scrollRef = React.useRef(null);
+  const { x, y } = useScroll(scrollRef);
+
+  const [measureRef, { width }] = useMeasure();
+
+  const ref = combineRefs(scrollRef, measureRef)
+
+  return (
+    <div ref={ref}>
+      <div>x: {x}</div>	
+      <div>y: {y}</div>
+      <div>width: {width}</div>
+    </div>
+  );
+};
+```

--- a/src/combineRefs.ts
+++ b/src/combineRefs.ts
@@ -1,0 +1,22 @@
+import { MutableRefObject } from "react";
+
+type Ref<T> =
+  | ((instance: T) => void)
+  | MutableRefObject<T>
+  | null;
+
+function combineRefs<T>(...refs: Ref<T>[]) {
+  return function (instance: T) {
+    refs.forEach((ref) => {
+      if (typeof ref === "function") {
+        ref(instance);
+        return;
+      }
+      if (ref) {
+        ref.current = instance;
+      }
+    });
+  };
+}
+
+export default combineRefs

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,3 +114,4 @@ export { useFirstMountState } from './useFirstMountState';
 export { default as useSet } from './useSet';
 export { createGlobalState } from './createGlobalState';
 export { useHash } from './useHash';
+export { default as combineRefs } from './combineRefs'

--- a/stories/combineRefs.story.tsx
+++ b/stories/combineRefs.story.tsx
@@ -1,0 +1,33 @@
+import { storiesOf } from '@storybook/react';
+import React from 'react';
+import { useMeasure, useScroll, combineRefs } from '../src';
+import ShowDocs from './util/ShowDocs';
+
+const style = {
+  background: 'red',
+  height: '400px',
+  overflow: 'scroll',
+}
+
+const Demo = () => {
+  const scrollRef = React.useRef(null);
+  const { x, y } = useScroll(scrollRef);
+  const [measureRef, state] = useMeasure();
+
+  const ref = combineRefs(scrollRef, measureRef)
+
+  return (
+    <>
+      <pre>{JSON.stringify(state, null, 2)}</pre>
+      <div>x: {x}</div>
+      <div>y: {y}</div>
+      <div ref={ref} style={style}>
+        <div style={{ height: '2000px' }}>Scroll me & Resize me</div>
+      </div>
+    </>
+  );
+};
+
+storiesOf('Miscellaneous|combineRefs', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/combineRefs.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/combineRefs.test.ts
+++ b/tests/combineRefs.test.ts
@@ -1,0 +1,25 @@
+import combineRefs from '../src/combineRefs';
+import { MutableRefObject } from 'react';
+
+describe('combineRefs', () => {
+  it('should be defined', () => {
+    expect(combineRefs).toBeDefined();
+  });
+
+  it('should combine a variety of refs', () => {
+    const aNullRef: null = null;
+    const aRefObject: MutableRefObject<string | null> = { current: null };
+    const aCallbackRef = jest.fn((instance: string | null) => instance);
+
+    const refs = [aNullRef, aRefObject, aCallbackRef] as const
+
+    const ref = combineRefs(...refs);
+
+    ref('hello world')
+
+    expect(aNullRef).toBeNull();
+    expect(aRefObject.current).toEqual('hello world');
+    expect(aCallbackRef.mock.calls.length).toBe(1);
+    expect(aCallbackRef.mock.calls[0][0]).toBe('hello world');
+  });
+})


### PR DESCRIPTION
# Description

This is a utility for combining multiple refs into one. It's particularly useful when using hooks that provide you with a ref to place onto a DOM element, but where you may already be making use of a ref on that element.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas

> there are no comments, but I didn't think any were necessary 

- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
