### PR TITLE
fix(useLocalStorage): Fixed function updater providing stale state

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -69,7 +69,7 @@ const useLocalStorage = <T>(
         // localStorage can throw. Also JSON.stringify can throw.
       }
     },
-    [key, setState]
+    [key, state, setState]
   );
 
   const remove = useCallback(() => {

--- a/tests/useLocalStorage.test.ts
+++ b/tests/useLocalStorage.test.ts
@@ -151,6 +151,18 @@ describe(useLocalStorage, () => {
     expect(value!.fizz).toEqual('buzz');
   });
 
+  it("function updater doesn't get stale state", () => {
+    const { result, rerender } = renderHook(() => useLocalStorage('foo', false));
+
+    act(() => result.current[1](state => !state));
+    rerender();
+    expect(result.current[0]).toEqual(true);
+
+    act(() => result.current[1](state => !state));
+    rerender();
+    expect(result.current[0]).toEqual(false);
+  });
+
   it('rejects nullish or undefined keys', () => {
     const { result } = renderHook(() => useLocalStorage(null as any));
     try {


### PR DESCRIPTION
# Description

The state provided to the `setState` callback from `useLocalStorage` is stale, which for example means that the below toggle usage only works once, and after that the state is "stuck". I.e. calling the `toggle` callback will only work the first time.

```ts
export default function useToggle(key: string, initialValue: boolean): [boolean, () => void] {
  const [value, setValue] = useLocalStorage(key, initialValue)

  const toggleValue = useCallback(() => {
    // calling toggleValue() will only work once, because state passed to setValue is "stuck" on first value
    setValue((value) => !value)
  }, [setValue])

  return [value, toggleValue]
}
```


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_

Although, it might be breaking if someone relies on the faulty stuck/stale state...

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).
