### PR TITLE
fix(useMeasure): allow null element

### DIFF
--- a/src/useMeasure.ts
+++ b/src/useMeasure.ts
@@ -6,7 +6,7 @@ export type UseMeasureRect = Pick<
   DOMRectReadOnly,
   'x' | 'y' | 'top' | 'left' | 'right' | 'bottom' | 'height' | 'width'
 >;
-export type UseMeasureRef<E extends HTMLElement = HTMLElement> = (element: E) => void;
+export type UseMeasureRef<E extends HTMLElement = HTMLElement> = (element: E | null) => void;
 export type UseMeasureResult<E extends HTMLElement = HTMLElement> = [UseMeasureRef<E>, UseMeasureRect];
 
 const defaultState: UseMeasureRect = {


### PR DESCRIPTION
# Description

With strictNullChecks enabled in typescript `UseMeasureRef` complains
that it's being passed something that may be null.

It's already checking for nulls with `if (!element) return;`, so it
should be no problem changing the type to allow it.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
