### PR TITLE
feat:add useTrackedEffect

### DIFF
--- a/docs/useTrackedEffect.md
+++ b/docs/useTrackedEffect.md
@@ -1,0 +1,40 @@
+# `useTrackedEffect`
+
+React lifecycle hook that runs an effect and pass indexes of changed dependencies into callback function, for tracking, further processing,...
+
+## Usage
+
+```jsx
+import {useTrackedEffect, useTimeoutFn} from 'react-use';
+
+const [deps, setDeps] = React.useState({
+    dep1: 0,
+    dep2: 0,
+    dep3: 0,
+  });
+  useTrackedEffect(
+    (changedDeps) => {
+      console.log(`There're ${changedDeps.length} changed dependencies.`);
+      console.log(`Indexes of changes:`, changedDeps);
+
+      return () => {
+        console.log('Running clean-up of effect on unmount');
+      };
+    },
+    [deps.dep1, deps.dep2, deps.dep3]
+  );
+  useTimeoutFn(() => {
+    console.log('Start change dep 1 and dep 2');
+    setDeps({
+      ...deps,
+      dep1: 1,
+      dep2: 1,
+    });
+  }, 1000);
+```
+
+## Reference
+
+```js
+useTrackedEffect(effect: Function, deps: DependencyList);
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,3 +114,4 @@ export { useFirstMountState } from './useFirstMountState';
 export { default as useSet } from './useSet';
 export { createGlobalState } from './createGlobalState';
 export { useHash } from './useHash';
+export { default as useTrackedEffect } from './useTrackedEffect';

--- a/src/useTrackedEffect.ts
+++ b/src/useTrackedEffect.ts
@@ -1,0 +1,23 @@
+/* eslint-disable */
+import { useEffect, useRef, DependencyList } from 'react';
+
+const useTrackedEffect = (effect, deps?: DependencyList) => {
+  const initDeps = useRef<DependencyList>();
+  const diffTwoDeps = (deps1, deps2) => {
+    //Let's do a reference equality check on 2 dependency list.
+    //If deps1 is defined, we iterate over deps1 and do comparison on each element with equivalent element from deps2
+    //As this func is used only in this hook, we assume 2 deps always have same length.
+    return deps1
+      ? deps1.map((_ele, idx) => (deps1[idx] != deps2[idx] ? idx : -1)).filter((ele) => ele >= 0)
+      : deps2
+      ? deps2.map((_ele, idx) => idx)
+      : [];
+  };
+  useEffect(() => {
+    let changes = diffTwoDeps(initDeps.current, deps);
+    initDeps.current = deps;
+    return effect(changes);
+  }, deps);
+};
+
+export default useTrackedEffect;

--- a/stories/useTrackedEffect.story.tsx
+++ b/stories/useTrackedEffect.story.tsx
@@ -1,0 +1,46 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useTrackedEffect, useTimeoutFn } from '../src';
+import ConsoleStory from './util/ConsoleStory';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const [deps, setDeps] = React.useState({
+    dep1: 0,
+    dep2: 0,
+    dep3: 0,
+  });
+  useTrackedEffect(
+    (changedDeps) => {
+      console.log(`There're ${changedDeps.length} changed dependencies.`);
+      console.log(`Indexes of changes:`, changedDeps);
+
+      return () => {
+        console.log('Running clean-up of effect on unmount');
+      };
+    },
+    [deps.dep1, deps.dep2, deps.dep3]
+  );
+  useTimeoutFn(() => {
+    console.log('Start change dep 1 and dep 2');
+    setDeps({
+      ...deps,
+      dep1: 1,
+      dep2: 1,
+    });
+  }, 1000);
+  useTimeoutFn(() => {
+    console.log('Start change dep 1 and dep 3');
+    setDeps({
+      ...deps,
+      dep1: 2,
+      dep2: 1,
+      dep3: 1,
+    });
+  }, 2000);
+  return <ConsoleStory />;
+};
+
+storiesOf('Lifecycle|useTrackedEffect', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useTrackedEffect.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useTrackedEffect.test.ts
+++ b/tests/useTrackedEffect.test.ts
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useTrackedEffect } from '../src';
+
+//We use a array to store which dependency has changed
+var changedDeps = [];
+const mockEffectCleanup = jest.fn();
+const mockEffectCallback = jest.fn().mockReturnValue(mockEffectCleanup);
+const mockEffectWithTracked = jest.fn().mockImplementation((changes) => {
+  //This effect callback accept an addition parameter which contains indexes of dependecies which changed their equalities.
+  changedDeps = changes;
+  return mockEffectCleanup;
+});
+
+it('should run provided effect as expected', () => {
+  const { rerender } = renderHook(() => useTrackedEffect(mockEffectCallback));
+  expect(mockEffectCallback).toHaveBeenCalledTimes(1);
+
+  rerender();
+  expect(mockEffectCallback).toHaveBeenCalledTimes(2);
+});
+
+it("should run provided effect and return single changed dependecy's index ", () => {
+  let var1 = 0;
+  let var2 = '0';
+  let var3 = { value: 0 };
+  const { rerender } = renderHook(() => useTrackedEffect(mockEffectWithTracked, [var1, var2, var3]));
+  expect(mockEffectWithTracked).toHaveBeenCalledTimes(1);
+
+  rerender();
+  expect(changedDeps).toHaveLength(3);
+  changedDeps = [];
+  var1++;
+  rerender();
+  expect(changedDeps).toHaveLength(1);
+  expect(changedDeps[0]).toEqual(0);
+});
+
+it("should run provided effect and return multiple changed dependecy's indexes", () => {
+  let var1 = 0;
+  let var2 = '0';
+  let var3 = { value: 0 };
+  const { rerender } = renderHook(() => useTrackedEffect(mockEffectWithTracked, [var1, var2, var3]));
+  expect(mockEffectWithTracked).toHaveBeenCalledTimes(1);
+  rerender();
+  expect(changedDeps).toHaveLength(3);
+  changedDeps = [];
+  var1++;
+  var2 = '1';
+  rerender();
+  expect(changedDeps).toHaveLength(2);
+  expect(changedDeps[0]).toEqual(0);
+  expect(changedDeps[1]).toEqual(1);
+  changedDeps = [];
+  var2 = '2';
+  rerender();
+  expect(changedDeps).toHaveLength(1);
+  expect(changedDeps[0]).toEqual(1);
+});
+it("should run provided effect and return empty if no dependency changed", () => {
+    let var1 = 0;
+    let var2 = '0';
+    let var3 = { value: 0 };
+    const { rerender } = renderHook(() => useTrackedEffect(mockEffectWithTracked, [var1, var2, var3]));
+    expect(mockEffectWithTracked).toHaveBeenCalledTimes(1);
+    rerender();
+    expect(changedDeps).toHaveLength(3);
+    changedDeps=[]
+    var1 = 0;
+    rerender();
+    expect(changedDeps).toHaveLength(0);
+  });
+it("should run provided effect and make sure reference equality is correct", () => {
+    let var1 = 0;
+    let var2 = '0';
+    let var3 = { value: 0 };
+    const { rerender } = renderHook(() => useTrackedEffect(mockEffectWithTracked, [var1, var2, var3]));
+    expect(mockEffectWithTracked).toHaveBeenCalledTimes(1);
+    rerender();
+    expect(changedDeps).toHaveLength(3);
+    changedDeps = [];
+    var3.value = 123;
+    rerender();
+    expect(changedDeps).toHaveLength(0);
+  });
+
+it('should run clean-up provided on unmount', () => {
+  const { unmount } = renderHook(() => useTrackedEffect(mockEffectCallback));
+  expect(mockEffectCleanup).not.toHaveBeenCalled();
+
+  unmount();
+  expect(mockEffectCleanup).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
# Description

useTrackedEffect is a customized version of useEffect that allow us to tracking which depedencies have caused the effect to triggered.


## Type of change

- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).


