### PR TITLE
remove event before adding, without using state to manage

### DIFF
--- a/src/useEvent.ts
+++ b/src/useEvent.ts
@@ -39,6 +39,7 @@ const useEvent = <T extends UseEventTarget>(
       return;
     }
     if (isListenerType1(target)) {
+      target.removeEventListener(name, handler, options);
       target.addEventListener(name, handler, options);
     } else if (isListenerType2(target)) {
       target.on(name, handler, options);


### PR DESCRIPTION
# Description

Events are pushed into a queue leading to multiple events being attached with useEvent
example:
useEvent('resize', reset);
![Screen Shot 2020-08-25 at 12 20 52 PM](https://user-images.githubusercontent.com/3979844/91218116-78f18600-e6cd-11ea-8235-dc4381478696.png)


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
