### PR TITLE
`setState` is unnecessary in deps

### DIFF
--- a/src/useSetState.ts
+++ b/src/useSetState.ts
@@ -8,7 +8,7 @@ const useSetState = <T extends object>(
     patch => {
       set(prevState => Object.assign({}, prevState, patch instanceof Function ? patch(prevState) : patch));
     },
-    [set]
+    []
   );
 
   return [state, setState];


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

Because [here](https://reactjs.org/docs/hooks-reference.html#usestate).


![image](https://user-images.githubusercontent.com/35673748/91916507-e9149300-ecef-11ea-81f0-8a0b391542a9.png)



## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
