### PR TITLE
fix: useLocalStorage setState should use latest state in updater cb

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -56,16 +56,24 @@ const useLocalStorage = <T>(
     (valOrFunc) => {
       try {
         const newState = typeof valOrFunc === 'function' ? (valOrFunc as Function)(latestState.current) : valOrFunc;
-        if (typeof newState === 'undefined') return;
-        let value: string;
 
-        if (options)
-          if (options.raw)
-            if (typeof newState === 'string') value = newState;
-            else value = JSON.stringify(newState);
-          else if (options.serializer) value = options.serializer(newState);
-          else value = JSON.stringify(newState);
-        else value = JSON.stringify(newState);
+        if (newState === undefined) {
+          return;
+        }
+
+        const getValue = () => {
+          if (options?.raw) {
+            return typeof newState === 'string' ? newState : JSON.stringify(newState);
+          }
+
+          if (options?.serializer) {
+            return options.serializer(newState);
+          }
+
+          return JSON.stringify(newState);
+        };
+
+        const value = getValue();
 
         localStorage.setItem(key, value);
         setState(deserializer(value));

--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, Dispatch, SetStateAction } from 'react';
+import useLatest from './useLatest';
 import { isClient } from './util';
 
 type parserOptions<T> =
@@ -48,10 +49,13 @@ const useLocalStorage = <T>(
   });
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
+  const latestState = useLatest(state);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const set: Dispatch<SetStateAction<T | undefined>> = useCallback(
     (valOrFunc) => {
       try {
-        const newState = typeof valOrFunc === 'function' ? (valOrFunc as Function)(state) : valOrFunc;
+        const newState = typeof valOrFunc === 'function' ? (valOrFunc as Function)(latestState.current) : valOrFunc;
         if (typeof newState === 'undefined') return;
         let value: string;
 
@@ -70,7 +74,7 @@ const useLocalStorage = <T>(
         // localStorage can throw. Also JSON.stringify can throw.
       }
     },
-    [key, setState]
+    [key, setState, latestState]
   );
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/stories/useLocalStorage.story.tsx
+++ b/stories/useLocalStorage.story.tsx
@@ -6,6 +6,7 @@ import ShowDocs from './util/ShowDocs';
 const Demo = () => {
   const [value, setValue] = useLocalStorage('hello-key', 'foo');
   const [removableValue, setRemovableValue, remove] = useLocalStorage('removeable-key');
+  const [toggleableValue, setToggleableValue] = useLocalStorage('toggle-key', false);
 
   return (
     <div>
@@ -18,6 +19,10 @@ const Demo = () => {
       <button onClick={() => setRemovableValue('foo')}>foo</button>
       <button onClick={() => setRemovableValue('bar')}>bar</button>
       <button onClick={() => remove()}>Remove</button>
+      <br />
+      <br />
+      <div>Toggleable Value: {toggleableValue.toString()}</div>
+      <button onClick={() => setToggleableValue((old) => !old)}>toggle</button>
     </div>
   );
 };

--- a/tests/useLocalStorage.test.ts
+++ b/tests/useLocalStorage.test.ts
@@ -150,6 +150,23 @@ describe(useLocalStorage, () => {
     expect(value!.fizz).toEqual('buzz');
   });
 
+  it('sets localStorage from the function updater with latest state', () => {
+    const { result, rerender } = renderHook(() => useLocalStorage('foo', false));
+
+    const [foo, setFoo] = result.current;
+    act(() => setFoo((state) => !state));
+    rerender();
+
+    const [value] = result.current;
+    expect(value).toEqual(!foo);
+
+    act(() => setFoo((state) => !state));
+    rerender();
+
+    const [secondValue] = result.current;
+    expect(secondValue).toEqual(foo);
+  });
+
   it('rejects nullish or undefined keys', () => {
     const { result } = renderHook(() => useLocalStorage(null as any));
     try {


### PR DESCRIPTION
# Description

Fixes #1379 

Using `useLocalStorage`'s `setState` function with updater function, state passed to callback is stale (always `initialValue`). I would expects it to work like the way `useState`'s updater works. 

For instance below fails to correctly toggle state after first run:

```
const [state, setState] = useLocalStorage('foo', false);
const toggleState = setState(old => !old);
```

This pr fixes this by passing state to updater using `useLatest`-hook. 

This might affect some developers.

## Type of change
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).
