### PR TITLE
fix: fixes createBreakpoint useEffect hook always called on render

### DIFF
--- a/src/createBreakpoint.ts
+++ b/src/createBreakpoint.ts
@@ -14,10 +14,12 @@ const createBreakpoint = (
     return () => {
       window.removeEventListener('resize', setSideScreen);
     };
-  });
+  }, []);
+
   const sortedBreakpoints = useMemo(() => Object.entries(breakpoints).sort((a, b) => (a[1] >= b[1] ? 1 : -1)), [
     breakpoints,
   ]);
+
   const result = sortedBreakpoints.reduce((acc, [name, width]) => {
     if (screen >= width) {
       return name;
@@ -25,6 +27,7 @@ const createBreakpoint = (
       return acc;
     }
   }, sortedBreakpoints[0][0]);
+
   return result;
 };
 


### PR DESCRIPTION
# Description

`useEffect` hook on `createBreakpoints` is called on each render because `useEffect` is called without second parameter (dependencies). It should be called once on component mount.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
