### PR TITLE
fix: useMountedState should not change state on componentDidUpdate lifecycle

### DIFF
--- a/src/useMountedState.ts
+++ b/src/useMountedState.ts
@@ -10,7 +10,7 @@ export default function useMountedState(): () => boolean {
     return () => {
       mountedRef.current = false;
     };
-  });
+  }, []);
 
   return get;
 }


### PR DESCRIPTION
useEffect when deps is not provided, It will be executed in the three life cycles of componentDidMount, componentDidUpdate, componentWillUnmount.

useMountedState should change state only in componentDidMount, componentWillUnmount.