### PR TITLE
feat: add useBodySize hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 
 - [**Sensors**](./docs/Sensors.md)
   - [`useBattery`](./docs/useBattery.md) &mdash; tracks device battery state. [![][img-demo]](https://codesandbox.io/s/qlvn662zww)
+  - [`useBodySize`](./docs/useBodySize.md) &mdash; tracks `body` dimensions.
   - [`useGeolocation`](./docs/useGeolocation.md) &mdash; tracks geo location state of user's device. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/sensors-usegeolocation--demo)
   - [`useHover` and `useHoverDirty`](./docs/useHover.md) &mdash; tracks mouse hover state of some element. [![][img-demo]](https://codesandbox.io/s/zpn583rvx)
   - [`useHash`](./docs/useHash.md) &mdash; tracks location hash value. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/sensors-usehash--demo)

--- a/docs/useBodySize.md
+++ b/docs/useBodySize.md
@@ -1,0 +1,31 @@
+# `useBodySize`
+
+React sensor hook that tracks dimensions of HTML body using the [Resize Observer API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver).
+
+## Usage
+
+```jsx
+import { useBodySize } from 'react-use';
+
+const Demo = () => {
+  const { width, height } = useBodySize();
+
+  return (
+    <div>
+      <div>width: {width}</div>
+      <div>height: {height}</div>
+    </div>
+  );
+};
+```
+
+Consider installing [`resize-observer-polyfill`][resize-observer-polyfill] to support legacy browsers. 
+
+```js
+if (!window.ResizeObserver) {
+  window.ResizeObserver = (await import('resize-observer-polyfill')).default;
+}
+```
+
+[resize-observer]: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
+[resize-observer-polyfill]: https://www.npmjs.com/package/resize-observer-polyfill

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { default as useAsyncRetry } from './useAsyncRetry';
 export { default as useAudio } from './useAudio';
 export { default as useBattery } from './useBattery';
 export { default as useBeforeUnload } from './useBeforeUnload';
+export { default as useBodySize } from './useBodySize';
 export { default as useBoolean } from './useBoolean';
 export { default as useClickAway } from './useClickAway';
 export { default as useCookie } from './useCookie';

--- a/src/useBodySize.ts
+++ b/src/useBodySize.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
+import useRafState from './useRafState';
+import { isClient } from './util';
+
+const useBodySize = (initialWidth = Infinity, initialHeight = Infinity) => {
+  const [state, setState] = useRafState<{ width: number; height: number }>({
+    width: isClient ? document.body.clientWidth : initialWidth,
+    height: isClient ? document.body.clientHeight : initialHeight,
+  });
+
+  const observer = useMemo(
+    () =>
+      new (window as any).ResizeObserver((entries) => {
+        if (entries[0]) {
+          const { width, height } = entries[0].contentRect;
+          setState({ width, height });
+        }
+      }),
+    []
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    if (!isClient) return;
+    observer.observe(document.body);
+    return () => {
+      observer.disconnect();
+    };
+  }, [document.body]);
+
+  return state;
+};
+
+export default useBodySize;

--- a/stories/useBodySize.story.tsx
+++ b/stories/useBodySize.story.tsx
@@ -1,0 +1,24 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useBodySize } from '../src';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const { width, height } = useBodySize();
+
+  const exampleText = 'Tristique senectus et netus et malesuada. Ultricies mi quis hendrerit dolor magna eget est lorem. Sapien eget mi proin sed libero enim sed faucibus. Duis ultricies lacus sed turpis tincidunt id aliquet risus. Turpis tincidunt id aliquet risus. Eu tincidunt tortor aliquam nulla. Eu augue ut lectus arcu bibendum at varius vel. Facilisis sed odio morbi quis commodo odio aenean sed adipiscing. Morbi leo urna molestie at elementum eu facilisis sed odio. Et ultrices neque ornare aenean euismod elementum nisi. In ante metus dictum at. Adipiscing elit ut aliquam purus sit amet luctus venenatis. Laoreet non curabitur gravida arcu ac tortor dignissim convallis. A erat nam at lectus urna duis convallis convallis. Euismod lacinia at quis risus sed vulputate odio ut. Ultrices sagittis orci a scelerisque purus semper. Lectus nulla at volutpat diam ut. Egestas fringilla phasellus faucibus scelerisque.'
+
+  return (
+    <div>
+      <div>width: {width}</div>
+      <div>height: {height}</div>
+      <div>
+        <textarea rows={10} cols={45} defaultValue={exampleText}/>
+      </div>
+    </div>
+  );
+};
+
+storiesOf('Sensors|useBodySize', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useBodySize.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useBodySize.test.tsx
+++ b/tests/useBodySize.test.tsx
@@ -1,0 +1,42 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { replaceRaf } from 'raf-stub';
+import useBodySize from '../src/useBodySize';
+import { isClient } from '../src/util';
+
+declare var requestAnimationFrame: {
+  reset: () => void;
+  step: (steps?: number, duration?: number) => void;
+};
+
+describe('useBodySize', () => {
+  beforeAll(() => {
+    replaceRaf();
+  });
+
+  afterEach(() => {
+    requestAnimationFrame.reset();
+  });
+
+  it('should be defined', () => {
+    expect(useBodySize).toBeDefined();
+  });
+
+  function getHook(...args) {
+    return renderHook(() => useBodySize(...args));
+  }
+
+  it('should return current body dimensions', () => {
+    const hook = getHook();
+
+    expect(typeof hook.result.current).toBe('object');
+    expect(typeof hook.result.current.height).toBe('number');
+    expect(typeof hook.result.current.width).toBe('number');
+  });
+
+  it('should use passed parameters as initial values in case of non-browser use', () => {
+    const hook = getHook(1, 1);
+
+    expect(hook.result.current.height).toBe(isClient ? document.body.clientHeight : 1);
+    expect(hook.result.current.width).toBe(isClient ? document.body.clientWidth : 1);
+  });
+});


### PR DESCRIPTION
# Description

A new sensor hook _useBodySize_ added. It has various use-cases, e.g. when a whole page width and/or height are needed within Components. Personally I used it for a "smart" scroll-up button, which has a full stop on a certain point of the page.

## Type of change

- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
