### PR TITLE
feat: useCookie: allow `options` to be passed to deleteCookie

### DIFF
--- a/src/useCookie.ts
+++ b/src/useCookie.ts
@@ -14,10 +14,13 @@ const useCookie = (
     [cookieName]
   );
 
-  const deleteCookie = useCallback(() => {
-    Cookies.remove(cookieName);
-    setValue(null);
-  }, [cookieName]);
+  const deleteCookie = useCallback(
+    (options?: Cookies.CookieAttributes) => {
+      Cookies.remove(cookieName, options);
+      setValue(null);
+    },
+    [cookieName]
+  );
 
   return [value, updateCookie, deleteCookie];
 };

--- a/tests/useCookie.test.tsx
+++ b/tests/useCookie.test.tsx
@@ -60,7 +60,7 @@ it('should delete the cookie on call to deleteCookie', () => {
 
   expect(result.current[0]).toBeNull();
   expect(spy).toHaveBeenCalledTimes(1);
-  expect(spy).toHaveBeenLastCalledWith(cookieName);
+  expect(spy).toHaveBeenLastCalledWith(cookieName, undefined);
 
   // cleanup
   spy.mockRestore();


### PR DESCRIPTION
# Description

This PR allows `options` to be passed to the `deleteCookie` function of the `useCookie` hook.

This is necessary because cookies created with `options` need to be deleted with the same options.

See https://github.com/streamich/react-use/issues/1518 for more info.

closes #1518 

## Type of change

- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).
