### PR TITLE
fix: useAsync. Fixed loading not immediately set to true when deps change

### DIFF
--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -1,4 +1,4 @@
-import { DependencyList, useEffect } from 'react';
+import { DependencyList, useEffect, useMemo, useRef } from 'react';
 import useAsyncFn from './useAsyncFn';
 import { FnReturningPromise } from './util';
 
@@ -8,10 +8,26 @@ export default function useAsync<T extends FnReturningPromise>(fn: T, deps: Depe
   const [state, callback] = useAsyncFn(fn, deps, {
     loading: true,
   });
+  // Keep track of the deps for which the current output is based on
+  const refDepsLoading = useRef<DependencyList>([]);
 
   useEffect(() => {
+    // we started loading for the new set of dependencies
+    refDepsLoading.current = deps;
     callback();
-  }, [callback]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, callback]);
 
-  return state;
+  return useMemo(() => {
+    const allDependenciesEqual = deps.every((dep, i) => {
+      return refDepsLoading.current[i] === dep;
+    });
+
+    return {
+      ...state,
+      // loading should be true when there is a mismatch between the given deps, and the deps we were last loading
+      loading: state.loading || !allDependenciesEqual,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, state]);
 }


### PR DESCRIPTION
# Description
Fixes #1528 

Not happy with the implementation for this fix, but not seeing a good way to improve. 

I don't think there is any method of applying all dependencies to a useMemo while keeping jslint happy. So this uses `eslint-disable-next-line` twice.

According to the react docs we can't rely on useMemo for side effects, so we need to manually keep track of the dependencies and compare.

The hook testing method of react-testing-library does not allow (I think) to test the state between calling the hook and running the useEffect callback, so we need to use it's component testing helper functions instead.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->

# future scope
In the future this slight change in behaviour could also reduce the number of hook renders on any change from 3 to 2. But this would require not reusing the current `useAsyncFn` implementation.