### PR TITLE
docs: fix React hook in useTimeoutFn, fix typos

### DIFF
--- a/docs/useTimeoutFn.md
+++ b/docs/useTimeoutFn.md
@@ -1,8 +1,8 @@
 # `useTimeoutFn`
 
-Calls given function after specified amount of milliseconds.
+Calls a given function after a specified amount of milliseconds.
 
-Several thing about it's work:
+Several thing about its work:
 - does not re-render component;
 - automatically cancel timeout on cancel;
 - automatically reset timeout on delay change;
@@ -23,7 +23,7 @@ const Demo = () => {
   }
 
   const [isReady, cancel, reset] = useTimeoutFn(fn, 5000);
-  const cancelButtonClick = useCallback(() => {
+  const cancelButtonClick = React.useCallback(() => {
     if (isReady() === false) {
       cancel();
       setState(`cancelled`);


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
The documentation example for `useTimeoutFn` uses `useCallback` but this isn't in scope directly - the latter function was imported under the `React` object. This updates the documentation example accordingly to use it as `React.useCallback`. Several minor typo fixes in the preceding text in the example documentation are included as well at the same time.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
