### PR TITLE
docs: add missing import to useInterval example

### DIFF
--- a/docs/useInterval.md
+++ b/docs/useInterval.md
@@ -6,7 +6,7 @@ A declarative interval hook based on [Dan Abramov's article on overreacted.io](h
 
 ```jsx
 import * as React from 'react';
-import {useInterval} from 'react-use';
+import {useInterval, useBoolean} from 'react-use';
 
 const Demo = () => {
   const [count, setCount] = React.useState(0);


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
Add missing import of `useBoolean` to `useInterval` example in documentation

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
