### PR TITLE
add useRafEffect hook

### DIFF
--- a/docs/useRaf.md
+++ b/docs/useRaf.md
@@ -3,6 +3,7 @@
 React animation hook that forces component to re-render on each `requestAnimationFrame`,
 returns percentage of time elapsed.
 
+See `useRafEffect` for a comparison of the different `rAF` hooks.
 
 ## Usage
 

--- a/docs/useRafEffect.md
+++ b/docs/useRafEffect.md
@@ -1,0 +1,53 @@
+# `useRafEffect`
+
+React effect hook that runs inside a `window.requestAnimationFrame()` call. The signature and behavior is exactly the same as the `useEffect` hook.
+
+The [`DOMHighResTimeStamp`](https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp) from `window.requestAnimationFrame()` is forwarded
+as an argument to the provided callback.
+
+## Differences from other `rAF` hooks
+
+Animations may either be triggered by events/state changes, or started automatically.
+
+If you want your animations to be triggred by state or data changes, consider `useRafEffect` and `useRafState`. This will trigger a single animation frame for each effect or state event.
+
+- `useRafEffect` is best for changes from props, context, and hooks like `useMemo`. It pairs well with hooks for state management (Redux) or data fetching (SWR). For example, `useRafEffect` can render fetched data to a `<canvas>`.
+- `useRafState` is best when that same component owns the state. For example, a browser event like `mousemove` on an `<svg>` may use `useRafState` and trigger other DOM changes (like element positioning or style). This wraps a regular `setState` in a `rAF`, with added intelligence.
+
+If you want your animation start automatically or run continuously automatically, consider `useRaf` and `useRafLoop`. These hooks continuously re-render the component on each `rAF` tick, ideally at ~60fps. This is the opposite pattern from the above hooks; here the hook starts and stops the animation.
+
+- `useRaf` runs for a specific, limited time period. For example, it can run an animation on for 5 seconds starting 1 second after mount.
+- `useRafLoop` runs forever with start/stop callbacks, and a flag to start on mount.
+
+## Usage
+
+```jsx
+import React from 'react';
+import { useRefEffect } from 'react-use';
+
+const Demo = ({ color }) => {
+  const ref = React.useRef(); // for canvas demo; not required
+
+  useRafEffect(
+    (time) => {
+      console.log('timestamp from window.requestAnimationFrame() start is ' + time);
+      if (ref.current) {
+        const canvasContext = ref.current.getContext('2d');
+        canvasContext.clearRect(0, 0, 100, 100);
+        canvasContext.fillStyle = '#f0f';
+        canvasContext.fillRect(50, 50, 100, 100);
+        canvasContext.fillStyle = '#0f0';
+        canvasContext.fillRect(0, 0, 50, 50);
+      }
+      return (time) => {
+        console.log('timestamp from window.requestAnimationFrame() cleanup is ' + time);
+        // *OPTIONAL*
+        // do something on unmount
+      };
+    },
+    [color]
+  ); // you can include deps array if necessary
+
+  return <canvas ref={ref} width={100} height={100}></canvas>;
+};
+```

--- a/docs/useRafLoop.md
+++ b/docs/useRafLoop.md
@@ -5,6 +5,8 @@ Loop stops automatically on component unmount.
 
 Additionally hook provides methods to start/stop loop and check current state.
 
+See `useRafEffect` for a comparison of the different `rAF` hooks.
+
 ## Usage
 
 ```jsx

--- a/docs/useRafState.md
+++ b/docs/useRafState.md
@@ -2,6 +2,8 @@
 
 React state hook that only updates state in the callback of [`requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame).
 
+See `useRafEffect` for a comparison of the different `rAF` hooks.
+
 ## Usage
 
 ```jsx

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ export { default as usePreviousDistinct } from './usePreviousDistinct';
 export { default as usePromise } from './usePromise';
 export { default as useQueue } from './useQueue';
 export { default as useRaf } from './useRaf';
+export { default as useRafEffect } from './useRafEffect';
 export { default as useRafLoop } from './useRafLoop';
 export { default as useRafState } from './useRafState';
 export { default as useSearchParam } from './useSearchParam';

--- a/src/useRafEffect.ts
+++ b/src/useRafEffect.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+type EffectCallbackWithTimestamp = (time: number) => (time: number) => void | undefined | void;
+
+const useRafEffect = (effectFn: EffectCallbackWithTimestamp, deps: any[]) => {
+  useEffect(() => {
+    let cleanupFn;
+    window.requestAnimationFrame((time) => {
+      cleanupFn = effectFn(time);
+    });
+    return () => {
+      if (cleanupFn) {
+        window.requestAnimationFrame((time) => {
+          cleanupFn(time);
+        });
+      }
+    };
+  }, deps);
+};
+
+export default useRafEffect;

--- a/stories/useRafEffect.story.tsx
+++ b/stories/useRafEffect.story.tsx
@@ -1,0 +1,90 @@
+import React, { useRef, useState } from 'react';
+import { storiesOf } from '@storybook/react';
+import ShowDocs from './util/ShowDocs';
+import { useRafEffect } from '../src';
+
+const Demo = () => {
+  const canvasRef = useRef();
+
+  const [color1, setColor1] = useState('#f0f');
+  const [color2, setColor2] = useState('#0f0');
+  const [alpha, setAlpha] = useState('1');
+
+  useRafEffect(
+    (time) => {
+      console.log('timestamp from window.requestAnimationFrame() start is ' + time);
+
+      // Everything below is general canvas stuff and not specific to the hook
+      const canvasContext = canvasRef.current.getContext('2d');
+
+      // Canvas by default renders at 1x pixel ratio (blurry on retina 2x)
+      const pixelRatio = window.devicePixelRatio || 1;
+      canvasRef.current.setAttribute('width', 600 * pixelRatio);
+      canvasRef.current.setAttribute('height', 600 * pixelRatio);
+      canvasContext.scale(pixelRatio, pixelRatio);
+      canvasRef.current.style.width = '600px';
+      canvasRef.current.style.height = '600px';
+
+      canvasContext.clearRect(0, 0, 600, 600);
+
+      canvasContext.globalAlpha = alpha;
+
+      canvasContext.fillStyle = color1;
+      canvasContext.fillRect(300, 300, 300, 300);
+      canvasContext.fillStyle = color2;
+      canvasContext.fillRect(0, 0, 300, 300);
+      canvasContext.fillStyle = '#000';
+      canvasContext.font = '11px Helvetica';
+      canvasContext.fillText('useRafEffect time argument: ' + time, 0, 590);
+
+      return (time) => {
+        // This is optional
+        console.log('timestamp from window.requestAnimationFrame() cleanup is ' + time);
+      };
+    },
+    [color1, color2, alpha]
+  );
+
+  return (
+    <div>
+      <div style={{ marginBottom: '20px' }}>
+        <label htmlFor="color1">First color</label>
+        <input
+          id="color1"
+          value={color1}
+          onChange={(e) => {
+            setColor1(e.target.value);
+          }}
+          style={{ marginLeft: '10px', marginRight: '45px' }}
+        />
+        <label htmlFor="color2">Second color</label>
+        <input
+          id="color2"
+          value={color2}
+          onChange={(e) => {
+            setColor2(e.target.value);
+          }}
+          style={{ marginLeft: '10px', marginRight: '45px' }}
+        />
+        <label htmlFor="alpha">Alpha</label>
+        <input
+          id="alpha"
+          type="range"
+          min="0"
+          max="1"
+          step="0.005"
+          value={alpha}
+          onChange={(e) => {
+            setAlpha(e.target.value);
+          }}
+          style={{ marginLeft: '10px' }}
+        />
+      </div>
+      <canvas ref={canvasRef} width={600} height={600}></canvas>
+    </div>
+  );
+};
+
+storiesOf('Animation|useRafEffect', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useRafEffect.md')} />)
+  .add('Demo', () => <Demo />);


### PR DESCRIPTION
# Description

This PR adds a hook for `useRafEffect`. This wraps a standard `useEffect` calback in a `window.requestAnimationFrame`. This is idea for things like `<canvas>` where the UI work is imperative and not tied to JSX output. 

This also helps with animations triggered by props/context/hooks, as that won't easily fit within the existing `useRafState`, and it's a single event so it doesn't fit `useRaf` / `useRafLoop`.

I added some explanation of the four different `rAF` hooks to the docs. (I was confused, tbh.) I am not sure where this belongs and am very open to feedback.

I'm opening this as a draft PR and will revisit soon for unit tests and remaining tasks.

![2020-10-02 12 51 35](https://user-images.githubusercontent.com/310323/94964451-b2789680-04ae-11eb-9741-32c583bd54f5.gif)


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
