### PR TITLE
feat: add useStateDelayed hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
   - [`useRafState`](./docs/useRafState.md) &mdash; creates `setState` method which only updates after `requestAnimationFrame`. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-userafstate--demo)
   - [`useSetState`](./docs/useSetState.md) &mdash; creates `setState` method which works like `this.setState`. [![][img-demo]](https://codesandbox.io/s/n75zqn1xp0)
   - [`useStateList`](./docs/useStateList.md) &mdash; circularly iterates over an array. [![][img-demo]](https://codesandbox.io/s/bold-dewdney-pjzkd)
+  - [`useStateDelayed`]('./docs/useStateDelayed.md')  &mdash; setState that loads `initialState` when you finish loading
   - [`useToggle` and `useBoolean`](./docs/useToggle.md) &mdash; tracks state of a boolean. [![][img-demo]](https://codesandbox.io/s/focused-sammet-brw2d)
   - [`useCounter` and `useNumber`](./docs/useCounter.md) &mdash; tracks state of a number. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usecounter--demo)
   - [`useList`](./docs/useList.md) ~and [`useUpsert`](./docs/useUpsert.md)~ &mdash; tracks state of an array. [![][img-demo]](https://codesandbox.io/s/wonderful-mahavira-1sm0w)

--- a/docs/useStateDelayed.md
+++ b/docs/useStateDelayed.md
@@ -1,0 +1,41 @@
+# `useStateDelayed`
+
+React state hook that loads initialState once when some value was updated and in the meantime returns defaultState.
+Usefull for displaying temporary value and updating it when async request finishes with data that is used for initialState.
+
+## Usage
+
+```jsx
+import {useState, useEffect} from 'react';
+import {useStateDelayed} from 'react-use';
+
+const Demo = () => {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setLoading(false);
+    }, 500)
+  });
+
+  const [state, setState] = useStateDelayed(getInitialState, !loading)
+
+  return null;
+
+  function getInitialState() {
+    // ...
+    return '';
+  }
+}
+```
+
+## Reference
+
+```ts
+const [state, setState] = useStateDelayed<S>(initialState: S || ( () => S ) , watchInput: Boolean, defaultState?: S || ( () => S ))
+```
+
+When `watchInput` changes to `true`, the state is updated once to `initialState`. Before that happens the `defaultState` value is returned.
+
+- **state** - current state value
+- **setState** - update state value (note: if you manually update the state before `watchInput` changes to `true` the `initialState` will be ignored)

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export { default as useSpeech } from './useSpeech';
 // not exported because of peer dependency
 // export { default as useSpring } from './useSpring';
 export { default as useStartTyping } from './useStartTyping';
+export { default as useStateDelayed } from './useStateDelayed';
 export { useStateWithHistory } from './useStateWithHistory';
 export { default as useStateList } from './useStateList';
 export { default as useThrottle } from './useThrottle';

--- a/src/useStateDelayed.ts
+++ b/src/useStateDelayed.ts
@@ -1,0 +1,27 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+
+function useStateDelayed<S>(
+  initialState: S | (() => S),
+  watchInput: Boolean,
+  defaultState?: S | (() => S)
+): [S | undefined, Dispatch<SetStateAction<S | undefined>>] {
+  const [loaded, setLoaded] = useState(false);
+  const [state, setState] = useState(defaultState);
+
+  useEffect(() => {
+    if (!loaded && watchInput) {
+      setState(initialState);
+      setLoaded(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watchInput, loaded]);
+
+  function updateState(value) {
+    setState(value);
+    setLoaded(true);
+  }
+
+  return [state, updateState];
+}
+
+export default useStateDelayed;

--- a/src/useStateDelayed.ts
+++ b/src/useStateDelayed.ts
@@ -16,8 +16,9 @@ function useStateDelayed<S>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [watchInput, loaded]);
 
-  function updateState(value) {
-    setState(value);
+  function updateState(change) {
+    // update state manunally, don't wait for watchInput to change
+    setState(change);
     setLoaded(true);
   }
 

--- a/stories/useStateDelayed.story.tsx
+++ b/stories/useStateDelayed.story.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from "react";
+import { storiesOf } from "@storybook/react";
+import ShowDocs from './util/ShowDocs';
+import useStateDelayed from "../src/useStateDelayed";
+
+const EXAMPLE_BRANCHES_LIST = [
+  'main',
+  'stage',
+  'dev'
+];
+
+const Demo = () => {
+  const [branches, setBranches] = useState([]);
+  const [selectedBranch, setSelectedBranch] = useStateDelayed(() => {
+    // find default branch
+    const commonBranch = branches.find(branch => branch === 'master' || branch === 'main');
+    if (commonBranch) return commonBranch;
+    return branches[0];
+  }, !!branches.length, 'Loading...');
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setBranches(EXAMPLE_BRANCHES_LIST)
+    }, 1000);
+
+    return () => {
+      handle && clearTimeout(handle);
+    }
+  }, []);
+
+  return (
+    <div>
+      <p>Selected branch: {selectedBranch}</p>
+      <select onChange={e => setSelectedBranch(e.target.value)}>
+        {branches.map(branch => <option key={branch} value={branch}>{branch}</option>)}
+      </select>
+    </div>
+  )
+}
+
+storiesOf('State|useStateDelayed', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useStateDelayed.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useStateDelayed.test.ts
+++ b/tests/useStateDelayed.test.ts
@@ -1,0 +1,70 @@
+import { renderHook, RenderHookResult } from '@testing-library/react-hooks';
+import useStateDelayed from '../src/useStateDelayed';
+
+const DEFAULT_STATE = 'default state';
+const INITIAL_STATE = 'initial state';
+
+interface HookInitialValues {
+  initialState: any;
+  watchInput: Boolean;
+  defaultState: any;
+}
+
+function getHook(initialValues?: HookInitialValues): RenderHookResult<HookInitialValues, [any, Function]> {
+  return renderHook(
+    ({ initialState, watchInput, defaultState }) => useStateDelayed(initialState, watchInput, defaultState),
+    {
+      initialProps: {
+        initialState: initialValues?.initialState ?? INITIAL_STATE,
+        watchInput: initialValues?.watchInput ?? false,
+        defaultState: initialValues?.defaultState ?? DEFAULT_STATE,
+      },
+    }
+  );
+}
+
+describe('useStateDelayed', () => {
+  it('should be defined', () => {
+    expect(useStateDelayed).toBeDefined();
+  });
+
+  it('should return an array of [state, setState]', () => {
+    const { result } = getHook();
+
+    expect(result.current).toStrictEqual([expect.anything(), expect.any(Function)]);
+  });
+
+  it('should return the defaultState on init when watchInput is set to false', () => {
+    const { result } = getHook();
+
+    expect(result.current).toStrictEqual([DEFAULT_STATE, expect.any(Function)]);
+  });
+
+  it('should update the state with initialState when watchInput has changed to true', () => {
+    const { result, rerender } = getHook();
+    expect(result.current[0]).toStrictEqual(DEFAULT_STATE);
+
+    rerender({ watchInput: true, defaultState: DEFAULT_STATE, initialState: INITIAL_STATE });
+
+    expect(result.current[0]).toStrictEqual(INITIAL_STATE);
+  });
+
+  it('should update state with initialState only once', () => {
+    const { result, rerender } = getHook();
+
+    expect(result.current[0]).toStrictEqual(DEFAULT_STATE);
+    rerender({ watchInput: true, initialState: INITIAL_STATE, defaultState: DEFAULT_STATE });
+    rerender({ watchInput: false, initialState: 'other initial state', defaultState: DEFAULT_STATE });
+    rerender({ watchInput: true, initialState: 'other initial state', defaultState: DEFAULT_STATE });
+    expect(result.current[0]).toStrictEqual(INITIAL_STATE);
+  });
+
+  it('should ignore changes to defaultState', () => {
+    const { result, rerender } = getHook();
+    const [state] = result.current;
+
+    rerender({ watchInput: true, initialState: INITIAL_STATE, defaultState: DEFAULT_STATE });
+    rerender({ watchInput: true, initialState: INITIAL_STATE, defaultState: 'other default state' });
+    expect(state).toStrictEqual(DEFAULT_STATE);
+  });
+});

--- a/tests/useStateDelayed.test.ts
+++ b/tests/useStateDelayed.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, RenderHookResult } from '@testing-library/react-hooks';
+import { act, renderHook, RenderHookResult } from '@testing-library/react-hooks';
 import useStateDelayed from '../src/useStateDelayed';
 
 const DEFAULT_STATE = 'default state';
@@ -66,5 +66,18 @@ describe('useStateDelayed', () => {
     rerender({ watchInput: true, initialState: INITIAL_STATE, defaultState: DEFAULT_STATE });
     rerender({ watchInput: true, initialState: INITIAL_STATE, defaultState: 'other default state' });
     expect(state).toStrictEqual(DEFAULT_STATE);
+  });
+
+  it('should ignore watchInput chages when state was updated manually by setState', () => {
+    const { result, rerender } = getHook();
+
+    const NEW_SATTE = 'manual state change';
+
+    act(() => {
+      result.current[1](NEW_SATTE);
+    });
+    rerender({ watchInput: true, initialState: INITIAL_STATE, defaultState: DEFAULT_STATE });
+
+    expect(result.current[0]).toStrictEqual(NEW_SATTE);
   });
 });


### PR DESCRIPTION
# Description

This PR adds a new `useStateDelayed` hook that allows delaying loading initial state until a condition is met.

I've created this hook to solve the problem of a state that is dependant on async request (ex. fetching default value, user preferences).

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
