### PR TITLE
docs: Fix useAsyncFn example to avoid error

### DIFF
--- a/docs/useAsyncFn.md
+++ b/docs/useAsyncFn.md
@@ -9,7 +9,7 @@ function that returns a promise. The state is of the same shape as `useAsync`.
 import {useAsyncFn} from 'react-use';
 
 const Demo = ({url}) => {
-  const [state, fetch] = useAsyncFn(async () => {
+  const [state, doFetch] = useAsyncFn(async () => {
     const response = await fetch(url);
     const result = await response.text();
     return result
@@ -23,7 +23,7 @@ const Demo = ({url}) => {
           ? <div>Error: {state.error.message}</div>
           : <div>Value: {state.value}</div>
       }
-      <button onClick={() => fetch()}>Start loading</button>
+      <button onClick={() => doFetch()}>Start loading</button>
     </div>
   );
 };


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
When trying to test the `useAsyncFn` example, an error occurs: `Error: Maximum call stack size exceeded`.

Reproduction link: https://codesandbox.io/s/eager-christian-2q5iu?file=/src/App.js (click on _Start loading_ to see the error).

Fix : rename `fetch` to avoid conflict with `window.fetch`.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
