### PR TITLE
fix: add generic parameter to createHTMLMediaHook. no typecheck problem with ref anymore

### DIFF
--- a/src/factory/createHTMLMediaHook.ts
+++ b/src/factory/createHTMLMediaHook.ts
@@ -27,25 +27,20 @@ export interface HTMLMediaControls {
   seek: (time: number) => void;
 }
 
-type createHTMLMediaHookReturn = [
-  React.ReactElement<HTMLMediaProps>,
-  HTMLMediaState,
-  HTMLMediaControls,
-  { current: HTMLAudioElement | null }
-];
+type MediaPropsWithRef<T> = HTMLMediaProps & { ref?: React.MutableRefObject<T | null> };
 
-export default function createHTMLMediaHook(tag: 'audio' | 'video') {
+export default function createHTMLMediaHook<T extends HTMLAudioElement | HTMLVideoElement>(tag: 'audio' | 'video') {
   return (
     elOrProps: HTMLMediaProps | React.ReactElement<HTMLMediaProps>
-  ): createHTMLMediaHookReturn => {
-    let element: React.ReactElement<any> | undefined;
-    let props: HTMLMediaProps;
+) => {
+  let element: React.ReactElement<MediaPropsWithRef<T>> | undefined;
+  let props: MediaPropsWithRef<T>;
 
     if (React.isValidElement(elOrProps)) {
       element = elOrProps;
       props = element.props;
     } else {
-      props = elOrProps as HTMLMediaProps;
+      props = elOrProps;
     }
 
     const [state, setState] = useSetState<HTMLMediaState>({
@@ -56,7 +51,7 @@ export default function createHTMLMediaHook(tag: 'audio' | 'video') {
       muted: false,
       volume: 1,
     });
-    const ref = useRef<HTMLAudioElement | null>(null);
+		const ref = useRef<T | null>(null);
 
     const wrapEvent = (userEvent, proxyEvent?) => {
       return (event) => {
@@ -234,6 +229,6 @@ export default function createHTMLMediaHook(tag: 'audio' | 'video') {
       }
     }, [props.src]);
 
-    return [element, state, controls, ref];
-  };
-}
+		return [element, state, controls, ref] as const;
+  }
+};

--- a/src/useAudio.ts
+++ b/src/useAudio.ts
@@ -1,5 +1,4 @@
 import createHTMLMediaHook from './factory/createHTMLMediaHook';
 
-const useAudio = createHTMLMediaHook('audio');
-
+const useAudio = createHTMLMediaHook<HTMLAudioElement>('audio');
 export default useAudio;

--- a/src/useVideo.ts
+++ b/src/useVideo.ts
@@ -1,5 +1,5 @@
 import createHTMLMediaHook from './factory/createHTMLMediaHook';
 
-const useVideo = createHTMLMediaHook('video');
+const useVideo = createHTMLMediaHook<HTMLVideoElement>('video');
 
 export default useVideo;


### PR DESCRIPTION
# Description


this commit fix #969 

useAudio and useVideo hooks are using createHTMLMediaHook.

I added a generic parameter to createHTMLMediaHook

I also enhanced typing of some other variables inside createHTMLMediaHook.

Now we can use `as const` in return and there is no need to createHTMLMediaHookReturn.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
