### PR TITLE
feat(createGlobalState): improve type inference

### DIFF
--- a/src/createGlobalState.ts
+++ b/src/createGlobalState.ts
@@ -2,7 +2,9 @@ import { useState } from 'react';
 import useEffectOnce from './useEffectOnce';
 import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 
-export function createGlobalState<S = any>(initialState?: S) {
+export function createGlobalState<S = any>(): () => [S | undefined, (state: S) => void]
+export function createGlobalState<S = any>(initialState: S): () => [S, (state: S) => void]
+export function createGlobalState<S = any>(initialState?: S): () => [S | undefined, (state: S) => void] {
   const store: { state: S | undefined; setState: (state: S) => void; setters: any[] } = {
     state: initialState,
     setState(state: S) {
@@ -12,7 +14,7 @@ export function createGlobalState<S = any>(initialState?: S) {
     setters: [],
   };
 
-  return (): [S | undefined, (state: S) => void] => {
+  return () => {
     const [globalState, stateSetter] = useState<S | undefined>(store.state);
 
     useEffectOnce(() => () => {


### PR DESCRIPTION
# Description

Provide overloads for case when initialState were provided, so currentValue is always type of `S`.
Solves `Object is possibly 'undefined'.(2532)` error while accessing hook value.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).
