### PR TITLE
fix(useStateWithHistory): support callback style setState

### DIFF
--- a/src/useStateWithHistory.ts
+++ b/src/useStateWithHistory.ts
@@ -57,7 +57,7 @@ export function useStateWithHistory<S, I extends S>(
   const setState = useCallback(
     (newState: ResolvableHookState<S>): void => {
       innerSetState((currentState) => {
-        newState = resolveHookState(newState);
+        newState = resolveHookState(newState, currentState);
 
         // is state has changed
         if (newState !== currentState) {

--- a/tests/useStateWithHistory.test.ts
+++ b/tests/useStateWithHistory.test.ts
@@ -52,9 +52,9 @@ describe('useStateWithHistory', () => {
     });
     expect(hook.result.current[0][0]).toBe(321);
     act(() => {
-      hook.result.current[0][1](() => 111);
+      hook.result.current[0][1]((current) => (current ?? 0) + 111);
     });
-    expect(hook.result.current[0][0]).toBe(111);
+    expect(hook.result.current[0][0]).toBe(432);
   });
 
   it('should receive initial history', () => {


### PR DESCRIPTION
# Description

Make `useStateWithHistory` support the callback style set state, e.g. `setState(current => current + 1)`. 

Currently, it's typed as if it does support it, but the `current` parameter is always `undefined`.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->

Fixes #1916 