### PR TITLE
feat: add clear method to useSet hook

### DIFF
--- a/docs/useSet.md
+++ b/docs/useSet.md
@@ -5,10 +5,10 @@ React state hook that tracks a [Set](https://developer.mozilla.org/en-US/docs/We
 ## Usage
 
 ```jsx
-import {useSet} from 'react-use';
+import { useSet } from 'react-use';
 
 const Demo = () => {
-  const [set, { add, has, remove, toggle, reset }] = useSet(new Set(['hello']));
+  const [set, { add, has, remove, toggle, reset, clear }] = useSet(new Set(['hello']));
 
   return (
     <div>
@@ -18,6 +18,7 @@ const Demo = () => {
         Remove 'hello'
       </button>
       <button onClick={() => toggle('hello')}>Toggle hello</button>
+      <button onClick={() => clear()}>Clear</button>
       <pre>{JSON.stringify(Array.from(set), null, 2)}</pre>
     </div>
   );

--- a/src/useSet.ts
+++ b/src/useSet.ts
@@ -5,6 +5,7 @@ export interface StableActions<K> {
   remove: (key: K) => void;
   toggle: (key: K) => void;
   reset: () => void;
+  clear: () => void;
 }
 
 export interface Actions<K> extends StableActions<K> {
@@ -24,7 +25,7 @@ const useSet = <K>(initialSet = new Set<K>()): [Set<K>, Actions<K>] => {
           : new Set([...Array.from(prevSet), item])
       );
 
-    return { add, remove, toggle, reset: () => setSet(initialSet) };
+    return { add, remove, toggle, reset: () => setSet(initialSet), clear: () => setSet(new Set<K>()) };
   }, [setSet]);
 
   const utils = {

--- a/tests/useSet.test.ts
+++ b/tests/useSet.test.ts
@@ -14,6 +14,7 @@ it('should init set and utils', () => {
     remove: expect.any(Function),
     toggle: expect.any(Function),
     reset: expect.any(Function),
+    clear: expect.any(Function),
   });
 });
 
@@ -143,6 +144,17 @@ it('should reset to initial set provided', () => {
   });
 
   expect(result.current[0]).toEqual(new Set([1]));
+});
+
+it('should clear set to contain an empty set', () => {
+  const { result } = setUp(new Set([1]));
+  const [, utils] = result.current;
+
+  act(() => {
+    utils.clear();
+  });
+
+  expect(result.current[0]).toEqual(new Set([]));
 });
 
 it('should memoized its utils methods', () => {


### PR DESCRIPTION
# Description

Add `clear` method to `useSet` so that a user could clear the values in a set created with some initial values

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
