### PR TITLE
add useIsMorphicLayoutEffec to eslint-plugin-hooks rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,11 @@
 {
-  "extends": "react-app"
+  "extends": "react-app",
+  "rules": {
+    "react-hooks/rules-of-hooks": ["error", {
+      "additionalHooks": "(useIsomorphicLayoutEffect)"
+    }],
+    "react-hooks/exhaustive-deps": ["error", {
+      "additionalHooks": "(useIsomorphicLayoutEffect)"
+    }]
+  }
 }

--- a/docs/useIsomorphicLayoutEffect.md
+++ b/docs/useIsomorphicLayoutEffect.md
@@ -22,3 +22,17 @@ const Demo = ({value}) => {
 ```ts
 useIsomorphicLayoutEffect(effect: EffectCallback, deps?: ReadonlyArray<any> | undefined);
 ```
+
+## eslint-plugin-react-hooks
+
+If your project uses the `react-hooks/exhaustive-deps` ESLint rule, it's recommended to add `useIsomorphicLayoutEffect` to the `additionalHooks` of the rule. Example:
+
+```js
+  rules: {
+    'react-hooks/exhaustive-deps': [
+      'warn',
+      {
+        additionalHooks: '(useIsomorphicLayoutEffect)'
+      }
+    ]
+  }

--- a/src/util/resolveHookState.ts
+++ b/src/util/resolveHookState.ts
@@ -5,7 +5,7 @@ export type InitialHookState<S> = S | InitialStateSetter<S>;
 export type HookState<S> = S | StateSetter<S>;
 export type ResolvableHookState<S> = S | StateSetter<S> | InitialStateSetter<S>;
 
-export function resolveHookState<S, C extends S>(newState: InitialStateSetter<S>): S;
+export function resolveHookState<S>(newState: InitialStateSetter<S>): S;
 export function resolveHookState<S, C extends S>(newState: StateSetter<S>, currentState: C): S;
 export function resolveHookState<S, C extends S>(newState: ResolvableHookState<S>, currentState?: C): S;
 export function resolveHookState<S, C extends S>(newState: ResolvableHookState<S>, currentState?: C): S {

--- a/tests/useAsync.test.tsx
+++ b/tests/useAsync.test.tsx
@@ -147,7 +147,7 @@ describe('useAsync', () => {
         callCount = 0;
         hook = renderHook(
           ({ fn, counter }) => {
-            const callback = useCallback(() => fn(counter), [counter]);
+            const callback = useCallback(() => fn(counter), [counter, fn]);
             return useAsync<any>(callback, [callback]);
           },
           {


### PR DESCRIPTION
# Description

I fell foul of `useIsomorphicLayoutEffect` not picking up the `react-hooks/exhaustive-deps` rule and I had a stale closure which took me ages to work out what was going on.

If you add `useIsomorphicLayoutEffect` then it will work exactly the same as `useEffect` and `useLayoutEffect`

This PR adds `useIsomorphicLayoutEffect` to the `.eslintrc.json` and updates the docs to advise users to do the same:

```json
{
  "extends": "react-app",
  "rules": {
    "react-hooks/rules-of-hooks": ["error", {
      "additionalHooks": "(useIsomorphicLayoutEffect)"
    }],
    "react-hooks/exhaustive-deps": ["error", {
      "additionalHooks": "(useIsomorphicLayoutEffect)"
    }]
  }
}
```  


## Type of change

<!-- Check all relevant options. -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_

# Checklist
- [X] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [X] Perform a code self-review
- [X] Comment the code, particularly in hard-to-understand areas
- [X] Add documentation
- [X] Add hook's story at Storybook
- [X] Cover changes with tests
- [X] Ensure the test suite passes (`yarn test`)
- [X] Provide 100% tests coverage
- [X] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [X] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
