### PR TITLE
fix: #1646

### DIFF
--- a/src/useGeolocation.ts
+++ b/src/useGeolocation.ts
@@ -1,5 +1,18 @@
 import { useEffect, useState } from 'react';
 
+/**
+ * @desc Made compatible with {GeolocationPositionError} and {PositionError} cause
+ * PositionError been renamed to GeolocationPositionError in typescript 4.1.x and making
+ * own compatible interface is most easiest way to avoid errors.
+ */
+export interface IGeolocationPositionError {
+  readonly code: number;
+  readonly message: string;
+  readonly PERMISSION_DENIED: number;
+  readonly POSITION_UNAVAILABLE: number;
+  readonly TIMEOUT: number;
+}
+
 export interface GeoLocationSensorState {
   loading: boolean;
   accuracy: number | null;
@@ -10,7 +23,7 @@ export interface GeoLocationSensorState {
   longitude: number | null;
   speed: number | null;
   timestamp: number | null;
-  error?: Error | PositionError;
+  error?: Error | IGeolocationPositionError;
 }
 
 const useGeolocation = (options?: PositionOptions): GeoLocationSensorState => {
@@ -43,7 +56,7 @@ const useGeolocation = (options?: PositionOptions): GeoLocationSensorState => {
       });
     }
   };
-  const onEventError = (error: PositionError) =>
+  const onEventError = (error: IGeolocationPositionError) =>
     mounted && setState((oldState) => ({ ...oldState, loading: false, error }));
 
   useEffect(() => {


### PR DESCRIPTION
# Description

Typescript 4.1 has `PositionError` renamed to `GeolocationPositionError` and it caused errors 

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
