### PR TITLE
fix: useMeasure type definitions for SVG

### DIFF
--- a/src/useMeasure.ts
+++ b/src/useMeasure.ts
@@ -6,8 +6,8 @@ export type UseMeasureRect = Pick<
   DOMRectReadOnly,
   'x' | 'y' | 'top' | 'left' | 'right' | 'bottom' | 'height' | 'width'
 >;
-export type UseMeasureRef<E extends HTMLElement = HTMLElement> = (element: E) => void;
-export type UseMeasureResult<E extends HTMLElement = HTMLElement> = [
+export type UseMeasureRef<E extends Element = Element> = (element: E) => void;
+export type UseMeasureResult<E extends Element = Element> = [
   UseMeasureRef<E>,
   UseMeasureRect
 ];
@@ -23,7 +23,7 @@ const defaultState: UseMeasureRect = {
   right: 0,
 };
 
-function useMeasure<E extends HTMLElement = HTMLElement>(): UseMeasureResult<E> {
+function useMeasure<E extends Element = Element>(): UseMeasureResult<E> {
   const [element, ref] = useState<E | null>(null);
   const [rect, setRect] = useState<UseMeasureRect>(defaultState);
 


### PR DESCRIPTION
Re-applied the changes of @thevtm from https://github.com/streamich/react-use/pull/479 to the `useMeasure` hook, because the Resize Observer API [also works](https://github.com/WICG/resize-observer/issues/9#issuecomment-228181533) on SVG elements.

@streamich can you have a look? 