### PR TITLE
Pr/use async fn callback promise rejection propagation

### DIFF
--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -10,7 +10,9 @@ export default function useAsync<T extends FnReturningPromise>(fn: T, deps: Depe
   });
 
   useEffect(() => {
-    callback();
+    // catch an error to prevent propagating outside
+    // hook will change own internal state
+    callback().catch(() => {});
   }, [callback]);
 
   return state;

--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -50,7 +50,7 @@ export default function useAsyncFn<T extends FnReturningPromise>(
       (error) => {
         isMounted() && callId === lastCallId.current && set({ error, loading: false });
 
-        return error;
+        return Promise.reject(error);
       }
     ) as ReturnType<T>;
   }, deps);


### PR DESCRIPTION
# Description

I found an easy way to do not swallow error in `useAsyncFn` callback. This is potentially a breaking change, because the `callback` returned from hook behave differently now, but for me now it makes more sense, especially when we want to fire more side effect connect to this one (e.g. save data and if succeed move to next route).

If this breaking change can't be merged, maybe introducing a new hook with behavior described in this PR will be a way?

This fixes the issue described here https://github.com/streamich/react-use/pull/612

## Type of change

- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).