### PR TITLE
feat: Allow for basic state reducers with useGlobalState() hook

### DIFF
--- a/src/createGlobalState.ts
+++ b/src/createGlobalState.ts
@@ -2,17 +2,25 @@ import { useState } from 'react';
 import useEffectOnce from './useEffectOnce';
 import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 
+function isFunction(value: unknown): value is Function {
+  return typeof value === 'function';
+}
+
 export function createGlobalState<S = any>(initialState?: S) {
-  const store: { state: S | undefined; setState: (state: S) => void; setters: any[] } = {
+  const store: {
+    state: S | undefined;
+    setState: (state: S | ((prevState: S) => S)) => void;
+    setters: any[];
+  } = {
     state: initialState,
-    setState(state: S) {
-      store.state = state;
+    setState(state: S | ((prevState: S) => S)) {
+      store.state = isFunction(state) ? state(store.state!) : state;
       store.setters.forEach((setter) => setter(store.state));
     },
     setters: [],
   };
 
-  return (): [S | undefined, (state: S) => void] => {
+  return (): [S | undefined, (state: S | ((prevState: S) => S)) => void] => {
     const [globalState, stateSetter] = useState<S | undefined>(store.state);
 
     useEffectOnce(() => () => {

--- a/tests/createGlobalState.test.ts
+++ b/tests/createGlobalState.test.ts
@@ -17,5 +17,10 @@ describe('useGlobalState', () => {
     });
     expect(result1.current[0] === 1);
     expect(result2.current[0] === 1);
+    act(() => {
+      result1.current[1]((prevState) => prevState + 1);
+    });
+    expect(result1.current[0] === 2);
+    expect(result2.current[0] === 2);
   });
 });


### PR DESCRIPTION
# Description

Allow for basic state reducers with `useGlobalState()` hook (i.e. `(prevState: S) => S`)


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
