### PR TITLE
Add use local synced state

### DIFF
--- a/docs/useLocalSyncedState.md
+++ b/docs/useLocalSyncedState.md
@@ -1,0 +1,38 @@
+# `useLocalSyncedState`
+
+React hook that creates a state that can be synced between contexts on the same browser running on the same machine: tabs, windows, iframes can keep the value of a state synced between them.
+
+A state must have an identifier, and any other state with the same identifier will keep synced to it.
+
+It can be either a receiver: will be updated from other states but won't update others itself; sender: will update other states but won't be updated; both: will update and be updated.
+
+Underneath it uses BroadcastChannel to communicate between contexts.
+
+## Usage
+
+```tsx
+import { useLocalSyncedState } from 'react-use';
+
+const Demo = () => {
+  const [value, setValue] = useLocalSyncedState('value', 0);
+
+  return (
+    <div>
+      Value: {value}
+      <button onClick={() => setValue(value + 1)}>Increase!</button>
+    </div>
+  );
+};
+```
+
+
+## Reference
+
+```ts
+type Role = 'receiver' | 'sender' | 'both';
+useLocalSyncedState<T>(identifier: string, baseValue: T | null, role: Role): [T, (T) => void];
+```
+
+- `identifier` &mdash; unique idenifier shared between all states to be synced.
+- `baseValue` &mdash; base value to be given to the state.
+- `role` &mdash; role of this instance: receiver, will be updated from other states but won't update others itself; sender: will update other states but won't be updated; both: will update and be updated.

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,3 +114,4 @@ export { useFirstMountState } from './useFirstMountState';
 export { default as useSet } from './useSet';
 export { createGlobalState } from './createGlobalState';
 export { useHash } from './useHash';
+export { useLocalSyncedState } from './useLocalSyncedState';

--- a/src/useLocalSyncedState.ts
+++ b/src/useLocalSyncedState.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react';
+
+const ROLES = ['receiver', 'sender', 'both'] as const;
+type Roles = typeof ROLES[number];
+
+type DataCb<T = any> = (d: T) => void;
+
+type Source = {
+  onData: <T = any>(key: string, cb: DataCb<T>) => void;
+  sendData: <T = any>(key: string, data: T) => void;
+};
+
+function broadcastSource(): Source {
+  const channels: Record<string, BroadcastChannel> = {};
+
+  function getChannel(key: string): BroadcastChannel {
+    if (channels[key]) return channels[key];
+    const newChannel = new BroadcastChannel(key);
+    channels[key] = newChannel;
+    return newChannel;
+  }
+
+  function sendData<T = any>(key: string, data: T) {
+    const channel = getChannel(key);
+    channel.postMessage(data);
+  }
+
+  function onData<T = any>(key: string, cb: DataCb<T>) {
+    const channel = getChannel(key);
+    channel.onmessage = (ev) => void cb(ev.data);
+  }
+  return { sendData, onData };
+}
+
+const source = broadcastSource();
+
+/**
+ * Creates a state that can be synced between contexts on the same browser running on the same machine:
+ * tabs, windows, iframes can keep a state synced between them.
+ * A state must have an identifier, and any other state with the same identifier will keep synced to it.
+ * It can be either a receiver, a sender or both.
+ * @param identifier string identifier shared between synced states
+ * @param baseValue starting value of the state
+ * @param role sender, receiver or both, defines if the state will update, get updated or both
+ */
+export function useLocalSyncedState<T = any>(identifier: string, baseValue: T | null = null, role: Roles = 'both') {
+  const componentIsMounted = useRef<boolean>(false);
+  const [value, setValue] = useState<T | null>(baseValue);
+
+  useEffect(() => {
+    componentIsMounted.current = true;
+    return () => {
+      componentIsMounted.current = false;
+    };
+  }, []);
+
+  const isSender = role === 'sender' || role === 'both';
+  const isReceiver = role === 'receiver' || role === 'both';
+
+  if (isReceiver) {
+    source.onData(identifier, (d) => componentIsMounted.current && setValue(d));
+  }
+
+  function setData(newVal: T) {
+    setValue(newVal);
+    if (isSender) {
+      source.sendData(identifier, newVal);
+    }
+  }
+
+  return [value, setData] as const;
+}

--- a/src/useLocalSyncedState.ts
+++ b/src/useLocalSyncedState.ts
@@ -5,12 +5,12 @@ type Roles = typeof ROLES[number];
 
 type DataCb<T = any> = (d: T) => void;
 
-type Source = {
+type Connector = {
   onData: <T = any>(key: string, cb: DataCb<T>) => void;
   sendData: <T = any>(key: string, data: T) => void;
 };
 
-function broadcastSource(): Source {
+function createConnector(): Connector {
   const channels: Record<string, BroadcastChannel> = {};
 
   function getChannel(key: string): BroadcastChannel {
@@ -32,7 +32,7 @@ function broadcastSource(): Source {
   return { sendData, onData };
 }
 
-const source = broadcastSource();
+const connector = createConnector();
 
 /**
  * Creates a state that can be synced between contexts on the same browser running on the same machine:
@@ -58,13 +58,13 @@ export function useLocalSyncedState<T = any>(identifier: string, baseValue: T | 
   const isReceiver = role === 'receiver' || role === 'both';
 
   if (isReceiver) {
-    source.onData(identifier, (d) => componentIsMounted.current && setValue(d));
+    connector.onData(identifier, (d) => componentIsMounted.current && setValue(d));
   }
 
   function setData(newVal: T) {
     setValue(newVal);
     if (isSender) {
-      source.sendData(identifier, newVal);
+      connector.sendData(identifier, newVal);
     }
   }
 

--- a/stories/useLocalSyncedState.story.tsx
+++ b/stories/useLocalSyncedState.story.tsx
@@ -1,0 +1,38 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useLocalSyncedState } from '../src';
+import ShowDocs from './util/ShowDocs';
+
+const WINDOW_CHILD_NAME = 'child';
+
+const Demo = () => {
+  const [value, setValue] = useLocalSyncedState('value', 0);
+
+  const isParent = window.parent.name !== WINDOW_CHILD_NAME;
+
+  function openWindow() {
+    window.open(window.parent.location.href, WINDOW_CHILD_NAME);
+  }
+
+  function changeValue() {
+    isParent ? setValue(value + 1) : setValue(value - 1);
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <div style={{ marginBottom: '20px' }}>Current Value: {value}</div>
+      <button style={{ cursor: 'pointer', marginBottom: '20px' }} onClick={changeValue}>
+        Click me to {isParent ? 'increase' : 'decrease'} value!
+      </button>
+      <div>
+        <button style={{ cursor: 'pointer' }} onClick={openWindow}>
+          Click me to open a new window!
+        </button>
+      </div>
+    </div>
+  );
+};
+
+storiesOf('Side effects/useLocalSyncedState', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useLocalSyncedState.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -4,3 +4,35 @@ import 'jest-localstorage-mock';
   observe() {}
   disconnect() {}
 };
+
+window['channels'] = {};
+(window as any).BroadcastChannel = class BroadcastChannel {
+  id: string;
+  key: string;
+  _onmessage: any[] = [];
+
+  constructor(key: string) {
+    this.key = key;
+    this.id = Math.random().toString(32);
+    window['channels'] = window['channels'] || {};
+    window['channels'][key] = window['channels'][key] || [];
+    window['channels'][key].push(this);
+  }
+
+  set onmessage(fn: any) {
+    this._onmessage.push(fn);
+  }
+
+  get onmessage() {
+    return this._onmessage;
+  }
+
+  postMessage(message: string) {
+    const channels = window['channels'][this.key] || [];
+    channels.forEach((channel) => {
+      channel.onmessage.forEach((handler) => {
+        handler({ data: message });
+      });
+    });
+  }
+};

--- a/tests/useLocalSyncedState.test.ts
+++ b/tests/useLocalSyncedState.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useLocalSyncedState } from '../src/useLocalSyncedState';
+
+describe('useLocalSyncedState', () => {
+  it('should be defined', () => {
+    expect(useLocalSyncedState).toBeDefined();
+  });
+
+  it('should update its own value', () => {
+    const STARTING_VALUE = 0;
+    const NEXT_VALUE = 100;
+    const { result } = renderHook(() => useLocalSyncedState('test', STARTING_VALUE));
+    expect(result.current[0]).toBe(STARTING_VALUE);
+    act(() => result.current[1](NEXT_VALUE));
+    expect(result.current[0]).toBe(NEXT_VALUE);
+  });
+
+  it('should update all hooks with same identifier', () => {
+    const STARTING_VALUE = 0;
+    const NEXT_VALUE = 100;
+    const firstHook = renderHook(() => useLocalSyncedState('test', STARTING_VALUE));
+    const secondHook = renderHook(() => useLocalSyncedState('test', STARTING_VALUE));
+    expect(firstHook.result.current[0]).toBe(STARTING_VALUE);
+    expect(secondHook.result.current[0]).toBe(STARTING_VALUE);
+    act(() => firstHook.result.current[1](NEXT_VALUE));
+    expect(firstHook.result.current[0]).toBe(NEXT_VALUE);
+    expect(secondHook.result.current[0]).toBe(NEXT_VALUE);
+  });
+
+  it('should only update hooks with same identifier', () => {
+    const STARTING_VALUE = 0;
+    const NEXT_VALUE = 100;
+    const firstHook = renderHook(() => useLocalSyncedState('test', STARTING_VALUE));
+    const secondHook = renderHook(() => useLocalSyncedState('test2', STARTING_VALUE));
+    expect(firstHook.result.current[0]).toBe(STARTING_VALUE);
+    expect(secondHook.result.current[0]).toBe(STARTING_VALUE);
+    act(() => firstHook.result.current[1](NEXT_VALUE));
+    expect(firstHook.result.current[0]).toBe(NEXT_VALUE);
+    expect(secondHook.result.current[0]).toBe(STARTING_VALUE);
+  });
+
+  it('should only update receiver hooks with same identifier', () => {
+    const STARTING_VALUE = 0;
+    const NEXT_VALUE = 100;
+    const firstHook = renderHook(() => useLocalSyncedState('test', STARTING_VALUE));
+    const secondHook = renderHook(() => useLocalSyncedState('test', STARTING_VALUE, 'sender'));
+    expect(firstHook.result.current[0]).toBe(STARTING_VALUE);
+    expect(secondHook.result.current[0]).toBe(STARTING_VALUE);
+    act(() => firstHook.result.current[1](NEXT_VALUE));
+    expect(firstHook.result.current[0]).toBe(NEXT_VALUE);
+    expect(secondHook.result.current[0]).toBe(STARTING_VALUE);
+  });
+
+  it('should only update hooks if first updated hook is sender', () => {
+    const STARTING_VALUE = 0;
+    const NEXT_VALUE = 100;
+    const firstHook = renderHook(() => useLocalSyncedState('test', STARTING_VALUE, 'receiver'));
+    const secondHook = renderHook(() => useLocalSyncedState('test', STARTING_VALUE));
+    expect(firstHook.result.current[0]).toBe(STARTING_VALUE);
+    expect(secondHook.result.current[0]).toBe(STARTING_VALUE);
+    act(() => firstHook.result.current[1](NEXT_VALUE));
+    expect(firstHook.result.current[0]).toBe(NEXT_VALUE);
+    expect(secondHook.result.current[0]).toBe(STARTING_VALUE);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6535,7 +6535,7 @@ debug@^4.2.0:
   dependencies:
     ms "2.1.2"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -9276,7 +9276,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -10999,11 +10999,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -11012,32 +11007,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -11093,11 +11066,6 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -12210,7 +12178,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -12225,7 +12192,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -12244,14 +12210,8 @@ npm@^6.10.3:
     libnpx "^10.2.4"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -12339,7 +12299,6 @@ npm@^6.14.9:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -12354,7 +12313,6 @@ npm@^6.14.9:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -12373,14 +12331,8 @@ npm@^6.14.9:
     libnpx "^10.2.4"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
# Description

This PR proposes to add a new hook (and, in the future, another similar one) that will sync its value to any other hooks created in windows that are reachable from a [Broadcast Channel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel).
A similar hook can be created that uses different connectors in order to allow sync between applications on separate browsers running on separate machines, via a server.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [X] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [X] Perform a code self-review
- [X] Comment the code, particularly in hard-to-understand areas
- [X] Add documentation
- [X] Add hook's story at Storybook
- [X] Cover changes with tests
- [X] Ensure the test suite passes (`yarn test`)
- [X] Provide 100% tests coverage
- [X] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [X] Make sure types are fine (`yarn lint:types`).