### PR TITLE
fix: proper definition for `useMeasure`

### DIFF
--- a/src/useMeasure.ts
+++ b/src/useMeasure.ts
@@ -48,4 +48,4 @@ function useMeasure<E extends HTMLElement = HTMLElement>(): UseMeasureResult<E> 
 
 export default isBrowser && typeof (window as any).ResizeObserver !== 'undefined'
   ? useMeasure
-  : () => [noop, defaultState];
+  : (() => [noop, defaultState]) as typeof useMeasure;


### PR DESCRIPTION
# Description
Type of `[noop, defaultState]` is :
```
Array<(
  | Pick<DOMRectReadOnly, "x" | "y" | "top" | "left" | "right" | "bottom" | "height" | "width"> 
  | (() => void)
)>
```

This fix it.

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
