### PR TITLE
Default to window.innerWidth instead of 0 in createBreakpoint

### DIFF
--- a/src/factory/createBreakpoint.ts
+++ b/src/factory/createBreakpoint.ts
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
-import { off, on } from '../misc/util';
+import { isBrowser, off, on } from '../misc/util';
 
 const createBreakpoint = (
   breakpoints: { [name: string]: number } = { laptopL: 1440, laptop: 1024, tablet: 768 }
 ) => () => {
-  const [screen, setScreen] = useState(0);
+  const [screen, setScreen] = useState(isBrowser ? window.innerWidth : 0);
 
   useEffect(() => {
     const setSideScreen = (): void => {


### PR DESCRIPTION
# Description

Fixes #1493 

I tried to write tests for this but I couldn't manage with the setup `react-use` has. I think it's hard to catch in JSDom.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
