### PR TITLE
New react state hook - useConverter

### DIFF
--- a/docs/useConverter.md
+++ b/docs/useConverter.md
@@ -1,0 +1,21 @@
+# `useConverter`
+
+React state hook that keeps track of the input 
+and immediately generates the output based on the converter function.
+
+## Usage
+
+```jsx
+import { useConverter } from 'react-use';
+
+const Demo = () => {
+  const [input, setInput, output] = useConverter((data) => btoa(data), 'Hello World');
+
+  return (
+    <div>
+      <textarea value={input} onChange={(event) => setInput(event.target.value)} />
+      <pre>{output}</pre>
+    </div>
+  );
+};
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { default as useBattery } from './useBattery';
 export { default as useBeforeUnload } from './useBeforeUnload';
 export { default as useBoolean } from './useBoolean';
 export { default as useClickAway } from './useClickAway';
+export { default as useConverter } from './useConverter';
 export { default as useCookie } from './useCookie';
 export { default as useCopyToClipboard } from './useCopyToClipboard';
 export { default as useCounter } from './useCounter';

--- a/src/useConverter.ts
+++ b/src/useConverter.ts
@@ -1,0 +1,13 @@
+import { useState, useMemo } from 'react';
+
+const useConverter = (converter, initialInput) => {
+  const [input, setInput] = useState(initialInput);
+
+  const output = useMemo(() => {
+    return converter(input);
+  }, [converter, input]);
+
+  return [input, setInput, output];
+};
+
+export default useConverter;

--- a/stories/useConverter.story.tsx
+++ b/stories/useConverter.story.tsx
@@ -1,0 +1,19 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useConverter } from '../src';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const [input, setInput, output] = useConverter((data) => btoa(data), 'Hello World');
+
+  return (
+    <div>
+      <textarea value={input} onChange={(event) => setInput(event.target.value)} />
+      <pre>{output}</pre>
+    </div>
+  );
+};
+
+storiesOf('State/useConverter', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useConverter.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useConverter.test.ts
+++ b/tests/useConverter.test.ts
@@ -1,0 +1,25 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import useConverter from '../src/useConverter';
+
+const setUp = (converter, initialInput) => renderHook(() => useConverter(converter, initialInput));
+
+it('should return input value, set input function, output value (base64)', () => {
+  const { result } = setUp((data) => btoa(data), 'Hello World');
+
+  expect(result.current[0]).toBe('Hello World');
+  expect(typeof result.current[1]).toBe('function');
+  expect(result.current[2]).toBe('SGVsbG8gV29ybGQ=');
+});
+
+it('should change state and return input value, set input function, output value (html)', () => {
+  const { result } = setUp((data) => '<p>' + data + '</p>', 'Hello World');
+  const [, setInput] = result.current;
+
+  act(() => {
+    setInput("It's me");
+  });
+
+  expect(result.current[0]).toBe("It's me");
+  expect(typeof result.current[1]).toBe('function');
+  expect(result.current[2]).toBe("<p>It's me</p>");
+});


### PR DESCRIPTION
# `useConverter`

React state hook that keeps track of the input and immediately generates the output based on the converter function.

## Usage

```jsx
import { useConverter } from 'react-use';

const Demo = () => {
  const [input, setInput, output] = useConverter((data) => btoa(data), 'Hello World');

  return (
    <div>
      <textarea value={input} onChange={(event) => setInput(event.target.value)} />
      <pre>{output}</pre>
    </div>
  );
};
```

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md);
- [x] Perform a code self-review;
- [x] Comment the code, particularly in hard-to-understand areas;
- [x] Add documentation;
- [x] Add hook's story at Storybook;
- [x] Cover changes with tests;
- [x] Ensure the test suite passes (`yarn test`);
- [x] Provide 100% tests coverage;
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure;
- [x] Make sure types are fine (`yarn lint:types`);