### PR TITLE
test: Add test coverage for ensuredForwardRef

### DIFF
--- a/tests/useEnsuredForwardedRef.test.tsx
+++ b/tests/useEnsuredForwardedRef.test.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { renderHook } from '@testing-library/react-hooks';
 import TestUtils from 'react-dom/test-utils';
-import { useEnsuredForwardedRef } from '../src';
+import { ensuredForwardRef, useEnsuredForwardedRef } from '../src';
 
 let container: HTMLDivElement;
 
@@ -50,4 +50,25 @@ test('should return a valid ref when the forwarded ref is undefined', () => {
   const { ensuredRef } = result.current;
 
   expect(ensuredRef.current.id).toBe('test_id');
+});
+
+test('should return a valid ref when using the wrapper function style', () => {
+  const { result } = renderHook(() => {
+    const initialRef = useRef<HTMLDivElement | null>(null);
+
+    const WrappedComponent = ensuredForwardRef<HTMLDivElement>((_props, ref) => {
+      return <div id="test_id" ref={ref} />;
+    });
+
+    TestUtils.act(() => {
+      ReactDOM.render(<WrappedComponent ref={initialRef} />, container);
+    });
+
+    return { initialRef };
+  });
+
+  const { initialRef } = result.current;
+
+  expect(initialRef.current).toBeTruthy();
+  expect(initialRef.current?.id).toBe('test_id');
 });


### PR DESCRIPTION
# Description

This only adds a test for `ensuredForwardRef`

```diff
-  useEnsuredForwardedRef.ts    |      75 |      100 |      50 |      75 | 31-33
+  useEnsuredForwardedRef.ts    |     100 |      100 |     100 |     100 |
```

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
