### PR TITLE
Adds useAsyncPolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
     <br/>
 - [**Side-effects**](./docs/Side-effects.md)
   - [`useAsync`](./docs/useAsync.md), [`useAsyncFn`](./docs/useAsyncFn.md), and [`useAsyncRetry`](./docs/useAsyncRetry.md) &mdash; resolves an `async` function.
+  - [`useAsyncPolling`](./docs/useAsyncPolling.md) &mdash; resolves an `async` function retrying until a certain condition is met.
   - [`useBeforeUnload`](./docs/useBeforeUnload.md) &mdash; shows browser alert when user try to reload or close the page.
   - [`useCookie`](./docs/useCookie.md) &mdash; provides way to read, update and delete a cookie. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/side-effects-usecookie--demo)
   - [`useCopyToClipboard`](./docs/useCopyToClipboard.md) &mdash; copies text to clipboard.

--- a/docs/useAsyncPolling.md
+++ b/docs/useAsyncPolling.md
@@ -1,0 +1,88 @@
+# `useAsyncPolling`
+
+A specialized `useAsync` to continue retrying until a certain condition is met. Typically used when a backend is eventually consistent and exposes an endpoint to verify the status of a process.
+
+It passes a `next` function to the callback that is supposed to be called when polling must continue. For the polling to finish you simply return the value (and then `value` will be set) or throw (and then `error` will be set). You can also pass a value to `next` in order to have it as part of the state (`currentResult`) in case you want to show the user what is going on (see below).
+
+It extends the regular `useAsync` state (`loading`, `error` and `value`) by adding:
+
+- `attempt`: The current attempt number (starting with 1).
+- `currentResult`: The last result passed to the next function.
+- `results`: The full list of previous results passed to the next function.
+
+It also accepts 2 options, `interval` and `maxAttempts`.
+
+- The `interval` can be a number or a function that will receive the current attempt number and return a number in milliseconds. This number will be used to sleep between the attempts. Default 2000.
+
+- The `maxAttempts` sets the limit of attempts, and if reached will throw the `MaxAttemptsError` (that is, this will become the `error`). Default 30.
+
+## Usage
+
+```jsx
+import { useAsyncPolling } from 'react-use';
+
+const Demo = () => {
+  const state = usePolling({}, async (next) => {
+    const response = await fetch('/status');
+    const { status } = await response.json();
+    
+    // in this case, receiving 'waiting' is meant to continue polling,
+    // any other result will resolve
+    return status === 'waiting' ? next(status) : status
+  }, [url]);
+
+  return (
+    <div>
+      {state.loading
+        ? <div>Waiting for status... 
+            Attempt {state.attempt}
+            Current result {state.currentResult}
+            Previous results {JSON.stringify(state.results)} .</div>
+        : state.error
+          ? <div>Error: {state.error.message}</div>
+          : <div>Status: {state.value}</div>
+      }
+    </div>
+  );
+};
+```
+
+Setting an interval and max attempts:
+
+```js
+  const state = usePolling({ interval: 5000, maxAttempts: 5 }, async (next) => {
+    const response = await fetch('/status');
+    const { status } = await response.json();
+    
+    return status === 'waiting' ? next(status) : status
+  }, [url]);
+```
+
+Setting an increasing interval, in this case it will increase from 1 second to 10 seconds, taking a total time of around 55s (plus latency, execution time, etc):
+
+```js
+  const state = usePolling({ interval: (attempt => attempt * 1000), maxAttempts: 10 }, async (next) => {
+    const response = await fetch('/status');
+    const { status } = await response.json();
+    
+    return status === 'waiting' ? next(status) : status
+  }, [url]);
+```
+
+Stopping if it's not possible to continue given a certain condition:
+
+```js
+  const state = usePolling({}, async (next) => {
+    const response = await fetch('/status');
+    const { status, reason } = await response.json();
+    
+    switch(status) {
+      case 'done':
+        return status
+      case 'failed':
+        throw new Error(reason)
+      default:
+        next(status)
+    }
+  }, [url]);
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { default as createReducer } from './factory/createReducer';
 export { default as createStateContext } from './factory/createStateContext';
 export { default as useAsync } from './useAsync';
 export { default as useAsyncFn } from './useAsyncFn';
+export { default as useAsyncPolling } from './useAsyncPolling';
 export { default as useAsyncRetry } from './useAsyncRetry';
 export { default as useAudio } from './useAudio';
 export { default as useBattery } from './useBattery';

--- a/src/misc/sleep.ts
+++ b/src/misc/sleep.ts
@@ -1,0 +1,5 @@
+export async function sleep(interval: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, interval);
+  });
+}

--- a/src/useAsyncPolling.ts
+++ b/src/useAsyncPolling.ts
@@ -1,0 +1,78 @@
+import { sleep } from './misc/sleep';
+import { DependencyList, useEffect, useState } from 'react';
+import useAsyncFn, { AsyncState } from './useAsyncFn';
+
+export type PollingState<T> = {
+  attempt: number;
+  results: T[];
+  currentResult?: T;
+};
+export type AsyncStatePolling<T> = AsyncState<T> & PollingState<T>;
+export type NextFn<T> = (curretnResult: T) => void;
+export type PollingOptions = {
+  maxAttempts?: number;
+  interval?: number | ((attempt: number) => number);
+};
+export class MaxAttemptsError extends Error {}
+
+type DeepNonNullable<T> = {
+  [P in keyof T]-?: NonNullable<T[P]>;
+};
+
+type Opts = DeepNonNullable<PollingOptions>;
+
+const defaultOptions: Opts = {
+  maxAttempts: 30,
+  interval: 2 * 1000,
+};
+
+const useAsyncPolling = <T>(
+  options: PollingOptions,
+  fn: (next: NextFn<T>) => Promise<T>,
+  deps: DependencyList = []
+): AsyncStatePolling<T> => {
+  const opts = { ...defaultOptions, ...options } as Opts;
+
+  const [state, callback] = useAsyncFn(fn, deps, {
+    loading: true,
+  });
+
+  const [pollingState, setPollingState] = useState<PollingState<T>>({
+    attempt: 1,
+    results: [],
+  });
+
+  let attempt = 1;
+  async function next(currentResult: T) {
+    setPollingState((pollingState) => {
+      return {
+        ...pollingState,
+        results: [...pollingState.results, currentResult],
+        currentResult,
+      };
+    });
+
+    if (attempt === opts.maxAttempts) {
+      throw new MaxAttemptsError(`Max attempts exceeded`);
+    }
+
+    await sleep(opts.interval instanceof Function ? opts.interval(attempt) : opts.interval);
+
+    setPollingState((pollingState) => {
+      return {
+        ...pollingState,
+        attempt: (attempt += 1),
+      };
+    });
+
+    return await callback(next);
+  }
+
+  useEffect(() => {
+    callback(next);
+  }, [callback]);
+
+  return { ...state, ...pollingState };
+};
+
+export default useAsyncPolling;

--- a/src/useAsyncPolling.ts
+++ b/src/useAsyncPolling.ts
@@ -15,13 +15,7 @@ export type PollingOptions = {
 };
 export class MaxAttemptsError extends Error {}
 
-type DeepNonNullable<T> = {
-  [P in keyof T]-?: NonNullable<T[P]>;
-};
-
-type Opts = DeepNonNullable<PollingOptions>;
-
-const defaultOptions: Opts = {
+const defaultOptions: Required<PollingOptions> = {
   maxAttempts: 30,
   interval: 2 * 1000,
 };
@@ -31,7 +25,7 @@ const useAsyncPolling = <T>(
   fn: (next: NextFn<T>) => Promise<T>,
   deps: DependencyList = []
 ): AsyncStatePolling<T> => {
-  const opts = { ...defaultOptions, ...options } as Opts;
+  const opts = { ...defaultOptions, ...options } as Required<PollingOptions>;
 
   const [state, callback] = useAsyncFn(fn, deps, {
     loading: true,

--- a/tests/useAsyncPolling.test.tsx
+++ b/tests/useAsyncPolling.test.tsx
@@ -7,8 +7,6 @@ import useAsyncPolling, { MaxAttemptsError } from '../src/useAsyncPolling';
 import { sleep } from '../src/misc/sleep';
 
 describe('useAsyncPolling', () => {
-  let hook;
-
   function createResolver(responses: string[]) {
     responses = [...responses];
 

--- a/tests/useAsyncPolling.test.tsx
+++ b/tests/useAsyncPolling.test.tsx
@@ -1,0 +1,173 @@
+jest.mock('../src/misc/sleep', () => ({
+  sleep: jest.fn(),
+}));
+
+import { renderHook } from '@testing-library/react-hooks';
+import useAsyncPolling, { MaxAttemptsError } from '../src/useAsyncPolling';
+import { sleep } from '../src/misc/sleep';
+
+describe('useAsyncPolling', () => {
+  let hook;
+
+  function createResolver(responses: string[]) {
+    responses = [...responses];
+
+    const resolver = async (next) => {
+      return new Promise((resolve, reject) => {
+        const wait = setTimeout(() => {
+          clearTimeout(wait);
+
+          const response = responses.shift();
+
+          if (response === 'throw') reject(new Error('Oops'));
+
+          return resolve(response === 'waiting' ? next(response) : response);
+        }, 0);
+      });
+    };
+
+    return resolver;
+  }
+
+  function createRenderHook(options, responses: string[]) {
+    const resolver = createResolver(responses);
+
+    return renderHook(
+      ({ options, fn }) => {
+        return useAsyncPolling(options, fn, [fn]);
+      },
+      {
+        initialProps: {
+          options,
+          fn: resolver,
+        },
+      }
+    );
+  }
+
+  it('should be defined', () => {
+    expect(useAsyncPolling).toBeDefined();
+  });
+
+  it('initially starts loading', async () => {
+    const hook = createRenderHook({}, []);
+    await hook.waitForNextUpdate();
+  });
+
+  it('resolves after polling', async () => {
+    const responses = ['waiting', 'waiting', 'waiting', 'waiting', 'finished'];
+    const hook = createRenderHook({}, responses);
+
+    for (let attempt = 0; attempt < responses.length; attempt++) {
+      expect(hook.result.current.loading).toBe(true);
+      expect(hook.result.current.value).toEqual(undefined);
+      expect(hook.result.current.error).toEqual(undefined);
+      expect(hook.result.current.attempt).toEqual(attempt + 1);
+      expect(hook.result.current.results).toEqual(responses.slice(0, attempt));
+      expect(hook.result.current.currentResult).toEqual(attempt ? 'waiting' : undefined);
+
+      await hook.waitForNextUpdate();
+
+      expect(sleep).lastCalledWith(2000);
+    }
+
+    expect(hook.result.current.loading).toBe(false);
+    expect(hook.result.current.value).toEqual(`finished`);
+    expect(hook.result.current.error).toEqual(undefined);
+    expect(hook.result.current.attempt).toEqual(responses.length);
+  });
+
+  it('resolves after polling with custom intervals', async () => {
+    const responses = ['waiting', 'finished'];
+    const hook = createRenderHook({ interval: 1000 }, responses);
+
+    for (let attempt = 0; attempt < responses.length; attempt++) {
+      expect(hook.result.current.loading).toBe(true);
+      expect(hook.result.current.value).toEqual(undefined);
+      expect(hook.result.current.error).toEqual(undefined);
+      expect(hook.result.current.attempt).toEqual(attempt + 1);
+      expect(hook.result.current.results).toEqual(responses.slice(0, attempt));
+      expect(hook.result.current.currentResult).toEqual(attempt ? 'waiting' : undefined);
+
+      await hook.waitForNextUpdate();
+
+      expect(sleep).lastCalledWith(1000);
+    }
+
+    expect(hook.result.current.loading).toBe(false);
+    expect(hook.result.current.value).toEqual(`finished`);
+    expect(hook.result.current.error).toEqual(undefined);
+    expect(hook.result.current.attempt).toEqual(responses.length);
+  });
+
+  it('fails if reaches maxAttempts', async () => {
+    const responses = ['waiting', 'waiting', 'waiting', 'finished'];
+    const hook = createRenderHook({ interval: 1000, maxAttempts: 3 }, responses);
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      expect(hook.result.current.loading).toBe(true);
+      expect(hook.result.current.value).toEqual(undefined);
+      expect(hook.result.current.error).toEqual(undefined);
+      expect(hook.result.current.attempt).toEqual(attempt + 1);
+      expect(hook.result.current.results).toEqual(responses.slice(0, attempt));
+      expect(hook.result.current.currentResult).toEqual(attempt ? 'waiting' : undefined);
+
+      await hook.waitForNextUpdate();
+
+      expect(sleep).lastCalledWith(1000);
+    }
+
+    expect(hook.result.current.loading).toBe(false);
+    expect(hook.result.current.value).toEqual(undefined);
+    expect(hook.result.current.error).toEqual(new MaxAttemptsError(`Max attempts exceeded`));
+    expect(hook.result.current.attempt).toEqual(3);
+    expect(hook.result.current.results).toEqual(['waiting', 'waiting', 'waiting']);
+  });
+
+  it('allows passing interval function', async () => {
+    const responses = ['waiting', 'waiting', 'waiting', 'waiting', 'finished'];
+    const hook = createRenderHook({ interval: (attempt: number) => attempt * 1000 }, responses);
+
+    for (let attempt = 0; attempt < responses.length; attempt++) {
+      expect(hook.result.current.loading).toBe(true);
+      expect(hook.result.current.value).toEqual(undefined);
+      expect(hook.result.current.error).toEqual(undefined);
+      expect(hook.result.current.attempt).toEqual(attempt + 1);
+      expect(hook.result.current.results).toEqual(responses.slice(0, attempt));
+      expect(hook.result.current.currentResult).toEqual(attempt ? 'waiting' : undefined);
+
+      await hook.waitForNextUpdate();
+
+      if (attempt < 4) expect(sleep).lastCalledWith((attempt + 1) * 1000);
+    }
+
+    expect(hook.result.current.loading).toBe(false);
+    expect(hook.result.current.value).toEqual(`finished`);
+    expect(hook.result.current.error).toEqual(undefined);
+    expect(hook.result.current.attempt).toEqual(responses.length);
+  });
+
+  it('fails if callback rejects', async () => {
+    const responses = ['waiting', 'waiting', 'throw', 'finished'];
+    const hook = createRenderHook({ interval: 1000, maxAttempts: 3 }, responses);
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      expect(hook.result.current.loading).toBe(true);
+      expect(hook.result.current.value).toEqual(undefined);
+      expect(hook.result.current.error).toEqual(undefined);
+      expect(hook.result.current.attempt).toEqual(attempt + 1);
+      expect(hook.result.current.results).toEqual(responses.slice(0, attempt));
+      expect(hook.result.current.currentResult).toEqual(attempt ? 'waiting' : undefined);
+
+      await hook.waitForNextUpdate();
+
+      expect(sleep).lastCalledWith(1000);
+    }
+
+    expect(hook.result.current.loading).toBe(false);
+    expect(hook.result.current.value).toEqual(undefined);
+    expect(hook.result.current.error).toEqual(new Error(`Oops`));
+    expect(hook.result.current.attempt).toEqual(3);
+    expect(hook.result.current.results).toEqual(['waiting', 'waiting']);
+  });
+});

--- a/tests/useAsyncRetry.test.tsx
+++ b/tests/useAsyncRetry.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react-test-renderer';
+import useAsyncRetry from '../src/useAsyncRetry';
+
+describe('useAsyncRetry', () => {
+  it('should be defined', () => {
+    expect(useAsyncRetry).toBeDefined();
+  });
+
+  describe('success with retry', () => {
+    let hook;
+    let callCount = 0;
+
+    const resolver = async () => {
+      return new Promise((resolve) => {
+        callCount++;
+
+        const wait = setTimeout(() => {
+          clearTimeout(wait);
+          resolve(`result-${callCount}`);
+        }, 0);
+      });
+    };
+
+    beforeEach(() => {
+      callCount = 0;
+      hook = renderHook(({ fn }) => useAsyncRetry(fn, [fn]), {
+        initialProps: {
+          fn: resolver,
+        },
+      });
+    });
+
+    it('initially starts loading', async () => {
+      expect(hook.result.current.loading).toEqual(true);
+      await hook.waitForNextUpdate();
+    });
+
+    it('resolves and retries', async () => {
+      expect.assertions(8);
+
+      hook.rerender({ fn: resolver });
+      await hook.waitForNextUpdate();
+
+      expect(callCount).toEqual(1);
+      expect(hook.result.current.loading).toBeFalsy();
+      expect(hook.result.current.value).toEqual('result-1');
+      expect(hook.result.current.error).toEqual(undefined);
+
+      act(() => {
+        hook.result.current.retry();
+      });
+
+      await hook.waitForNextUpdate();
+
+      expect(callCount).toEqual(2);
+      expect(hook.result.current.loading).toBeFalsy();
+      expect(hook.result.current.value).toEqual('result-2');
+      expect(hook.result.current.error).toEqual(undefined);
+    });
+  });
+});


### PR DESCRIPTION
# Description

Adds `useAsyncPolling` a function to continually call an endpoint until a certain condition is met.

It also adds specs to `useAsyncRetry` that were missing.

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
