### PR TITLE
fix(useLocalStorage): state change on first mount

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -1,4 +1,5 @@
-import { Dispatch, SetStateAction, useCallback, useState, useRef, useLayoutEffect } from 'react';
+import { Dispatch, SetStateAction, useCallback, useState, useRef } from 'react';
+import useUpdateEffect from './useUpdateEffect';
 import { isBrowser, noop } from './misc/util';
 
 type parserOptions<T> =
@@ -53,7 +54,7 @@ const useLocalStorage = <T>(
   const [state, setState] = useState<T | undefined>(() => initializer.current(key));
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  useLayoutEffect(() => setState(initializer.current(key)), [key]);
+  useUpdateEffect(() => setState(initializer.current(key)), [key]);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const set: Dispatch<SetStateAction<T | undefined>> = useCallback(

--- a/tests/useLocalStorage.test.ts
+++ b/tests/useLocalStorage.test.ts
@@ -93,6 +93,14 @@ describe(useLocalStorage, () => {
     expect(state).toEqual('bar');
   });
 
+  it('should initialize only once', () => {
+    const getItemSpy = jest.spyOn(localStorage, 'getItem');
+    renderHook(() => useLocalStorage('foo', 'bar'));
+
+    expect(getItemSpy).toHaveBeenCalledWith('foo');
+    expect(getItemSpy).toHaveBeenCalledTimes(1);
+  });
+
   /*
   it('keeps multiple hooks accessing the same key in sync', () => {
     localStorage.setItem('foo', 'bar');


### PR DESCRIPTION
# Description

Fixes a regression introduced in https://github.com/streamich/react-use/commit/fdd1b23fd7ba6ae30139eeef02c552a8c7d6d333 where `useLocalStorage` updates it state during first mount leading to an unwanted re-render. To avoid that I replaced `useLayoutEffect` by `useUpdateEffect` and added a test that ensure we only read the storage once on first mount.

closes #1970 

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
