### PR TITLE
feat: add useDevicePixelRatio hook

### DIFF
--- a/docs/useDevicePixelRatio.md
+++ b/docs/useDevicePixelRatio.md
@@ -1,0 +1,19 @@
+# `useDevicePixelRatio`
+
+React sensor hook that tracks pixel ratio of the device.
+
+## Usage
+
+```jsx
+import { useDevicePixelRatio } from 'react-use';
+
+const Demo = () => {
+  const pixelRatio = useDevicePixelRatio();
+
+  return (
+    <div>
+      <div>pixelRatio: {pixelRatio}</div>
+    </div>
+  );
+};
+```

--- a/docs/useDevicePixelRatio.md
+++ b/docs/useDevicePixelRatio.md
@@ -10,10 +10,6 @@ import { useDevicePixelRatio } from 'react-use';
 const Demo = () => {
   const pixelRatio = useDevicePixelRatio();
 
-  return (
-    <div>
-      <div>pixelRatio: {pixelRatio}</div>
-    </div>
-  );
+  return <div>pixelRatio: {pixelRatio}</div>;
 };
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export { default as useCustomCompareEffect } from './useCustomCompareEffect';
 export { default as useDebounce } from './useDebounce';
 export { default as useDeepCompareEffect } from './useDeepCompareEffect';
 export { default as useDefault } from './useDefault';
+export { default as useDevicePixelRatio } from './useDevicePixelRatio';
 export { default as useDrop } from './useDrop';
 export { default as useDropArea } from './useDropArea';
 export { default as useEffectOnce } from './useEffectOnce';

--- a/src/useDevicePixelRatio.ts
+++ b/src/useDevicePixelRatio.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+import useRafState from './useRafState';
+import { isBrowser, off, on } from './misc/util';
+
+const useDevicePixelRatio = (initialRatio = 1) => {
+  const [state, setState] = useRafState<number>(initialRatio);
+
+  useEffect((): (() => void) | void => {
+    if (isBrowser) {
+      const handler = () => {
+        setState(window.devicePixelRatio);
+      };
+
+      on(window, 'resize', handler);
+
+      return () => {
+        off(window, 'resize', handler);
+      };
+    }
+  }, []);
+
+  return state;
+};
+
+export default useDevicePixelRatio;

--- a/stories/useDevicePixelRatio.story.tsx
+++ b/stories/useDevicePixelRatio.story.tsx
@@ -6,11 +6,7 @@ import ShowDocs from './util/ShowDocs';
 const Demo = () => {
   const pixelRatio = useDevicePixelRatio();
 
-  return (
-    <div>
-      <div>pixelRatio: {pixelRatio}</div>
-    </div>
-  );
+  return <div>pixelRatio: {pixelRatio}</div>;
 };
 
 storiesOf('Sensors/useDevicePixelRatio', module)

--- a/stories/useDevicePixelRatio.story.tsx
+++ b/stories/useDevicePixelRatio.story.tsx
@@ -1,0 +1,18 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useDevicePixelRatio } from '../src';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const pixelRatio = useDevicePixelRatio();
+
+  return (
+    <div>
+      <div>pixelRatio: {pixelRatio}</div>
+    </div>
+  );
+};
+
+storiesOf('Sensors/useDevicePixelRatio', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useDevicePixelRatio.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useDevicePixelRatio.test.ts
+++ b/tests/useDevicePixelRatio.test.ts
@@ -1,0 +1,93 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { replaceRaf } from 'raf-stub';
+import useDevicePixelRatio from '../src/useDevicePixelRatio';
+import { isBrowser } from '../src/misc/util';
+
+declare var requestAnimationFrame: {
+  reset: () => void;
+  step: (steps?: number, duration?: number) => void;
+};
+
+describe('useDevicePixelRatio', () => {
+  beforeAll(() => {
+    replaceRaf();
+  });
+
+  afterEach(() => {
+    requestAnimationFrame.reset();
+  });
+
+  it('should be defined', () => {
+    expect(useDevicePixelRatio).toBeDefined();
+  });
+
+  function getHook(...args) {
+    return renderHook(() => useDevicePixelRatio(...args));
+  }
+
+  function triggerResize(dimension: 'width' | 'height', value: number) {
+    if (dimension === 'width') {
+      (window.innerWidth as number) = value;
+    } else if (dimension === 'height') {
+      (window.innerHeight as number) = value;
+    }
+
+    window.dispatchEvent(new Event('resize'));
+  }
+
+  function setDevicePixelRatio(value: number) {
+    (window.devicePixelRatio as number) = value;
+  }
+
+  it('should return current device pixel ratio', () => {
+    const hook = getHook();
+
+    expect(typeof hook.result.current).toBe('number');
+  });
+
+  it('should use passed parameters as initial values in case of non-browser use', () => {
+    const hook = getHook(1);
+
+    expect(hook.result.current).toBe(isBrowser ? window.devicePixelRatio : 1);
+  });
+
+  it('should re-render after height change on closest RAF', () => {
+    const hook = getHook();
+
+    act(() => {
+      setDevicePixelRatio(1);
+      triggerResize('height', 720);
+      requestAnimationFrame.step();
+    });
+
+    expect(hook.result.current).toBe(1);
+
+    act(() => {
+      setDevicePixelRatio(1.5);
+      triggerResize('height', 480);
+      requestAnimationFrame.step();
+    });
+
+    expect(hook.result.current).toBe(1.5);
+  });
+
+  it('should re-render after width change on closest RAF', () => {
+    const hook = getHook();
+
+    act(() => {
+      setDevicePixelRatio(1);
+      triggerResize('width', 1280);
+      requestAnimationFrame.step();
+    });
+
+    expect(hook.result.current).toBe(1);
+
+    act(() => {
+      setDevicePixelRatio(2);
+      triggerResize('width', 640);
+      requestAnimationFrame.step();
+    });
+
+    expect(hook.result.current).toBe(2);
+  });
+});


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

React sensor hook that tracks pixel ratio of the device.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
