### PR TITLE
fix(useTitle): fix the strict mode issue and optimize the document.title access times

### DIFF
--- a/src/useTitle.ts
+++ b/src/useTitle.ts
@@ -5,21 +5,23 @@ export interface UseTitleOptions {
 }
 
 const DEFAULT_USE_TITLE_OPTIONS: UseTitleOptions = {
-  restoreOnUnmount: false,
+  restoreOnUnmount: true,
 };
 
 function useTitle(title: string, options: UseTitleOptions = DEFAULT_USE_TITLE_OPTIONS) {
-  const prevTitleRef = useRef(document.title);
-  document.title = title;
+  const orignalTitleRef = useRef(document.title);
   useEffect(() => {
     if (options && options.restoreOnUnmount) {
       return () => {
-        document.title = prevTitleRef.current;
+        document.title = orignalTitleRef.current;
       };
-    } else {
-      return;
     }
+    return;
   }, []);
+
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
 }
 
-export default typeof document !== 'undefined' ? useTitle : (_title: string) => {};
+export default typeof document !== "undefined" ? useTitle : (_title: string) => {};

--- a/tests/useTitle.test.ts
+++ b/tests/useTitle.test.ts
@@ -8,7 +8,6 @@ describe('useTitle', () => {
 
   it('should update document title', () => {
     const hook = renderHook((props) => useTitle(props), { initialProps: 'My page title' });
-
     expect(document.title).toBe('My page title');
     hook.rerender('My other page title');
     expect(document.title).toBe('My other page title');
@@ -18,8 +17,8 @@ describe('useTitle', () => {
     renderHook((props) => useTitle(props), { initialProps: 'Old Title' });
     expect(document.title).toBe('Old Title');
 
-    const hook = renderHook((props) => useTitle(props.title, { restoreOnUnmount: props.restore }), {
-      initialProps: { title: 'New Title', restore: true },
+    const hook = renderHook((props) => useTitle(props.title), {
+      initialProps: { title: 'New Title' },
     });
     expect(document.title).toBe('New Title');
     hook.unmount();


### PR DESCRIPTION
# Description

1. Don't think we should default the restore as `false` (more, we don't even need this), since it's more like a effect, if we don't do cleanup, why we use this hook?  If user pass the `restoreOnUnmount` as true, user can just do assign value to `document.title`, it's no any different, but with performance decrease [see below 2.]
2. **Currently in strict mode the `useTitle` does not restore to original title when I pass the `restoreOnUnmount=true`** 
See the demo https://codesandbox.io/s/usetitle-has-bug-hq4ku?file=/src/App.js:131-147
3. There's a performance issue, seems we update the `document.title` in each render.

For 3. I know it'll break the current usage, but I thought we should do before docs update. @streamich 

# What I do

1. **Turn the defaultOption `restoreOnUnmount` to be true**, this should be a side-effect, and I thought we should restore in cleanup as default
2. The current version we update the `document.title` just when the component re-render, it's just redundancy, let's access `document.title` only when `title` update
3. Separate the `title` effect and the restore clean-up to 2 effects, we restore it when unmounted, so the that effect use `[]` as comparedArray


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->

