### PR TITLE
fix: useMeasure top/left/y/x values were always zero

### DIFF
--- a/src/useMeasure.ts
+++ b/src/useMeasure.ts
@@ -28,7 +28,8 @@ function useMeasure<E extends Element = Element>(): UseMeasureResult<E> {
     () =>
       new (window as any).ResizeObserver((entries) => {
         if (entries[0]) {
-          const { x, y, width, height, top, left, bottom, right } = entries[0].contentRect;
+          const { x, y, width, height, top, left, bottom, right } =
+            entries[0].target.getBoundingClientRect();
           setRect({ x, y, width, height, top, left, bottom, right });
         }
       }),

--- a/tests/useMeasure.test.ts
+++ b/tests/useMeasure.test.ts
@@ -59,15 +59,17 @@ it('tracks rectangle of a DOM element', () => {
   act(() => {
     listener!([
       {
-        contentRect: {
-          x: 1,
-          y: 2,
-          width: 200,
-          height: 200,
-          top: 100,
-          bottom: 0,
-          left: 100,
-          right: 0,
+        target: {
+          getBoundingClientRect: () => ({
+            x: 1,
+            y: 2,
+            width: 200,
+            height: 200,
+            top: 100,
+            bottom: 0,
+            left: 100,
+            right: 0,
+          }),
         },
       },
     ]);
@@ -105,15 +107,17 @@ it('tracks multiple updates', () => {
   act(() => {
     listener!([
       {
-        contentRect: {
-          x: 1,
-          y: 1,
-          width: 1,
-          height: 1,
-          top: 1,
-          bottom: 1,
-          left: 1,
-          right: 1,
+        target: {
+          getBoundingClientRect: () => ({
+            x: 1,
+            y: 1,
+            width: 1,
+            height: 1,
+            top: 1,
+            bottom: 1,
+            left: 1,
+            right: 1,
+          }),
         },
       },
     ]);
@@ -133,15 +137,17 @@ it('tracks multiple updates', () => {
   act(() => {
     listener!([
       {
-        contentRect: {
-          x: 2,
-          y: 2,
-          width: 2,
-          height: 2,
-          top: 2,
-          bottom: 2,
-          left: 2,
-          right: 2,
+        target: {
+          getBoundingClientRect: () => ({
+            x: 2,
+            y: 2,
+            width: 2,
+            height: 2,
+            top: 2,
+            bottom: 2,
+            left: 2,
+            right: 2,
+          }),
         },
       },
     ]);


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
Fix for [this issue](https://github.com/streamich/react-use/issues/1711)

`x`, `y`, `top` and `left` are always `0` inside `contentRect`

Replace the usage of `ResizeObserverEntry.contentRect`, and retrive values from `ResizeObserverEntry.target.getBoundingClientRect()`
https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
