### PR TITLE
fix(useThrottle): Support function values

### DIFF
--- a/src/useThrottle.ts
+++ b/src/useThrottle.ts
@@ -2,18 +2,18 @@ import { useEffect, useRef, useState } from 'react';
 import useUnmount from './useUnmount';
 
 const useThrottle = <T>(value: T, ms: number = 200) => {
-  const [state, setState] = useState<T>(value);
+  const [state, setState] = useState<T>(() => value);
   const timeout = useRef<ReturnType<typeof setTimeout>>();
   const nextValue = useRef(null) as any;
   const hasNextValue = useRef(0) as any;
 
   useEffect(() => {
     if (!timeout.current) {
-      setState(value);
+      setState(() => value);
       const timeoutCallback = () => {
         if (hasNextValue.current) {
           hasNextValue.current = false;
-          setState(nextValue.current);
+          setState(() => nextValue.current);
           timeout.current = setTimeout(timeoutCallback, ms);
         } else {
           timeout.current = undefined;

--- a/tests/useThrottle.test.ts
+++ b/tests/useThrottle.test.ts
@@ -72,4 +72,25 @@ describe('useThrottle', () => {
     jest.advanceTimersByTime(100);
     expect(hook.result.current).toBe(0);
   });
+
+  it('should handle function values', () => {
+    const fn = () => {};
+    const { result } = renderHook((props) => useThrottle(props, 100), { initialProps: fn });
+    expect(result.current).toBe(fn);
+  });
+
+  it('should handle function value updates', (done) => {
+    const fn = () => {};
+    const hook = renderHook((props) => useThrottle(props, 100), { initialProps: fn });
+    expect(hook.result.current).toBe(fn);
+
+    const newFn = () => {};
+    hook.rerender(newFn);
+    expect(hook.result.current).toBe(fn);
+    hook.waitForNextUpdate().then(() => {
+      expect(hook.result.current).toBe(newFn);
+      done();
+    });
+    jest.advanceTimersByTime(100);
+  });
 });


### PR DESCRIPTION
If the caller passes a function as the value, this invokes the function form of
useState and setState which does not set the state to the value but instead invokes
the function and sets the state to the return value of the function. This causes
useThrottle to behave incorrectly when passing a value which is a function. Rather
than returning the function (as the type signature indicates), useThrottle returns
the return value of the function.

This changes fixes useThrottle to support function values as the value to throttle
to align with the type signature.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

Depending on how you think existing functionality should behave. The type signature indicates that the value passed to useThrottle is the value that is throttled - but existing callers which previously passed a function and rely on the behavior of calling the function to return the value would no longer be getting said behavior.

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure. (yarn lint doesn't run)
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
