### PR TITLE
fix(useThrottle): add type annotation for values which are functions

### DIFF
--- a/src/useThrottle.ts
+++ b/src/useThrottle.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import useUnmount from './useUnmount';
 
-const useThrottle = <T>(value: T, ms: number = 200) => {
+const useThrottle = <T>(value: T | (() => T), ms: number = 200) => {
   const [state, setState] = useState<T>(value);
   const timeout = useRef<ReturnType<typeof setTimeout>>();
   const nextValue = useRef(null) as any;

--- a/tests/useThrottle.test.ts
+++ b/tests/useThrottle.test.ts
@@ -72,4 +72,22 @@ describe('useThrottle', () => {
     jest.advanceTimersByTime(100);
     expect(hook.result.current).toBe(0);
   });
+
+  it('should handle function values', () => {
+    const { result } = renderHook((props) => useThrottle(props, 100), { initialProps: () => 0 });
+    expect(result.current).toBe(0);
+  });
+
+  it('should handle function value updates', (done) => {
+    const hook = renderHook((props) => useThrottle(props, 100), { initialProps: () => 0 });
+    expect(hook.result.current).toBe(0);
+
+    hook.rerender(() => 1);
+    expect(hook.result.current).toBe(0);
+    hook.waitForNextUpdate().then(() => {
+      expect(hook.result.current).toBe(1);
+      done();
+    });
+    jest.advanceTimersByTime(100);
+  });
 });


### PR DESCRIPTION
If the value is a function, it is invoked and the return value of the function
becomes the throttled state. This happens because value is passed directly to
setState which has different behavior for function values.

This change updates the type annotation to correctly reflect the behavior
so users who pass function values get the correct return type (T) from
useThrottle.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure. (yarn lint doesn't run)
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
