### PR TITLE
Fix: call prev function when StateSet has only one item, the value of…

### DIFF
--- a/src/useStateList.ts
+++ b/src/useStateList.ts
@@ -44,8 +44,10 @@ export default function useStateList<T>(stateSet: T[] = []): UseStateListReturn<
         // in case of negative index it will start counting from the right, so -17 will bring us to 4th element
         index.current =
           newIndex >= 0
-            ? newIndex % stateSet.length
-            : stateSet.length + (newIndex % stateSet.length);
+          ? newIndex % stateSet.length
+          : newIndex === -1
+          ? stateSet.length - 1
+          : stateSet.length + (newIndex % stateSet.length);
         update();
       },
       setState: (state: T) => {


### PR DESCRIPTION
# Description

call prev function when StateSet has only one item, the value of currentindex is wrong

### Minimum example

```jsx
import { useStateList } from "react-use";

const list = ["onlyOne"];

export default function App() {
  const { state, prev, next, currentIndex } = useStateList(list);

	// Click prev button,
	// Expectation: currentIndex : 0
	// Results: currentIndex : 1
    
  return (
    <div>
      <button onClick={prev}>prev</button>
      <span> index : {currentIndex} </span>
      <button onClick={next}>next</button>
      <p> state : {state}</p>
    </div>
  );
}
```




## Type of change

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist

- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

