### PR TITLE
docs: remove undeclared state variable of useSlider hook

### DIFF
--- a/docs/useSlider.md
+++ b/docs/useSlider.md
@@ -15,7 +15,7 @@ const Demo = () => {
     <div>
       <div ref={ref} style={{ position: 'relative' }}>
         <p style={{ textAlign: 'center', color: isSliding ? 'red' : 'green' }}>
-          {Math.round(state.value * 100)}%
+          {Math.round(value * 100)}%
         </p>
         <div style={{ position: 'absolute', left: pos }}>🎚</div>
       </div>


### PR DESCRIPTION
# Description

The `useSlider` hook has an undeclared variable `state` that probably is a mistake on that doc.


## Type of change

<!-- Check all relevant options. -->
- [ x ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ x ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review (_does not apply for this change_)
- [ ] Comment the code, particularly in hard-to-understand areas (_does not apply for this change_)
- [ ] Add documentation (_does not apply for this change_)
- [ ] Add hook's story at Storybook (_does not apply for this change_)
- [ ] Cover changes with tests (_does not apply for this change_)
- [ x ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage (_does not apply for this change_)
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure. (_does not apply for this change_)
- [ ] Make sure types are fine (`yarn lint:types`). (_does not apply for this change_)
