### PR TITLE
Make useIntersection options parameter optional

### DIFF
--- a/src/useIntersection.ts
+++ b/src/useIntersection.ts
@@ -2,7 +2,7 @@ import { RefObject, useEffect, useState } from 'react';
 
 const useIntersection = (
   ref: RefObject<HTMLElement>,
-  options: IntersectionObserverInit
+  options?: IntersectionObserverInit
 ): IntersectionObserverEntry | null => {
   const [
     intersectionObserverEntry,
@@ -24,7 +24,7 @@ const useIntersection = (
       };
     }
     return () => {};
-  }, [ref.current, options.threshold, options.root, options.rootMargin]);
+  }, [ref.current, options?.threshold, options?.root, options?.rootMargin]);
 
   return intersectionObserverEntry;
 };


### PR DESCRIPTION
# Description

Per the [IntersectionObserver spec](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver). Defaults to the viewport with no margin and a threshold of 1.

I got tired of having to pass the default options on every invocation.

## Type of change

<!-- Check all relevant options. -->
- [ x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
