### PR TITLE
add callback option to useSetState as this.setState original

### DIFF
--- a/src/useSetState.ts
+++ b/src/useSetState.ts
@@ -1,14 +1,28 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef } from "react";
+import useUpdateEffect from "./useUpdateEffect";
+
+type SetCallback<T> = (state: T) => void;
 
 const useSetState = <T extends object>(
   initialState: T = {} as T
-): [T, (patch: Partial<T> | ((prevState: T) => Partial<T>)) => void] => {
+): [T, (patch: Partial<T> | ((prevState: T) => Partial<T>), callback?: SetCallback<T>) => void] => {
   const [state, set] = useState<T>(initialState);
-  const setState = useCallback((patch) => {
+  let setCallback = useRef<SetCallback<T> | undefined>(undefined);
+  const setState = useCallback((patch, callback?: SetCallback<T>) => {
+    setCallback.current = callback;
     set((prevState) =>
       Object.assign({}, prevState, patch instanceof Function ? patch(prevState) : patch)
     );
   }, []);
+
+  useUpdateEffect(() => {
+    // run callback only on updates
+    if (setCallback.current) {
+      setCallback.current(state);
+      // reset saved callback
+      setCallback.current = undefined;
+    }
+  }, [state]);
 
   return [state, setState];
 };

--- a/tests/useSetState.test.ts
+++ b/tests/useSetState.test.ts
@@ -1,24 +1,24 @@
-import { act, renderHook } from '@testing-library/react-hooks';
-import useSetState from '../src/useSetState';
+import { act, renderHook } from "@testing-library/react-hooks";
+import useSetState from "../src/useSetState";
 
 const setUp = (initialState?: object) => renderHook(() => useSetState(initialState));
 
-it('should init state and setter', () => {
-  const { result } = setUp({ foo: 'bar' });
+it("should init state and setter", () => {
+  const { result } = setUp({ foo: "bar" });
   const [state, setState] = result.current;
 
-  expect(state).toEqual({ foo: 'bar' });
+  expect(state).toEqual({ foo: "bar" });
   expect(setState).toBeInstanceOf(Function);
 });
 
-it('should init empty state if not initial state provided', () => {
+it("should init empty state if not initial state provided", () => {
   const { result } = setUp();
 
   expect(result.current[0]).toEqual({});
 });
 
-it('should merge changes into current state when providing object', () => {
-  const { result } = setUp({ foo: 'bar', count: 1 });
+it("should merge changes into current state when providing object", () => {
+  const { result } = setUp({ foo: "bar", count: 1 });
   const [state, setState] = result.current;
 
   act(() => {
@@ -26,11 +26,11 @@ it('should merge changes into current state when providing object', () => {
     setState({ count: state.count + 1, someBool: true });
   });
 
-  expect(result.current[0]).toEqual({ foo: 'bar', count: 2, someBool: true });
+  expect(result.current[0]).toEqual({ foo: "bar", count: 2, someBool: true });
 });
 
-it('should merge changes into current state when providing function', () => {
-  const { result } = setUp({ foo: 'bar', count: 1 });
+it("should merge changes into current state when providing function", () => {
+  const { result } = setUp({ foo: "bar", count: 1 });
   const [, setState] = result.current;
 
   act(() => {
@@ -38,14 +38,14 @@ it('should merge changes into current state when providing function', () => {
     setState((prevState) => ({ count: prevState.count + 1, someBool: true }));
   });
 
-  expect(result.current[0]).toEqual({ foo: 'bar', count: 2, someBool: true });
+  expect(result.current[0]).toEqual({ foo: "bar", count: 2, someBool: true });
 });
 
 /**
  * Enforces cases where a hook can safely depend on the callback without
  * causing an endless rerender cycle: useEffect(() => setState({ data }), [setState]);
  */
-it('should return a memoized setState callback', () => {
+it("should return a memoized setState callback", () => {
   const { result, rerender } = setUp({ ok: false });
   const [, setState1] = result.current;
 
@@ -57,4 +57,21 @@ it('should return a memoized setState callback', () => {
   const [, setState2] = result.current;
 
   expect(setState1).toBe(setState2);
+});
+
+it("should allow a callback to run after setState", () => {
+  const { result } = setUp({ foo: "bar" });
+  const [, setState] = result.current;
+
+  const callback = jest.fn();
+
+  act(() => {
+    setState({ foo: "bar2" }, callback);
+  });
+  const [state2] = result.current;
+
+  expect(state2).toEqual({ foo: "bar2" });
+
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith(state2);
 });


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [X] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [X] Perform a code self-review
- [X] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [X] Cover changes with tests
- [X] Ensure the test suite passes (`yarn test`)
- [X] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
