### PR TITLE
fix useSlider doc's bug

### DIFF
--- a/docs/useSlider.md
+++ b/docs/useSlider.md
@@ -15,7 +15,7 @@ const Demo = () => {
     <div>
       <div ref={ref} style={{ position: 'relative' }}>
         <p style={{ textAlign: 'center', color: isSliding ? 'red' : 'green' }}>
-          {Math.round(state.value * 100)}%
+          {Math.round(value * 100)}%
         </p>
         <div style={{ position: 'absolute', left: pos }}>🎚</div>
       </div>


### PR DESCRIPTION
The demo didn't had the `state` variable, just `value`
```jsx
import {useSlider} from 'react-use';

const Demo = () => {
  const ref = React.useRef(null);
  const {isSliding, value, pos, length} = useSlider(ref);
  ...
  {Math.round(state.value * 100)}%
};
```

It should be:
```jsx
{Math.round(value * 100)}%
```
