### PR TITLE
feat: add lazy initialization support for useMethods

### DIFF
--- a/docs/useMethods.md
+++ b/docs/useMethods.md
@@ -40,9 +40,12 @@ const Demo = () => {
 
 ## Reference
 
-```js
-const [state, methods] = useMethods(createMethods, initialState);
+```ts
+const [state, methods] = useMethods<M, T>(createMethods: CreateMethods<M, T>, initialState: T);
+const [state, methods] = useMethods<M, T, I>(createMethods: CreateMethods<M, T>, initArg: I, init: (arg: I) => T);
 ```
 
 - `createMethods` &mdash; function that takes current state and return an object containing methods that return updated state.
 - `initialState` &mdash; initial value of the state.
+- `initArg` &mdash; argument passed to `init` to perform lazy initialization
+- `init` &mdash; function which takes `initArg` as argument and returns initial state

--- a/src/useMethods.ts
+++ b/src/useMethods.ts
@@ -1,13 +1,11 @@
-import { Reducer, useMemo, useReducer } from 'react';
+import { Reducer, useRef, useMemo, useReducer } from 'react';
 
 type Action = {
   type: string;
   payload?: any;
 };
 
-type CreateMethods<M, T> = (
-  state: T
-) => {
+type CreateMethods<M, T> = (state: T) => {
   [P in keyof M]: (payload?: any) => T;
 };
 
@@ -15,10 +13,26 @@ type WrappedMethods<M> = {
   [P in keyof M]: (...payload: any) => void;
 };
 
-const useMethods = <M, T>(
+export default function useMethods<M, T>(
   createMethods: CreateMethods<M, T>,
   initialState: T
-): [T, WrappedMethods<M>] => {
+): [T, WrappedMethods<M>];
+export default function useMethods<M, T, I>(
+  createMethods: CreateMethods<M, T>,
+  initArg: I,
+  init: (arg: I) => T
+): [T, WrappedMethods<M>];
+export default function useMethods<M, T, I>(
+  createMethods: CreateMethods<M, T>,
+  initArg: I & T,
+  init: (arg: I & T) => T = (arg) => arg
+): [T, WrappedMethods<M>] {
+  const initArgInner = useRef(initArg);
+  const initInner = useRef(init);
+
+  initArgInner.current = initArg;
+  initInner.current = init;
+
   const reducer = useMemo<Reducer<T, Action>>(
     () => (reducerState: T, action: Action) => {
       return createMethods(reducerState)[action.type](...action.payload);
@@ -26,18 +40,16 @@ const useMethods = <M, T>(
     [createMethods]
   );
 
-  const [state, dispatch] = useReducer<Reducer<T, Action>>(reducer, initialState);
+  const [state, dispatch] = useReducer<Reducer<T, Action>, I>(reducer, initArg, init);
 
   const wrappedMethods: WrappedMethods<M> = useMemo(() => {
-    const actionTypes = Object.keys(createMethods(initialState));
+    const actionTypes = Object.keys(createMethods(initInner.current(initArgInner.current)));
 
     return actionTypes.reduce((acc, type) => {
       acc[type] = (...payload) => dispatch({ type, payload });
       return acc;
     }, {} as WrappedMethods<M>);
-  }, [createMethods, initialState]);
+  }, [createMethods]);
 
   return [state, wrappedMethods];
-};
-
-export default useMethods;
+}

--- a/tests/useMethods.test.ts
+++ b/tests/useMethods.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useMethods } from '../src';
 
-it('should have initialState value as the returned state value', () => {
+it('should init with initialState', () => {
   const initialState = {
     count: 10,
   };
@@ -13,6 +13,20 @@ it('should have initialState value as the returned state value', () => {
   const { result } = renderHook(() => useMethods(createMethods, initialState));
 
   expect(result.current[0]).toEqual(initialState);
+});
+
+it('should init with lazy initialized value', () => {
+  const initArg = 10;
+
+  const init = (initialCount: number) => ({ count: initialCount });
+
+  const createMethods = (state) => ({
+    doStuff: () => state,
+  });
+
+  const { result } = renderHook(() => useMethods(createMethods, initArg, init));
+
+  expect(result.current[0]).toEqual({ count: initArg });
 });
 
 it('should return wrappedMethods object containing all the methods defined in createMethods', () => {
@@ -39,7 +53,7 @@ it('should return wrappedMethods object containing all the methods defined in cr
   }
 });
 
-it('should properly update the state based on the createMethods', () => {
+it('should properly update the state based on the createMethods when initialState provided', () => {
   const count = 10;
   const initialState = {
     count,
@@ -58,6 +72,46 @@ it('should properly update the state based on the createMethods', () => {
   });
 
   const { result } = renderHook(() => useMethods(createMethods, initialState));
+
+  act(() => {
+    result.current[1].increment();
+  });
+  expect(result.current[0].count).toBe(count + 1);
+
+  act(() => {
+    result.current[1].decrement();
+  });
+  expect(result.current[0].count).toBe(count);
+
+  act(() => {
+    result.current[1].decrement();
+  });
+  expect(result.current[0].count).toBe(count - 1);
+
+  act(() => {
+    result.current[1].reset();
+  });
+  expect(result.current[0].count).toBe(count);
+});
+
+it('should properly update the state based on the createMethods when lazy initialized', () => {
+  const count = 10;
+
+  const init = (initialCount: number) => ({ count: initialCount });
+
+  const createMethods = (state) => ({
+    reset() {
+      return init(count);
+    },
+    increment() {
+      return { ...state, count: state.count + 1 };
+    },
+    decrement() {
+      return { ...state, count: state.count - 1 };
+    },
+  });
+
+  const { result } = renderHook(() => useMethods(createMethods, count, init));
 
   act(() => {
     result.current[1].increment();


### PR DESCRIPTION
# Description

Make `useMethods` support `initArg` and `init` to perform lazy initialization like [useReducer does](https://reactjs.org/docs/hooks-reference.html#lazy-initialization)

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
