### PR TITLE
useCopyToClipboard: add mimeType param, default it to text/plain

### DIFF
--- a/docs/useCopyToClipboard.md
+++ b/docs/useCopyToClipboard.md
@@ -24,9 +24,10 @@ const Demo = () => {
 ## Reference
 
 ```js
-const [{value, error, noUserInteraction}, copyToClipboard] = useCopyToClipboard();
+const [{value, error, noUserInteraction}, copyToClipboard] = useCopyToClipboard(mimeType);
 ```
 
+- `mimeType` &mdash; the MIME type of what you want to copy as. Use `text/html` to copy as HTML, `text/plain` to avoid inherited styles showing when pasted into rich text editor. Defaults to `text/plain`
 - `value` &mdash; value that was copied to clipboard, undefined when nothing was copied.
 - `error` &mdash; caught error when trying to copy to clipboard.
 - `noUserInteraction` &mdash; boolean indicating if user interaction was required to copy the value to clipboard to expose full API from underlying [`copy-to-clipboard`](https://github.com/sudodoki/copy-to-clipboard) library.

--- a/src/useCopyToClipboard.ts
+++ b/src/useCopyToClipboard.ts
@@ -9,7 +9,9 @@ export interface CopyToClipboardState {
   error?: Error;
 }
 
-const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] => {
+type mimeType = 'text/html' | 'text/plain'
+
+const useCopyToClipboard = (mimeType: mimeType = 'text/plain'): [CopyToClipboardState, (value: string) => void] => {
   const isMounted = useMountedState();
   const [state, setState] = useSetState<CopyToClipboardState>({
     value: undefined,
@@ -49,7 +51,9 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
         return;
       }
       normalizedValue = value.toString();
-      noUserInteraction = writeText(normalizedValue);
+      noUserInteraction = writeText(normalizedValue, {
+        format: mimeType,
+      });
       setState({
         value: normalizedValue,
         error: undefined,


### PR DESCRIPTION
# Description
When you use the hook to copy a text, it copies as `text/html` (since it is default for `copy-to-clipboard` package). This results in weird rendering in rich text editors, example:
![image](https://user-images.githubusercontent.com/9914480/134730280-3dbf912a-ba77-4294-b661-4858b4873e0b.png)

The value supplied to the method was of type string.

Since almost everyone will be copying plain text using this hook, it makes sense to use `text/plain` as the default value for mimeType.
We can go the other way as well, and set the default to `text/html` but most people will have to supply `text/plain` as a param.
I am actually surprised no one noticed/asked for this before. I assume most people will be using it to copy things like links, emails or plain text. 🤔 

Feel free to correct me if I am wrong with the above assumption.
Looking forward to a review.
Thanks


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
