### PR TITLE
docs: Fix Babel plugin syntax highlighting on `Usage.md`

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -12,23 +12,23 @@ or use ES6 named imports (tree shaking recommended)
 import {useToggle} from 'react-use'
 ```
 
-Depending on your bundler you might run into a missing dependency error with ES6 named import statements. Some hooks require you to install peer dependencies so we recommend using individual imports. If you want the best of both worlds you can transform the named import statements to individual import statements with [`babel-plugin-import`](https://github.com/ant-design/babel-plugin-import) by adding the following config to your `.babelrc` file:
+Depending on your bundler you might run into a missing dependency error with ES6 named import statements. Some hooks require you to install peer dependencies so we recommend using individual imports. If you want the best of both worlds you can transform the named import statements to individual import statements with [`babel-plugin-import`](https://github.com/ant-design/babel-plugin-import) by adding the following config to your `.babelrc.js` file:
 
-```json
+```js
 [
-      'import',
-      {
-        libraryName: 'react-use',
-        camel2DashComponentName: false,
-        customName(/** @type {string} */ name) {
-          const libraryDirectory = name.startsWith('Use')
-            ? 'lib/component'
-            : name.startsWith('create')
-            ? 'lib/factory'
-            : 'lib'
-          return `react-use/${libraryDirectory}/${name}`
-        }
-      },
-      'import-react-use'
-    ]
+  'import',
+  {
+    libraryName: 'react-use',
+    camel2DashComponentName: false,
+    customName(/** @type {string} */ name) {
+      const libraryDirectory = name.startsWith('Use')
+        ? 'lib/component'
+        : name.startsWith('create')
+        ? 'lib/factory'
+        : 'lib'
+      return `react-use/${libraryDirectory}/${name}`
+    }
+  },
+  'import-react-use'
+]
 ```


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

A JavaScript code block was tagged `json` instead of `js`, so GitHub is currently highlighting in red all the parts that violate JSON. This commit changes the language tag (and fixes some spacing), turning this...

```json
[
      'import',
      {
        libraryName: 'react-use',
        camel2DashComponentName: false,
        customName(/** @type {string} */ name) {
          const libraryDirectory = name.startsWith('Use')
            ? 'lib/component'
            : name.startsWith('create')
            ? 'lib/factory'
            : 'lib'
          return `react-use/${libraryDirectory}/${name}`
        }
      },
      'import-react-use'
    ]
```

...into this:

```js
[
  'import',
  {
    libraryName: 'react-use',
    camel2DashComponentName: false,
    customName(/** @type {string} */ name) {
      const libraryDirectory = name.startsWith('Use')
        ? 'lib/component'
        : name.startsWith('create')
        ? 'lib/factory'
        : 'lib'
      return `react-use/${libraryDirectory}/${name}`
    }
  },
  'import-react-use'
]
```

I also changed `.babelrc` to `.babelrc.js` in the preceding file, since on its own, `.babelrc` [is an alias for `.babelrc.json`](https://babeljs.io/docs/en/config-files#supported-file-extensions).

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).~

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
