### PR TITLE
fix: useMedia SSR hydration bug with defaultState

### DIFF
--- a/docs/useMedia.md
+++ b/docs/useMedia.md
@@ -25,3 +25,5 @@ useMedia(query: string, defaultState: boolean = false): boolean;
 ```
 
 The `defaultState` parameter is only used as a fallback for server side rendering.
+
+When server side rendering, it is important to set this parameter because without it the server's initial state will fallback to false, but the client will initialize to the result of the media query. When React hydrates the server render, it may not match the client's state. See the [React docs](https://reactjs.org/docs/react-dom.html#hydrate) for more on why this is can lead to costly bugs 🐛.

--- a/src/useMedia.ts
+++ b/src/useMedia.ts
@@ -1,10 +1,27 @@
 import { useEffect, useState } from 'react';
 import { isBrowser } from './misc/util';
 
-const useMedia = (query: string, defaultState: boolean = false) => {
-  const [state, setState] = useState(
-    isBrowser ? () => window.matchMedia(query).matches : defaultState
-  );
+const getInitialState = (query: string, defaultState?: boolean) => {
+  // Prevent a React hydration mismatch when a default value is provided by not defaulting to window.matchMedia(query).matches.
+  if (defaultState !== undefined) {
+    return defaultState;
+  }
+
+  // If a default value is not provided, and you are rendering on the server, warn of a possible hydration mismatch when defaulting to false.
+  if (!isBrowser) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        '`useMedia` When server side rendering, defaultState should be defined to prevent a hydration mismatches.'
+      );
+    }
+    return false;
+  }
+
+  return window.matchMedia(query).matches;
+};
+
+const useMedia = (query: string, defaultState?: boolean) => {
+  const [state, setState] = useState(getInitialState(query, defaultState));
 
   useEffect(() => {
     let mounted = true;

--- a/src/useMedia.ts
+++ b/src/useMedia.ts
@@ -7,17 +7,18 @@ const getInitialState = (query: string, defaultState?: boolean) => {
     return defaultState;
   }
 
-  // If a default value is not provided, and you are rendering on the server, warn of a possible hydration mismatch when defaulting to false.
-  if (!isBrowser) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        '`useMedia` When server side rendering, defaultState should be defined to prevent a hydration mismatches.'
-      );
-    }
-    return false;
+  if (isBrowser) {
+    return window.matchMedia(query).matches;
+  }
+  
+  // A default value has not been provided, and you are rendering on the server, warn of a possible hydration mismatch when defaulting to false.
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(
+      '`useMedia` When server side rendering, defaultState should be defined to prevent a hydration mismatches.'
+    );
   }
 
-  return window.matchMedia(query).matches;
+  return false;
 };
 
 const useMedia = (query: string, defaultState?: boolean) => {

--- a/tests/useMedia.test.ts
+++ b/tests/useMedia.test.ts
@@ -1,0 +1,42 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { renderHook as renderHookSSR } from '@testing-library/react-hooks/server';
+import { useMedia } from '../src';
+
+const createMockMediaMatcher = (matches: Record<string, boolean>) => (qs: string) => ({
+  matches: matches[qs] ?? false,
+  addListener: () => {},
+  removeListener: () => {},
+});
+
+describe('useMedia', () => {
+  beforeEach(() => {
+    window.matchMedia = createMockMediaMatcher({
+      '(min-width: 500px)': true,
+      '(min-width: 1000px)': false,
+    }) as any;
+  });
+  it('should return true if media query matches', () => {
+    const { result } = renderHook(() => useMedia('(min-width: 500px)'));
+    expect(result.current).toBe(true);
+  });
+  it('should return false if media query does not match', () => {
+    const { result } = renderHook(() => useMedia('(min-width: 1200px)'));
+    expect(result.current).toBe(false);
+  });
+  it('should return default state before hydration', () => {
+    const { result } = renderHookSSR(() => useMedia('(min-width: 500px)', false));
+    expect(result.current).toBe(false);
+  });
+  it('should return media query result after hydration', async () => {
+    const { result, hydrate } = renderHookSSR(() => useMedia('(min-width: 500px)', false));
+    expect(result.current).toBe(false);
+    hydrate();
+    expect(result.current).toBe(true);
+  });
+  it('should return media query result after hydration', async () => {
+    const { result, hydrate } = renderHookSSR(() => useMedia('(min-width: 1200px)', true));
+    expect(result.current).toBe(true);
+    hydrate();
+    expect(result.current).toBe(false);
+  });
+});


### PR DESCRIPTION
Fix server side render hydration mismatch when a default value is provided to useMedia

# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

Before, in pr #464 when server side rendering a component that used useMedia, the server's initial state would initialize to false, but then when React hydrated this on the client, it would initialize to the result of the media query. This caused bug #1885 because When React hydrates the server render, it may not match the client's state. The [React docs](https://reactjs.org/docs/react-dom.html#hydrate) have a little more info on why this can lead to perf issues as well.

## Type of change

<!-- Check all relevant options. -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [X] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [X] Perform a code self-review
- [X] Comment the code, particularly in hard-to-understand areas
- [X] Add documentation
- [ ] Add hook's story at Storybook 
- [X] Cover changes with tests
- [X] Ensure the test suite passes (`yarn test`)
- [X] Provide 100% tests coverage
- [X] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [X] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
