### PR TITLE
fix: enhance createBreakpoint return types

### DIFF
--- a/src/factory/createBreakpoint.ts
+++ b/src/factory/createBreakpoint.ts
@@ -6,36 +6,38 @@ export const defaultBreakpoints = { laptopL: 1440, laptop: 1024, tablet: 768 };
 export type DefaultBreakpoints = typeof defaultBreakpoints;
 export type DefaultBreakpointKeys = keyof DefaultBreakpoints;
 
-export type CreateBreakpointFunction = {
-  (breakpoints: undefined): () => DefaultBreakpointKeys;
-  <T extends BreakpointSelectors>(breakpoints: T): () => keyof T;
-}
+function createBreakpoint(): () => DefaultBreakpointKeys;
+function createBreakpoint<T extends BreakpointSelectors>(breakpoints: T): () => keyof T;
+function createBreakpoint(breakpoints = defaultBreakpoints) {
+  const useBreakpoint = () => {
+    const [screen, setScreen] = useState(isBrowser ? window.innerWidth : 0);
 
-const createBreakpoint: CreateBreakpointFunction = (breakpoints = defaultBreakpoints) => () => {
-  const [screen, setScreen] = useState(isBrowser ? window.innerWidth : 0);
- 
-  useEffect(() => {
-    const setSideScreen = (): void => {
-      setScreen(window.innerWidth);
-    };
-    setSideScreen();
-    on(window, 'resize', setSideScreen);
-    return () => {
-      off(window, 'resize', setSideScreen);
-    };
-  });
-  const sortedBreakpoints = useMemo(
-    () => Object.entries(breakpoints).sort((a, b) => (a[1] >= b[1] ? 1 : -1)),
-    [breakpoints]
-  );
-  const result = sortedBreakpoints.reduce((acc, [name, width]) => {
-    if (screen >= width) {
-      return name;
-    } else {
-      return acc;
-    }
-  }, sortedBreakpoints[0][0]);
-  return result;
-};
+    useEffect(() => {
+      const setSideScreen = (): void => {
+        setScreen(window.innerWidth);
+      };
+      setSideScreen();
+      on(window, 'resize', setSideScreen);
+      return () => {
+        off(window, 'resize', setSideScreen);
+      };
+    });
+    const sortedBreakpoints = useMemo(
+      () => Object.entries(breakpoints).sort((a, b) => (a[1] >= b[1] ? 1 : -1)),
+      [breakpoints]
+    );
+    const result = sortedBreakpoints.reduce((acc, [name, width]) => {
+      if (screen >= width) {
+        return name;
+      } else {
+        return acc;
+      }
+    }, sortedBreakpoints[0][0]);
+
+    return result;
+  };
+
+  return useBreakpoint;
+}
 
 export default createBreakpoint;

--- a/src/factory/createBreakpoint.ts
+++ b/src/factory/createBreakpoint.ts
@@ -1,33 +1,41 @@
 import { useEffect, useMemo, useState } from 'react';
 import { isBrowser, off, on } from '../misc/util';
 
-const createBreakpoint =
-  (breakpoints: { [name: string]: number } = { laptopL: 1440, laptop: 1024, tablet: 768 }) =>
-  () => {
-    const [screen, setScreen] = useState(isBrowser ? window.innerWidth : 0);
+export type BreakpointSelectors = { [name: string]: number };
+export const defaultBreakpoints = { laptopL: 1440, laptop: 1024, tablet: 768 };
+export type DefaultBreakpoints = typeof defaultBreakpoints;
+export type DefaultBreakpointKeys = keyof DefaultBreakpoints;
 
-    useEffect(() => {
-      const setSideScreen = (): void => {
-        setScreen(window.innerWidth);
-      };
-      setSideScreen();
-      on(window, 'resize', setSideScreen);
-      return () => {
-        off(window, 'resize', setSideScreen);
-      };
-    });
-    const sortedBreakpoints = useMemo(
-      () => Object.entries(breakpoints).sort((a, b) => (a[1] >= b[1] ? 1 : -1)),
-      [breakpoints]
-    );
-    const result = sortedBreakpoints.reduce((acc, [name, width]) => {
-      if (screen >= width) {
-        return name;
-      } else {
-        return acc;
-      }
-    }, sortedBreakpoints[0][0]);
-    return result;
-  };
+export type CreateBreakpointFunction = {
+  (breakpoints: undefined): () => DefaultBreakpointKeys;
+  <T extends BreakpointSelectors>(breakpoints: T): () => keyof T;
+}
+
+const createBreakpoint: CreateBreakpointFunction = (breakpoints = defaultBreakpoints) => () => {
+  const [screen, setScreen] = useState(isBrowser ? window.innerWidth : 0);
+ 
+  useEffect(() => {
+    const setSideScreen = (): void => {
+      setScreen(window.innerWidth);
+    };
+    setSideScreen();
+    on(window, 'resize', setSideScreen);
+    return () => {
+      off(window, 'resize', setSideScreen);
+    };
+  });
+  const sortedBreakpoints = useMemo(
+    () => Object.entries(breakpoints).sort((a, b) => (a[1] >= b[1] ? 1 : -1)),
+    [breakpoints]
+  );
+  const result = sortedBreakpoints.reduce((acc, [name, width]) => {
+    if (screen >= width) {
+      return name;
+    } else {
+      return acc;
+    }
+  }, sortedBreakpoints[0][0]);
+  return result;
+};
 
 export default createBreakpoint;


### PR DESCRIPTION
# Description

Before this PR, when using the `createBreakpoint` function with or without a custom breakpoint, it always returns a type `() => string`.

![Screen Shot 2021-11-19 at 12 11 02 PM](https://user-images.githubusercontent.com/6154901/142613428-b82ae70e-02a8-4afb-a5b4-81cb1a6e5c6c.png)
![Screen Shot 2021-11-19 at 12 11 19 PM](https://user-images.githubusercontent.com/6154901/142613431-b9fc505a-4ba0-4a4a-9433-5c6178d2c52e.png)

This commit adds overloaded and mapped types to the `createBreakpoint` function definition that reduces the cardinality of the type results according to the given parameters.

in case no custom breakpoints are given, the keys from the default object are resolved as the return type of the `useBreakpoint` function

![Screen Shot 2021-11-19 at 12 06 54 PM](https://user-images.githubusercontent.com/6154901/142613538-7f702325-f12d-4b99-8d46-b76a1a234eaf.png)
![Screen Shot 2021-11-19 at 12 07 04 PM](https://user-images.githubusercontent.com/6154901/142613540-ae9f9619-6b94-4628-8932-417a9872bb61.png)

This improves the developer experience and safety of applications written with Typescript using this module.

This is not the kind of thing that can be tested using `jest` or the current tooling that is setup in this repository, but if desired, I can set up `tsd` and add a `createBreakpoint.test-d.ts` file with tests to guarantee that this behaviour will not have a regression.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).
