### PR TITLE
Pr/use local storage fix

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -79,7 +79,7 @@ const useLocalStorage = <T>(
         // localStorage can throw. Also JSON.stringify can throw.
       }
     },
-    [key, setState]
+    [deserializer, key, options, state]
   );
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/tests/useLocalStorage.test.ts
+++ b/tests/useLocalStorage.test.ts
@@ -167,6 +167,27 @@ describe(useLocalStorage, () => {
     expect(value!.fizz).toEqual('buzz');
   });
 
+  it("sets localStorage from the function updater multiple times", () => {
+    const { result, rerender } = renderHook(() =>
+      useLocalStorage<{ foo: string; fizz?: string; fizz2?: string }>("foo", { foo: "bar" })
+    );
+
+    let [, setFoo] = result.current;
+    act(() => setFoo((state) => ({ ...state!, fizz: "buzz" })));
+    rerender();
+
+    // set another value in the state to ensure both values remain set
+    [, setFoo] = result.current;
+    act(() => setFoo((state) => ({ ...state!, fizz2: "buzz2" })));
+    rerender();
+
+    const [value] = result.current;
+    console.log({ value });
+    expect(value!.foo).toEqual("bar");
+    expect(value!.fizz2).toEqual("buzz2");
+    expect(value!.fizz).toEqual("buzz");
+  });
+  
   it('rejects nullish or undefined keys', () => {
     const { result } = renderHook(() => useLocalStorage(null as any));
     try {


### PR DESCRIPTION
# Description

The lack of these dependencies in the set function in the useCallback hook on line 59 (especially the lack of the 'state' dependency) was causing incorrect behaviour.

E.g. when the set method is called with a function, it would use an out of date state and would therefore apply the set function to the old state, causing an unexpected result.

Note, the setState dependency was redundant and was removed, see [react docs](https://reactjs.org/docs/hooks-reference.html#usestate):
 _"React guarantees that setState function identity is stable and won’t change on re-renders. This is why it’s safe to omit from the useEffect or useCallback dependency list."_

Also added test to verify that the change worked. The test makes sure that calling setState with a function twice in a row will preserve both the first and second state changes. 

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation **(reason: fixing a bug, intended functionality was already documented)**
- [ ] Add hook's story at Storybook **(reason: fixing a bug, I assume this was already done for this hook)**
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage **(reason: coverage unchanged and was already below 100%)**
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
