### PR TITLE
fix: prevent infinite loop in `useIntersection`

### DIFF
--- a/src/useIntersection.ts
+++ b/src/useIntersection.ts
@@ -22,7 +22,7 @@ const useIntersection = (
       };
     }
     return () => {};
-  }, [ref.current, options.threshold, options.root, options.rootMargin]);
+  }, [ref.current, options.threshold.toString(), options.root, options.rootMargin]);
 
   return intersectionObserverEntry;
 };


### PR DESCRIPTION
# Description
The `threshold` parameter to `useIntersection` is typed as `number | number[]`. Passing an array of number causes an infinite loop, because `threshold` is passed to `useEffect`'s dependencies. Stringifying `threshold` takes care of this issue, with the bonus of making `x` compute to the same as `[x]`.


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
