### PR TITLE
fix: don't return error in catch function

### DIFF
--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -57,8 +57,6 @@ export default function useAsyncFn<T extends FunctionReturningPromise>(
       },
       (error) => {
         isMounted() && callId === lastCallId.current && set({ error, loading: false });
-
-        return error;
       }
     ) as ReturnType<T>;
   }, deps);


### PR DESCRIPTION
return type of the callback function should be `undefined` or ` ReturnType<T>`

# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
