### PR TITLE
useEffectOnce update/fix

### DIFF
--- a/src/useEffectOnce.ts
+++ b/src/useEffectOnce.ts
@@ -1,7 +1,17 @@
-import { EffectCallback, useEffect } from 'react';
+import { EffectCallback, useEffect, useRef } from 'react';
 
 const useEffectOnce = (effect: EffectCallback) => {
-  useEffect(effect, []);
+  const hasExecuted = useRef(false);
+
+  useEffect(() => {
+    if (hasExecuted.current) {
+      return;
+    }
+
+    hasExecuted.current = true;
+    effect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 };
 
 export default useEffectOnce;


### PR DESCRIPTION
Making sure useEffectOnce actually runs only once. Particularly preventing React 18 from rendering twice in development mode.