### PR TITLE
Fix typo in useGetSetState docs

### DIFF
--- a/docs/useGetSetState.md
+++ b/docs/useGetSetState.md
@@ -1,6 +1,6 @@
 # `useGetSetState`
 
-A mix of `useGetSet` and `useGetSetState`.
+A mix of `useGetSet` and `useSetState`.
 
 
 ## Usage


### PR DESCRIPTION
# Description

Fixes a minor typo in the `useGetSetState` docs.

## Type of change

Documentation, not a code change.