### PR TITLE
feat: `useAsync` returns synchronously when given a sync function

### DIFF
--- a/docs/useAsync.md
+++ b/docs/useAsync.md
@@ -1,7 +1,9 @@
 # `useAsync`
 
 React hook that resolves an `async` function or a function that returns
-a promise;
+a promise. 
+
+If the function returns a value synchronously, `useAsync` will also return the value synchronously.
 
 ## Usage
 

--- a/src/useAsync.ts
+++ b/src/useAsync.ts
@@ -1,20 +1,74 @@
-import { DependencyList, useEffect } from 'react';
-import useAsyncFn from './useAsyncFn';
-import { FunctionReturningPromise } from './misc/types';
+import { DependencyList, useEffect, useMemo } from 'react'
+import useAsyncFn, { AsyncState } from './useAsyncFn'
 
-export { AsyncState, AsyncFnReturn } from './useAsyncFn';
+export { AsyncState, AsyncFnReturn } from './useAsyncFn'
 
-export default function useAsync<T extends FunctionReturningPromise>(
-  fn: T,
+function isPromise<T>(obj?: Promise<T> | T): obj is Promise<T> {
+  return (
+    !!obj &&
+    (typeof obj === 'object' || typeof obj === 'function') &&
+    'then' in obj &&
+    typeof obj.then === 'function'
+  )
+}
+
+export default function useAsync<T extends unknown>(
+  fn: () => Promise<T> | T,
   deps: DependencyList = []
-) {
-  const [state, callback] = useAsyncFn(fn, deps, {
-    loading: true,
-  });
+): AsyncState<T> {
+  /** First, run the function on mount & when the deps change: */
+  const result = useMemo(() => {
+    try {
+      return { value: fn() }
+    } catch (error: any) {
+      return { error }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+
+  /** Setup `useAsyncFn` hook incase `fn` is async  */
+  const [asyncState, callback] = useAsyncFn(
+    async () => {
+      /**
+       *  Since we don't want to run `fn` twice,
+       *   we need to pretend that we ran it here.
+       *   That means throwing any errors `fn` threw,
+       *   or returning the value that `fn` returned
+       */
+      if ('error' in result) throw result.error
+
+      return result.value
+    },
+    [result],
+    { loading: true }
+  )
 
   useEffect(() => {
-    callback();
-  }, [callback]);
+    /**
+     * The `useAsyncFn` callback awaits the async `fn` & handles the loading state.
+     *    However, if `fn` is sync, we don't need this, so we only run `callback` if `fn` is async
+     **/
+    if (isPromise(result.value)) {
+      callback()
+    }
+  }, [result, callback])
 
-  return state;
+  /**
+   *  If `fn` is async, then we return the output of `useAsyncFn`
+   */
+  if (isPromise(result.value)) {
+    return asyncState
+  }
+
+  /*
+   *  If `fn` is sync, we return the results of the `useMemo` run.
+   */
+
+  /** Did the function error? */
+  if ('error' in result) {
+    return { loading: false, value: undefined, error: result.error }
+  }
+
+  /** The `fn` ran succesfully & synchronously */
+  return { loading: false, value: result.value }
 }


### PR DESCRIPTION
# Description

Firstly, thanks for the library! It has saved me a ton of time, and also introduced me to a bunch of new ideas.

This changes the behaviour of the `useAsync` when given a sync function. 

Previously, this situation would cause an unnecessary render: first `useAsync` will return `loading: true` & `value: undefined`, and then re-render with `loading: false` & `value: "return value of sync function"`

This changes the behaviour, now `useAsync` will immediately return `loading: false` & `value: "return value of sync function"` when given the sync function.

This is useful for situations where is is not obvious whether an operation will be sync or async; e.g. an API request may be cached  & returns synchronously, or it may not be cached & requires `await`-ing.

While this is a behaviour change, I wouldn't expect it to negatively affect current usage of this hook, so I wouldn't call it a breaking change.


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [X] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [X] Perform a code self-review
- [X] Comment the code, particularly in hard-to-understand areas
- [X] Add documentation
- [ ] Add hook's story at Storybook
- [X] Cover changes with tests
- [X] Ensure the test suite passes (`yarn test`)
- [X] Provide 100% tests coverage
- [X] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [X] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
