### PR TITLE
imported hook name typo fix

### DIFF
--- a/docs/usePinchZoom.md
+++ b/docs/usePinchZoom.md
@@ -5,7 +5,7 @@ React sensor hook that tracks the changes in pointer touch events and detects va
 ## Usage
 
 ```jsx
-import { usePinchZoon } from "react-use";
+import { usePinchZoom } from "react-use";
 
 const Demo = () => {
   const [scale, setState] = useState(1);


### PR DESCRIPTION
# Description

hook name that imported had typo issue, fixed from `usePinchZoon` to `usePinchZoom`
not important but it's a issue anyways


## Type of change

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).