### PR TITLE
fix: `useEnsuredForwardedRef` fix types. `RefForwardingComponent` is …

### DIFF
--- a/docs/useEnsuredForwardedRef.md
+++ b/docs/useEnsuredForwardedRef.md
@@ -4,39 +4,33 @@ React hook to use a ForwardedRef safely.
 
 In some scenarios, you may need to use a _ref_ from inside and outside a component. If that's the case, you should use `React.forwardRef` to pass it through the child component. This is useful when you only want to forward that _ref_ and expose an internal `HTMLelement` to a parent component, for example. However, if you need to manipulate that reference inside a child's lifecycle hook... things get complicated, since you can't always ensure that the _ref_ is being sent by the parent component and if it is not, you will get `undefined` instead of a valid _ref_.
 
-This hook is useful in this specific case, it will __ensure__ that you get a valid reference on the other side.
+This hook is useful in this specific case, it will **ensure** that you get a valid reference on the other side.
 
 ## Usage
 
 ```jsx
-import {ensuredForwardRef} from 'react-use';
+import { ensuredForwardRef } from "react-use";
 
 const Demo = () => {
-  return (
-    <Child />
-  );
+  return <Child />;
 };
 
 const Child = ensuredForwardRef((props, ref) => {
   useEffect(() => {
-    console.log(ref.current.getBoundingClientRect())
-  }, [])
+    console.log(ref.current.getBoundingClientRect());
+  }, []);
 
-  return (
-    <div ref={ref} />
-  );
+  return <div ref={ref} />;
 });
 ```
 
 ## Alternative usage
 
 ```jsx
-import {useEnsuredForwardedRef} from 'react-use';
+import { useEnsuredForwardedRef } from "react-use";
 
 const Demo = () => {
-  return (
-    <Child />
-  );
+  return <Child />;
 };
 
 const Child = React.forwardRef((props, ref) => {
@@ -45,19 +39,17 @@ const Child = React.forwardRef((props, ref) => {
   // ensuredForwardRef will always be a valid reference.
 
   useEffect(() => {
-    console.log(ensuredForwardRef.current.getBoundingClientRect())
-  }, [])
+    console.log(ensuredForwardRef.current.getBoundingClientRect());
+  }, []);
 
-  return (
-    <div ref={ensuredForwardRef} />
-  );
+  return <div ref={ensuredForwardRef} />;
 });
 ```
 
 ## Reference
 
 ```ts
-ensuredForwardRef<T, P = {}>(Component: RefForwardingComponent<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+ensuredForwardRef<T, P = {}>(Component: ForwardRefRenderFunction<T, P>): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
 
 useEnsuredForwardedRef<T>(ref: React.MutableRefObject<T>): React.MutableRefObject<T>;
 ```

--- a/src/useEnsuredForwardedRef.ts
+++ b/src/useEnsuredForwardedRef.ts
@@ -5,10 +5,10 @@ import {
   PropsWithChildren,
   PropsWithoutRef,
   RefAttributes,
-  RefForwardingComponent,
   useEffect,
+  ForwardRefRenderFunction,
   useRef,
-} from 'react';
+} from "react";
 
 export default function useEnsuredForwardedRef<T>(
   forwardedRef: MutableRefObject<T>
@@ -26,7 +26,7 @@ export default function useEnsuredForwardedRef<T>(
 }
 
 export function ensuredForwardRef<T, P = {}>(
-  Component: RefForwardingComponent<T, P>
+  Component: ForwardRefRenderFunction<T, P>
 ): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>> {
   return forwardRef((props: PropsWithChildren<P>, ref) => {
     const ensuredRef = useEnsuredForwardedRef(ref as MutableRefObject<T>);


### PR DESCRIPTION
…not exported from react >= 18, replaced with ForwardRefRenderFunction

# Description
Update code according to React (>= 18), changes. Replace `RefForwardingComponent` with `ForwardRefRenderFunction`
```
   * @deprecated Use ForwardRefRenderFunction. forwardRef doesn't accept a
   *             "real" component.
```


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
