### PR TITLE
feat: wrapping useMouseWheel with useRafState

### DIFF
--- a/src/useMouseWheel.ts
+++ b/src/useMouseWheel.ts
@@ -1,8 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+
+import useRafState from './useRafState';
 import { off, on } from './misc/util';
 
 export default () => {
-  const [mouseWheelScrolled, setMouseWheelScrolled] = useState(0);
+  const [mouseWheelScrolled, setMouseWheelScrolled] = useRafState(0);
   useEffect(() => {
     const updateScroll = (e: MouseWheelEvent) => {
       setMouseWheelScrolled(e.deltaY + mouseWheelScrolled);


### PR DESCRIPTION
# Description
I found `useMouseWheel` is to set State directly on the event handler.
when I refer to the `useScroll`  which  is triggered by the scroll event similar to the wheel event ,
I thought it would show better performance to set a state through `useRafState` like `useScroll`


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
