### PR TITLE
update dependency and lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "screenfull": "^5.1.0",
     "set-harmonic-interval": "^1.0.1",
-    "throttle-debounce": "^3.0.1",
+    "throttle-debounce": "^5.0.0",
     "ts-easing": "^0.2.0",
     "tslib": "^2.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17321,6 +17321,11 @@ throttle-debounce@^3.0.1:
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-3.0.1.tgz#32f94d84dfa894f786c9a1f290e7a645b6a19abb"
   integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
 
+throttle-debounce@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-5.0.0.tgz#a17a4039e82a2ed38a5e7268e4132d6960d41933"
+  integrity sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==
+
 through2@^2.0.0, through2@^2.0.2, through2@~2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"


### PR DESCRIPTION
# Description

`throttle-debounce` was outdated causing duplicated dependencies when throttle-debounce was used in the same project as `react-use`

## Type of change

<!-- Check all relevant options. -->
- [x] Dependency update
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
