### PR TITLE
fix: useMeasure typescript error

### DIFF
--- a/src/useMeasure.ts
+++ b/src/useMeasure.ts
@@ -6,7 +6,7 @@ export type UseMeasureRect = Pick<
   DOMRectReadOnly,
   'x' | 'y' | 'top' | 'left' | 'right' | 'bottom' | 'height' | 'width'
 >;
-export type UseMeasureRef<E extends Element = Element> = (element: E) => void;
+export type UseMeasureRef<E extends Element = Element> = (element: E | null) => void;
 export type UseMeasureResult<E extends Element = Element> = [UseMeasureRef<E>, UseMeasureRect];
 
 const defaultState: UseMeasureRect = {


### PR DESCRIPTION
# Description

useMeasure hook caused typescript errors because the ref function argument could either be an element or null, but the function only accepted an element.

![image](https://user-images.githubusercontent.com/77127514/190287949-683c549b-1539-4654-b873-6124486c68e8.png)


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
