### PR TITLE
Pr/add use input state hook

### DIFF
--- a/docs/useInputState.md
+++ b/docs/useInputState.md
@@ -1,0 +1,28 @@
+# `useInputState`
+
+React state hook that saves the effort of manually mapping the event target value.
+
+## Usage
+
+```jsx
+import {useInputState} from 'react-use';
+
+const Demo = () => {
+  const [name, setName] = useInputState("");
+  return (
+    <label>
+      Name
+      <input value={name} onChange={setName} />;
+    </label>
+  );
+};
+```
+
+
+## Reference
+
+```js
+useInputState(initialState);
+```
+
+- `initialState` &mdash; initial value set for input element &mdash;

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,3 +115,4 @@ export { useFirstMountState } from './useFirstMountState';
 export { default as useSet } from './useSet';
 export { createGlobalState } from './factory/createGlobalState';
 export { useHash } from './useHash';
+export { useInputState } from './useInputState';

--- a/src/useInputState.ts
+++ b/src/useInputState.ts
@@ -1,0 +1,14 @@
+import { useState } from "react";
+
+type EventWithTargetValue = { target: { value: string } };
+const toEventTargetValue = (event: EventWithTargetValue) => {
+  return event.target.value;
+};
+
+export const useInputState = (
+  initialState: string
+): [string, (event: EventWithTargetValue) => void] => {
+  const [state, setState] = useState(initialState);
+  const setStateFromEvent = (event: EventWithTargetValue) => setState(toEventTargetValue(event));
+  return [state, setStateFromEvent];
+};

--- a/src/useInputState.ts
+++ b/src/useInputState.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState } from 'react';
 
 type EventWithTargetValue = { target: { value: string } };
 const toEventTargetValue = (event: EventWithTargetValue) => {

--- a/stories/useInputState.story.tsx
+++ b/stories/useInputState.story.tsx
@@ -1,10 +1,10 @@
-import { storiesOf } from "@storybook/react";
-import * as React from "react";
-import { useInputState } from "../src";
-import ShowDocs from "./util/ShowDocs";
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useInputState } from '../src';
+import ShowDocs from './util/ShowDocs';
 
 const Demo = () => {
-  const [name, setName] = useInputState("");
+  const [name, setName] = useInputState('');
   return (
     <label>
       Name
@@ -13,6 +13,6 @@ const Demo = () => {
   );
 };
 
-storiesOf("State/useInputState", module)
-  .add("Docs", () => <ShowDocs md={require("../docs/useInputState.md")} />)
-  .add("Demo", () => <Demo />);
+storiesOf('State/useInputState', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useInputState.md')} />)
+  .add('Demo', () => <Demo />);

--- a/stories/useInputState.story.tsx
+++ b/stories/useInputState.story.tsx
@@ -1,0 +1,18 @@
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import { useInputState } from "../src";
+import ShowDocs from "./util/ShowDocs";
+
+const Demo = () => {
+  const [name, setName] = useInputState("");
+  return (
+    <label>
+      Name
+      <input value={name} onChange={setName} />;
+    </label>
+  );
+};
+
+storiesOf("State/useInputState", module)
+  .add("Docs", () => <ShowDocs md={require("../docs/useInputState.md")} />)
+  .add("Demo", () => <Demo />);

--- a/tests/useInputState.test.ts
+++ b/tests/useInputState.test.ts
@@ -1,17 +1,17 @@
-import { renderHook } from "@testing-library/react-hooks";
-import { act } from "react-test-renderer";
-import { useInputState } from "../src";
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react-test-renderer';
+import { useInputState } from '../src';
 
-it("should successfully assign the state with event.target.value", () => {
-  const { result } = renderHook(() => useInputState(""));
+it('should successfully assign the state with event.target.value', () => {
+  const { result } = renderHook(() => useInputState(''));
   const fetchState = () => result.current[0];
   const setState = result.current[1];
 
-  const mockEvent = { target: { value: "input value" } };
+  const mockEvent = { target: { value: 'input value' } };
 
   act(() => {
     setState(mockEvent);
   });
-  
+
   expect(fetchState()).toEqual(mockEvent.target.value);
 });

--- a/tests/useInputState.test.ts
+++ b/tests/useInputState.test.ts
@@ -1,0 +1,17 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { act } from "react-test-renderer";
+import { useInputState } from "../src";
+
+it("should successfully assign the state with event.target.value", () => {
+  const { result } = renderHook(() => useInputState(""));
+  const fetchState = () => result.current[0];
+  const setState = result.current[1];
+
+  const mockEvent = { target: { value: "input value" } };
+
+  act(() => {
+    setState(mockEvent);
+  });
+  
+  expect(fetchState()).toEqual(mockEvent.target.value);
+});


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
### Why
Fetching the `event.target.value` is a tiresome job when creating a state with its setter and bind it to a input element.
Like this:

```jsx
const [name, setMyName] = useState()
<input onChange={event => setMyName(event.target.value)}/>
```
### How
This hook simplifies it like:
```jsx
const [name, setMyName] = useInputState()
<input onChange={setMyName}/>
```


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
