### PR TITLE
feat: add clipboard-read & clipboard-write permissions

### DIFF
--- a/src/usePermission.ts
+++ b/src/usePermission.ts
@@ -3,22 +3,22 @@ import { noop, off, on } from './misc/util';
 
 export type IState = PermissionState | '';
 
-interface IPushPermissionDescriptor extends PermissionDescriptor {
+interface IPushPermissionDescriptor {
   name: 'push';
   userVisibleOnly?: boolean;
 }
 
-interface IMidiPermissionDescriptor extends PermissionDescriptor {
+interface IMidiPermissionDescriptor {
   name: 'midi';
   sysex?: boolean;
 }
 
-interface IDevicePermissionDescriptor extends PermissionDescriptor {
+interface IDevicePermissionDescriptor {
   name: 'camera' | 'microphone' | 'speaker';
   deviceId?: string;
 }
 
-interface IClipboardPermissionDescriptor extends PermissionDescriptor {
+interface IClipboardPermissionDescriptor {
   name: 'clipboard-read' | 'clipboard-write';
 }
 
@@ -45,7 +45,7 @@ const usePermission = (permissionDesc: IPermissionDescriptor): IState => {
     };
 
     navigator.permissions
-      .query(permissionDesc)
+      .query(permissionDesc as PermissionDescriptor)
       .then((status) => {
         permissionStatus = status;
         on(permissionStatus, 'change', onChange);

--- a/src/usePermission.ts
+++ b/src/usePermission.ts
@@ -18,11 +18,16 @@ interface IDevicePermissionDescriptor extends PermissionDescriptor {
   deviceId?: string;
 }
 
+interface IClipboardPermissionDescriptor extends PermissionDescriptor {
+  name: 'clipboard-read' | 'clipboard-write';
+}
+
 export type IPermissionDescriptor =
   | PermissionDescriptor
   | IPushPermissionDescriptor
   | IMidiPermissionDescriptor
-  | IDevicePermissionDescriptor;
+  | IDevicePermissionDescriptor
+  | IClipboardPermissionDescriptor;
 
 // const usePermission = <T extends PermissionDescriptor>(permissionDesc: T): IState => {
 const usePermission = (permissionDesc: IPermissionDescriptor): IState => {


### PR DESCRIPTION
# Description

This PR adds `clipboard-read` & `clipboard-write` permissions to `usePermissions` hook.

Check https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API for further information.


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
