### PR TITLE
fix(useSearchParam): fix difference client server

### DIFF
--- a/src/useSearchParam.ts
+++ b/src/useSearchParam.ts
@@ -6,10 +6,12 @@ const getValue = (search: string, param: string) => new URLSearchParams(search).
 export type UseQueryParam = (param: string) => string | null;
 
 const useSearchParam: UseQueryParam = (param) => {
-  const location = window.location;
-  const [value, setValue] = useState<string | null>(() => getValue(location.search, param));
+  const [value, setValue] = useState<string | null>(() => null);
 
   useEffect(() => {
+    const location = window.location;
+    setValue(getValue(location.search, param))
+    
     const onChange = () => {
       setValue(getValue(location.search, param));
     };

--- a/src/useSearchParam.ts
+++ b/src/useSearchParam.ts
@@ -6,7 +6,7 @@ const getValue = (search: string, param: string) => new URLSearchParams(search).
 export type UseQueryParam = (param: string) => string | null;
 
 const useSearchParam: UseQueryParam = (param) => {
-  const [value, setValue] = useState<string | null>(() => null);
+  const [value, setValue] = useState<string | null>(null);
 
   useEffect(() => {
     const location = window.location;


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

Fix difference client / server on useSearchParam hook. 

On SSR useSearchParam return null (it's normal).
But on client side, useSearchParam, return directly value. 
It's not good. This causes a client/server difference.
You must return the value on the client side, only after a "did mount".

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
