### PR TITLE
fix: Call the handler as soon as the event is listened to

### DIFF
--- a/docs/useKeyPressEvent.md
+++ b/docs/useKeyPressEvent.md
@@ -8,8 +8,8 @@ if you press and hold a key, it will fire `keydown` callback only once.
 ## Usage
 
 ```jsx
-import React, { useState } from React;
-import {useKeyPressEvent} from 'react-use';
+import React, { useState } from 'React';
+import { useKeyPressEvent } from 'react-use';
 
 const Demo = () => {
   const [count, setCount] = useState(0);
@@ -39,5 +39,5 @@ const Demo = () => {
 ```js
 useKeyPressEvent('<key>', keydown);
 useKeyPressEvent('<key>', keydown, keyup);
-useKeyPressEvent('<key>', keydown, keyup, useKeyPress);
+useKeyPressEvent('<key>', keydown, keyup, useKey);
 ```

--- a/src/useKeyPressEvent.ts
+++ b/src/useKeyPressEvent.ts
@@ -1,21 +1,13 @@
-import { Handler, KeyFilter } from './useKey';
-import useKeyPressDefault from './useKeyPress';
-import useUpdateEffect from './useUpdateEffect';
+import useKeyDefault, { Handler, KeyFilter } from './useKey';
 
 const useKeyPressEvent = (
-  key: string | KeyFilter,
+  key: KeyFilter,
   keydown?: Handler | null | undefined,
   keyup?: Handler | null | undefined,
-  useKeyPress = useKeyPressDefault
+  useKey = useKeyDefault
 ) => {
-  const [pressed, event] = useKeyPress(key);
-  useUpdateEffect(() => {
-    if (!pressed && keyup) {
-      keyup(event!);
-    } else if (pressed && keydown) {
-      keydown(event!);
-    }
-  }, [pressed]);
+  useKey(key, (event) => keydown?.(event), { event: 'keydown' });
+  useKey(key, (event) => keyup?.(event), { event: 'keyup' });
 };
 
 export default useKeyPressEvent;


### PR DESCRIPTION
useKeyPressEvent previously listened for changes in the state of the key through the useKeyPress hook instead of directly listening for the event itself. Switching the useKeyPress call to useKey and listening directly to the events would resolve this problem, but would slightly change the parameter type.

Closes: #201

BREAKING-CHANGE: Change the last parameter of useKeyPressEvent from `useKeyPress = useKeyPressDefault` to `useKey = useKeyDefault`

# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
