### PR TITLE
feat: Add skip option to useWindowSize

### DIFF
--- a/docs/useWindowSize.md
+++ b/docs/useWindowSize.md
@@ -19,3 +19,14 @@ const Demo = () => {
   );
 };
 ```
+
+## Options
+
+**`initialWidth`**
+Fallback width, used when `window` global is `undefined`. For example, this will be used during a server render.
+
+**`initialHeight`**
+Fallback height, used when `window` global is `undefined`. For example, this will be used during a server render.
+
+**`skip`**
+If `true`, changes to window dimensions will be ignored.

--- a/src/useWindowSize.ts
+++ b/src/useWindowSize.ts
@@ -4,9 +4,9 @@ import useRafState from './useRafState';
 import { isBrowser, off, on } from './misc/util';
 
 interface Options {
-  initialWidth?: number,
-  initialHeight?: number,
-  skip?: boolean,
+  initialWidth?: number;
+  initialHeight?: number;
+  skip?: boolean;
 }
 
 const useWindowSize = ({

--- a/src/useWindowSize.ts
+++ b/src/useWindowSize.ts
@@ -3,14 +3,24 @@ import { useEffect } from 'react';
 import useRafState from './useRafState';
 import { isBrowser, off, on } from './misc/util';
 
-const useWindowSize = (initialWidth = Infinity, initialHeight = Infinity) => {
+interface Options {
+  initialWidth?: number,
+  initialHeight?: number,
+  skip?: boolean,
+}
+
+const useWindowSize = ({
+  initialWidth = Infinity,
+  initialHeight = Infinity,
+  skip = false,
+}: Options = {}) => {
   const [state, setState] = useRafState<{ width: number; height: number }>({
     width: isBrowser ? window.innerWidth : initialWidth,
     height: isBrowser ? window.innerHeight : initialHeight,
   });
 
   useEffect((): (() => void) | void => {
-    if (isBrowser) {
+    if (!skip && isBrowser) {
       const handler = () => {
         setState({
           width: window.innerWidth,
@@ -24,7 +34,7 @@ const useWindowSize = (initialWidth = Infinity, initialHeight = Infinity) => {
         off(window, 'resize', handler);
       };
     }
-  }, []);
+  }, [skip]);
 
   return state;
 };

--- a/tests/useWindowSize.test.tsx
+++ b/tests/useWindowSize.test.tsx
@@ -24,10 +24,7 @@ describe('useWindowSize', () => {
   type Props = Parameters<typeof useWindowSize>[0];
   type Result = ReturnType<typeof useWindowSize>;
   function getHook(opts: Props = {}) {
-    return renderHook<Props, Result>(
-      (opts) => useWindowSize(opts),
-      { initialProps: opts },
-    );
+    return renderHook<Props, Result>((opts) => useWindowSize(opts), { initialProps: opts });
   }
 
   function triggerResize(dimension: 'width' | 'height', value: number) {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

**Summary**
`useWindowSize` now accepts a "skip" option, which will cause it to ignore changes to window dimensions.

**Motivation**
Since hooks cannot be called conditionally, this is required to prevent un-necessary re-renders in components which want to conditionally subscribe to window resize events.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

_The options of `useWindowSize` are now an object, hence this is a breaking change. This can be avoided - happy to refactor accordingly but wanted to get feedback on this feature first._

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [ ] ~Add hook's story at Storybook~
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->

_Unable to check `Add hook's story at Storybook` because story already exists. Happy to add an additional story to cover this use case if needed._
