### PR TITLE
fix: useStateWithHistory properly init history when initialState is a function

### DIFF
--- a/src/useStateWithHistory.ts
+++ b/src/useStateWithHistory.ts
@@ -38,8 +38,8 @@ export function useStateWithHistory<S, I extends S>(
   if (isFirstMount) {
     if (history.current.length) {
       // if last element of history !== initial - push initial to history
-      if (history.current[history.current.length - 1] !== initialState) {
-        history.current.push(initialState as I);
+      if (history.current[history.current.length - 1] !== state) {
+        history.current.push(state as I);
       }
 
       // if initial history bigger that capacity - crop the first elements out
@@ -48,7 +48,7 @@ export function useStateWithHistory<S, I extends S>(
       }
     } else {
       // initiate the history with initial state
-      history.current.push(initialState as I);
+      history.current.push(state as I);
     }
 
     historyPosition.current = history.current.length && history.current.length - 1;

--- a/tests/useStateWithHistory.test.ts
+++ b/tests/useStateWithHistory.test.ts
@@ -70,6 +70,16 @@ describe('useStateWithHistory', () => {
     expect(hook.result.current[0][2].history).toEqual([1, 2, 3, 1]);
   });
 
+  it('should push initial state from fn to initial history if no initial history empty', () => {
+    const hook = getHook(() => 1);
+    expect(hook.result.current[0][2].history).toEqual([1]);
+  });
+
+  it('should push initial state from fn to initial history if last element not equals it', () => {
+    const hook = getHook(() => 4, undefined, [1, 2, 3]);
+    expect(hook.result.current[0][2].history).toEqual([1, 2, 3, 4]);
+  });
+
   it('should crop initial history in case it exceeds capacity', () => {
     const hook = getHook(10, 5, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     expect(hook.result.current[0][2].history).toEqual([6, 7, 8, 9, 10]);


### PR DESCRIPTION
# Description

This PR fixes `useStateWithHistory` when `initialState` is a function and `initialHistory` is not provided.

Currently, the code pushes `initialState` itself onto the history. However, because `initialState` could be a function, this causes a problem when `history.back()` is later called and the state is set to the `initialState` function instead of the correct value!

This PR fixes that by instead pushing `state`, which will either be the initial state _value_ or the result of calling the initial state _function_ (default `useState` behavior. Because this only runs on the first render (via `isFirstMount`), it is guaranteed to be the correct initial state.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
