### PR TITLE
fix: useMedia update deprecated event listener with onchange function

### DIFF
--- a/src/useMedia.ts
+++ b/src/useMedia.ts
@@ -27,19 +27,16 @@ const useMedia = (query: string, defaultState?: boolean) => {
   useEffect(() => {
     let mounted = true;
     const mql = window.matchMedia(query);
-    const onChange = () => {
-      if (!mounted) {
-        return;
-      }
-      setState(!!mql.matches);
+
+    mql.onchange = (e) => {
+      if (!mounted) return;
+      setState(e.matches);
     };
 
-    mql.addListener(onChange);
     setState(mql.matches);
 
     return () => {
       mounted = false;
-      mql.removeListener(onChange);
     };
   }, [query]);
 


### PR DESCRIPTION
# Description

`MediaQueryList.addListener()` method is no longer recommended and has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener). I have replaced it with `onchange` function in `useMedia` hook.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
