### PR TITLE
allow function passed to useObservable

### DIFF
--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -7,9 +7,13 @@ export interface Observable<T> {
   };
 }
 
-function useObservable<T>(observable$: Observable<T>): T | undefined;
-function useObservable<T>(observable$: Observable<T>, initialValue: T): T;
-function useObservable<T>(observable$: Observable<T>, initialValue?: T): T | undefined {
+type TypeOrFnReturnsType<T> = T | (() => T);
+type ObservableOrFn<T> = TypeOrFnReturnsType<Observable<T>>
+
+function useObservable<T>(observableOrFn: ObservableOrFn<T>): T | undefined;
+function useObservable<T>(observableOrFn: ObservableOrFn<T>, initialValue: T): T;
+function useObservable<T>(observableOrFn: ObservableOrFn<T>, initialValue?: T): T | undefined {
+  const [observable$] = useState<Observable<T>>(observableOrFn);
   const [value, update] = useState<T | undefined>(initialValue);
 
   useIsomorphicLayoutEffect(() => {

--- a/tests/useObservable.test.ts
+++ b/tests/useObservable.test.ts
@@ -3,12 +3,19 @@ import { Subject } from 'rxjs';
 import * as useIsomorphicLayoutEffect from '../src/useIsomorphicLayoutEffect';
 import useObservable, { Observable } from '../src/useObservable';
 
-const setUp = (observable: Observable<any>, initialValue?: any) =>
+const setUp = (observable: Observable<any> | (() => Observable<any>), initialValue?: any) =>
   renderHook(() => useObservable(observable, initialValue));
 
 it('should init to initial value provided', () => {
   const subject$ = new Subject();
   const { result } = setUp(subject$, 123);
+
+  expect(result.current).toBe(123);
+});
+
+it('should init to initial value provided, passing function', () => {
+  const subject$ = new Subject();
+  const { result } = setUp(() => subject$, 123);
 
   expect(result.current).toBe(123);
 });
@@ -53,6 +60,26 @@ it('should subscribe to observable only once', () => {
   expect(spy).not.toHaveBeenCalled();
 
   setUp(subject$, 123);
+
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  act(() => {
+    subject$.next('a');
+  });
+
+  act(() => {
+    subject$.next('b');
+  });
+
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+
+it('should subscribe to observable only once, passing function', () => {
+  const subject$ = new Subject();
+  const spy = jest.spyOn(subject$, 'subscribe');
+  expect(spy).not.toHaveBeenCalled();
+
+  setUp(() => subject$, 123);
 
   expect(spy).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
# Description

In response to - https://github.com/elastic/kibana/pull/146638/files#r1035809203

It would be nice to be able to `useObservable(observable$.pipe(...))` without creating a new observable on each render so I'm suggesting supporting `useObservable(() => observable$.pipe(...))`


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
