### PR TITLE
Use useLayoutEffect for useEvent to avoid race conditions

### DIFF
--- a/src/useEvent.ts
+++ b/src/useEvent.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { isBrowser, off, on } from './misc/util';
 
 export interface ListenerType1 {
@@ -38,7 +38,7 @@ const useEvent = <T extends UseEventTarget>(
   target: null | T | Window = defaultTarget,
   options?: UseEventOptions<T>
 ) => {
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!handler) {
       return;
     }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

I believe that using useEffect can lead to race conditions. Since the event is subscribed asynchronously, it can be missed or use an incorrect handler. See also:

* https://stackoverflow.com/questions/68407187/potential-bug-in-official-useinterval-example 
*https://stackoverflow.com/questions/74835264/avoiding-race-conditions-with-react-hooks-and-native-callbacks/74835303#74835303 

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
