### PR TITLE
fix(useMethods): make returned `methods` object reference stable

### DIFF
--- a/src/useMethods.ts
+++ b/src/useMethods.ts
@@ -26,14 +26,20 @@ const useMethods = <M, T>(
 
   const [state, dispatch] = useReducer<Reducer<T, Action>>(reducer, initialState);
 
-  const wrappedMethods: WrappedMethods<M> = useMemo(() => {
-    const actionTypes = Object.keys(createMethods(initialState));
+  const wrappedMethods: WrappedMethods<M> = useMemo(
+    () => {
+      const actionTypes = Object.keys(createMethods(initialState));
 
-    return actionTypes.reduce((acc, type) => {
-      acc[type] = (...payload) => dispatch({ type, payload });
-      return acc;
-    }, {} as WrappedMethods<M>);
-  }, [createMethods, initialState]);
+      return actionTypes.reduce((acc, type) => {
+        acc[type] = (...payload) => dispatch({ type, payload });
+        return acc;
+      }, {} as WrappedMethods<M>);
+    },
+    // Do not track `initialState` as it's supposed to be used only once.
+    // See https://github.com/streamich/react-use/issues/1286
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [createMethods]
+  );
 
   return [state, wrappedMethods];
 };

--- a/tests/useMethods.test.ts
+++ b/tests/useMethods.test.ts
@@ -79,3 +79,28 @@ it('should properly update the state based on the createMethods', () => {
   });
   expect(result.current[0].count).toBe(count);
 });
+
+it('should not update the returned methods reference when initialState changes', () => {
+  const initialState = {
+    count: 10,
+  };
+
+  const createMethods = () => ({
+    reset() {
+      return initialState;
+    },
+  });
+
+  const { result, rerender } = renderHook(
+    ({ initialState }) => useMethods(createMethods, initialState),
+    {
+      initialProps: { initialState },
+    }
+  );
+
+  const [, firstMethodsReference] = result.current;
+  rerender({ initialState: { count: 20 } });
+  const [, methodsReferenceAfterRerender] = result.current;
+
+  expect(firstMethodsReference).toBe(methodsReferenceAfterRerender);
+});


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

Make `useMethods` consistent with both `useState` and `useReducer` by not updating the returned `methods` object reference if `initialState` changes after the initial render:

> The `initialState` argument is the state used during the initial render. In subsequent renders, it is disregarded. 
> 
> — [reactjs.org/docs/hooks-reference.html#lazy-initial-state](https://reactjs.org/docs/hooks-reference.html#lazy-initial-state)

Closes #1286 

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
