### PR TITLE
Update useSlider.md

### DIFF
--- a/docs/useSlider.md
+++ b/docs/useSlider.md
@@ -9,16 +9,12 @@ import {useSlider} from 'react-use';
 
 const Demo = () => {
   const ref = React.useRef(null);
-  const {isSliding, value, pos, length} = useSlider(ref);
+  const {isSliding, value} = useSlider(ref);
 
   return (
-    <div>
-      <div ref={ref} style={{ position: 'relative' }}>
-        <p style={{ textAlign: 'center', color: isSliding ? 'red' : 'green' }}>
-          {Math.round(state.value * 100)}%
-        </p>
-        <div style={{ position: 'absolute', left: pos }}>🎚</div>
-      </div>
+    <div ref={ref} style={{ position: "relative", width: "100%" }}>
+      <p style={{ textAlign: "center", color: isSliding ? "red" : "green" }}>{Math.round(value * 100)}%</p>
+      <div style={{ position: "absolute", left: `${Math.round(value * 100)}%` }}>🎚</div>
     </div>
   );
 };


### PR DESCRIPTION
# Description

The exemple wasn't working properly.
- `useSlider` only returns `isSliding` and `value`.
- `state` was undefined.
- the slider icon wasn't moving, it needed to be used with `value`


## Type of change

- [x] Bug fix _(non-breaking change which fixes an issue)_



