### PR TITLE
Update useEffectOnce to run once in strictmode

### DIFF
--- a/src/useEffectOnce.ts
+++ b/src/useEffectOnce.ts
@@ -1,7 +1,12 @@
-import { EffectCallback, useEffect } from 'react';
+import { EffectCallback, useEffect, useRef } from "react"
 
 const useEffectOnce = (effect: EffectCallback) => {
-  useEffect(effect, []);
-};
+  const runOnce = useRef(false)
+  useEffect(() => {
+    if (runOnce.current) return
+    runOnce.current = true
+    return effect()
+  }, [])
+}
 
-export default useEffectOnce;
+export default useEffectOnce


### PR DESCRIPTION
# Description

In React18 StrictMode, effects without dependents can run multiple times. This ref prevents effect callback to run more than once.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
