### PR TITLE
create `useFakeResources`

### DIFF
--- a/docs/useFakeResources.md
+++ b/docs/useFakeResources.md
@@ -1,0 +1,37 @@
+# useFakeResources Hook
+It takes in an object of `FakeResourcesHookProps` as its parameter, which contains two properties:
+
+* `data`: any: The actual resource that will be displayed after the delay period.
+* `delay`: number: The duration, in milliseconds, for which the fake resource will be displayed.
+Return Value
+
+The `useFakeResources` hook returns an array of three elements:
+
+* `[0]`: The actual resource, once the delay period is over.  
+* `[1]`: A boolean value indicating if the fake resource is still being displayed (true) or if the actual resource is being displayed (false).  
+* `[2]`: A function that can be called to manually trigger the display of the actual resource, bypassing the delay period.  
+
+
+```tsx
+
+import React from 'react';
+import useFakeResources from './useFakeResources';
+
+function ExampleComponent() {
+  const [resource, loading, triggerLoading] = useFakeResources({
+    data: ['item1', 'item2', 'item3'],
+    delay: 2000
+  });
+
+  return (
+    <div>
+      {loading ? <p>Loading...</p> : resource.map((item, index) => (
+        <div key={index}>{item}</div>
+      ))}
+      <button onClick={triggerLoading}>Load Data Now</button>
+    </div>
+  );
+}
+
+
+```

--- a/src/useFakeResources.ts
+++ b/src/useFakeResources.ts
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface FakeResourcesHookProps {
+    data: any;
+    delay: number,
+};
+
+export default function useFakeResources({ data, delay }: FakeResourcesHookProps) {
+
+    const [loading, setIsLoading] = React.useState<boolean>(true);
+
+    React.useEffect(() => {
+        let timeout = setTimeout(() => {
+            setIsLoading(false)
+        }, delay);
+        return () => clearTimeout(timeout);
+    }, []);
+
+    function triggerLoading(): void {
+        setIsLoading(true)
+        setTimeout(() => {
+            setIsLoading(false)
+        }, delay);
+    }
+
+    return [loading ? null : data, loading, triggerLoading]
+}


### PR DESCRIPTION
# Description

The `useFakeResources` hook is a custom React hook that enables the display of fake resources, such as placeholder images or text, for a specified duration before returning the actual resource. 

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
