### PR TITLE
feat: add support for a cleanup function in useInterval

### DIFF
--- a/docs/useInterval.md
+++ b/docs/useInterval.md
@@ -1,6 +1,10 @@
 # `useInterval`
 
-A declarative interval hook based on [Dan Abramov's article on overreacted.io](https://overreacted.io/making-setinterval-declarative-with-react-hooks). The interval can be paused by setting the delay to `null`.
+A declarative interval hook based on [Dan Abramov's article on overreacted.io](https://overreacted.io/making-setinterval-declarative-with-react-hooks).
+
+The interval can be paused by setting the delay to `null`.
+When the delay changes, the interval is reset.
+You may also return a cleanup function from the callback, which is called between intervals and on unmount, much like `useEffect`.
 
 ## Usage
 

--- a/src/useInterval.ts
+++ b/src/useInterval.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react';
 
-const useInterval = (callback: Function, delay?: number | null) => {
-  const savedCallback = useRef<Function>(() => {});
+type Callback = () => VoidFunction | void;
+
+const useInterval = (callback: Callback, delay?: number | null) => {
+  const savedCallback = useRef<Callback>(() => {});
 
   useEffect(() => {
     savedCallback.current = callback;
@@ -9,8 +11,17 @@ const useInterval = (callback: Function, delay?: number | null) => {
 
   useEffect(() => {
     if (delay !== null) {
-      const interval = setInterval(() => savedCallback.current(), delay || 0);
-      return () => clearInterval(interval);
+      let cleanup: VoidFunction | void;
+
+      const interval = setInterval(() => {
+        if (cleanup) cleanup();
+        cleanup = savedCallback.current();
+      }, delay || 0);
+
+      return () => {
+        if (cleanup) cleanup();
+        clearInterval(interval);
+      };
     }
 
     return undefined;

--- a/tests/useInterval.test.ts
+++ b/tests/useInterval.test.ts
@@ -112,3 +112,35 @@ it('should clear pending interval when delay is updated', () => {
   expect(clearInterval).toHaveBeenCalledTimes(1);
   expect(jest.getTimerCount()).toBe(initialTimerCount);
 });
+
+it('should call cleanup function on unmount', () => {
+  const cleanup = jest.fn();
+  const { unmount } = renderHook(() => useInterval(() => cleanup, 200));
+
+  expect(cleanup).not.toHaveBeenCalled();
+  jest.advanceTimersByTime(200);
+  unmount();
+  expect(cleanup).toHaveBeenCalledTimes(1);
+});
+
+it('should not call cleanup function if interval never fires', () => {
+  const cleanup = jest.fn();
+  const { unmount } = renderHook(() => useInterval(() => cleanup, 200));
+
+  expect(cleanup).not.toHaveBeenCalled();
+  unmount();
+  expect(cleanup).not.toHaveBeenCalled();
+});
+
+it('should call cleanup function on each interval', () => {
+  const cleanup = jest.fn();
+  const { unmount } = renderHook(() => useInterval(() => cleanup, 200));
+
+  expect(cleanup).not.toHaveBeenCalled();
+
+  // fast-forward until 5 timers should be executed (that's 4 cleanup calls)
+  jest.advanceTimersToNextTimer(5);
+  expect(cleanup).toHaveBeenCalledTimes(4);
+  unmount();
+  expect(cleanup).toHaveBeenCalledTimes(5);
+});


### PR DESCRIPTION
# Description

This change updates the useInterval hook to allow the callback function to optionally return a cleanup function. The cleanup function, if provided, will be called between intervals and on unmount, much like the cleanup function in useEffect.

This change adds more flexibility to the useInterval hook, allowing users to more easily perform additional cleanup or tear-down logic as needed. This makes it easier to work with async code and event listeners.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [x] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
