### PR TITLE
fix: Keep audio control functions the same between state changes

### DIFF
--- a/tests/useAudio.test.ts
+++ b/tests/useAudio.test.ts
@@ -41,3 +41,25 @@ it('should init audio and utils', () => {
   controls.volume(0.5);
   expect(ref.current.volume).toBe(0.5);
 });
+
+it('should use same controls', () => {
+  global.console.error = jest.fn();
+
+  const MOCK_AUDIO_SRC = 'MOCK_AUDIO_SRC';
+  const MOCK_AUTO_PLAY_STATE = true;
+  const { result, rerender } = setUp(MOCK_AUDIO_SRC, MOCK_AUTO_PLAY_STATE);
+
+  const initialControls = result.current[2];
+
+  rerender();
+  expect(result.all.length).toBe(2);
+
+  const subsequentControls = result.current[2];
+  expect(initialControls).toBe(subsequentControls);
+  expect(initialControls.play).toBe(subsequentControls.play);
+  expect(initialControls.pause).toBe(subsequentControls.pause);
+  expect(initialControls.seek).toBe(subsequentControls.seek);
+  expect(initialControls.volume).toBe(subsequentControls.volume);
+  expect(initialControls.mute).toBe(subsequentControls.mute);
+  expect(initialControls.unmute).toBe(subsequentControls.unmute);
+});


### PR DESCRIPTION
# Description

I ran into this when I tried to call `controls.seek` inside a `useEffect` hook, and since `seek` was constantly changing the `useEffect` hook was constantly firing, leading to a render loop. For the change, I just wrapped all of the controls in `useCallback` so they stay the same between the renders, and then the `controls` object itself is wrapped in a `useMemo` for the same reason. The functions themselves didn't change. I considered doing the same for `state` but `state.duration` is the only real static element, so it didn't seem worth it.


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
