### PR TITLE
feat(useLocalStorage): use initial value when ssr option is passed

### DIFF
--- a/docs/useLocalStorage.md
+++ b/docs/useLocalStorage.md
@@ -32,6 +32,7 @@ useLocalStorage(key, initialValue, {
   serializer: (value: T) => string,
   deserializer: (value: string) => T,
 });
+useLocalStorage(key, { ssr: true });
 ```
 
 - `key` &mdash; `localStorage` key to manage.
@@ -39,3 +40,4 @@ useLocalStorage(key, initialValue, {
 - `raw` &mdash; boolean, if set to `true`, hook will not attempt to JSON serialize stored values.
 - `serializer` &mdash; custom serializer (defaults to `JSON.stringify`)
 - `deserializer` &mdash; custom deserializer (defaults to `JSON.parse`)
+- `ssr` boolean indicates whether to preserve intial value to match server side rendering

--- a/tests/useLocalStorage.test.ts
+++ b/tests/useLocalStorage.test.ts
@@ -29,6 +29,16 @@ describe(useLocalStorage, () => {
     expect(state).toEqual('bar');
   });
 
+  it('prefers initial state when ssr option is passed', () => {
+    localStorage.setItem('foo', '"bar"');
+    const { result } = renderHook(() => useLocalStorage('foo', 'baz', { ssr: true }));
+    const [firstSeenResult] = result.all;
+    if (firstSeenResult instanceof Error) throw firstSeenResult;
+
+    const [firstSeenState] = firstSeenResult;
+    expect(firstSeenState).toEqual('baz');
+  });
+
   it('does not clobber existing localStorage with initialState', () => {
     localStorage.setItem('foo', '"bar"');
     const { result } = renderHook(() => useLocalStorage('foo', 'buzz'));


### PR DESCRIPTION
# Description

This should fix the hydration bug when using useLocalStorage with the solution proposed by @streamich 

Linked issue : https://github.com/streamich/react-use/issues/702

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

