### PR TITLE
onChange to useWindowSize

### DIFF
--- a/src/useWindowSize.ts
+++ b/src/useWindowSize.ts
@@ -3,8 +3,21 @@ import { useEffect } from 'react';
 import useRafState from './useRafState';
 import { isBrowser, off, on } from './misc/util';
 
-const useWindowSize = (initialWidth = Infinity, initialHeight = Infinity) => {
-  const [state, setState] = useRafState<{ width: number; height: number }>({
+export interface Size {
+  height: number;
+  width: number;
+}
+
+export interface Options {
+  initialWidth?: number;
+  initialHeight?: number;
+  onChange?: (size: Size) => void;
+}
+
+const useWindowSize = (options?: Options) => {
+  const { initialHeight = Infinity, initialWidth = Infinity, onChange } = options || {};
+
+  const [state, setState] = useRafState<Size>({
     width: isBrowser ? window.innerWidth : initialWidth,
     height: isBrowser ? window.innerHeight : initialHeight,
   });
@@ -12,9 +25,14 @@ const useWindowSize = (initialWidth = Infinity, initialHeight = Infinity) => {
   useEffect((): (() => void) | void => {
     if (isBrowser) {
       const handler = () => {
-        setState({
-          width: window.innerWidth,
-          height: window.innerHeight,
+        setState(() => {
+          const size = { width: window.innerWidth, height: window.innerHeight };
+
+          if (onChange) {
+            onChange(size);
+          }
+
+          return size;
         });
       };
 

--- a/tests/useWindowSize.test.tsx
+++ b/tests/useWindowSize.test.tsx
@@ -44,7 +44,7 @@ describe('useWindowSize', () => {
   });
 
   it('should use passed parameters as initial values in case of non-browser use', () => {
-    const hook = getHook(1, 1);
+    const hook = getHook({ initialWidth: 1, initialHeight: 1 });
 
     expect(hook.result.current.height).toBe(isBrowser ? window.innerHeight : 1);
     expect(hook.result.current.width).toBe(isBrowser ? window.innerWidth : 1);
@@ -84,5 +84,46 @@ describe('useWindowSize', () => {
     });
 
     expect(hook.result.current.width).toBe(2048);
+  });
+
+  it('should run onChange function on re-render', () => {
+    let testValue = false;
+
+    getHook({
+      onChange: () => {
+        testValue = true;
+      },
+    });
+
+    act(() => {
+      triggerResize('height', 2048);
+      requestAnimationFrame.step();
+    });
+
+    expect(testValue).toBe(true);
+  });
+
+  it('should provide right size value for onChange function', () => {
+    let size = { width: Infinity, height: Infinity };
+
+    const hook = getHook({
+      onChange: ({ width, height }) => {
+        size = { width, height };
+      },
+    });
+
+    act(() => {
+      triggerResize('height', 2048);
+      requestAnimationFrame.step();
+    });
+
+    act(() => {
+      triggerResize('width', 2048);
+      requestAnimationFrame.step();
+    });
+
+    expect(hook.result.current.height).toBe(2048);
+    expect(hook.result.current.width).toBe(2048);
+    expect(size).toEqual(hook.result.current);
   });
 });


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->

This pull request closes #915
It adds an onChange callback parameter, as well as changing the parameters passed to useWindowSize from two numbers (initialWidth, initialHeight) to an object ({ initialWidth, initialHeight, onChange }).

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
