### PR TITLE
fix(useClickAway): Fix click on self in shadowDOM will also trigger a callback

### DIFF
--- a/src/useClickAway.ts
+++ b/src/useClickAway.ts
@@ -1,7 +1,7 @@
-import { RefObject, useEffect, useRef } from 'react';
-import { off, on } from './misc/util';
+import { RefObject, useEffect, useRef } from "react";
+import { off, on } from "./misc/util";
 
-const defaultEvents = ['mousedown', 'touchstart'];
+const defaultEvents = ["mousedown", "touchstart"];
 
 const useClickAway = <E extends Event = Event>(
   ref: RefObject<HTMLElement | null>,
@@ -13,16 +13,33 @@ const useClickAway = <E extends Event = Event>(
     savedCallback.current = onClickAway;
   }, [onClickAway]);
   useEffect(() => {
+    const { current: el } = ref;
+    if (!el) return;
+
+    const rootNode = el.getRootNode();
+    const isInShadow = rootNode instanceof ShadowRoot;
+
+    /**
+     * When events are captured outside the component, events that occur in shadow DOM will target the host element
+     * so additional event listeners need to be added for shadowDom
+     *
+     *  document       shadowDom          target
+     *    |                |                 |
+     *    |- on(document) -|-  on(rootNode) -|
+     */
     const handler = (event) => {
-      const { current: el } = ref;
-      el && !el.contains(event.target) && savedCallback.current(event);
+      !el.contains(event.target) &&
+        event.target.shadowRoot !== rootNode &&
+        savedCallback.current(event);
     };
     for (const eventName of events) {
       on(document, eventName, handler);
+      isInShadow && on(rootNode, eventName, handler);
     }
     return () => {
       for (const eventName of events) {
         off(document, eventName, handler);
+        isInShadow && off(rootNode, eventName, handler);
       }
     };
   }, [events, ref]);

--- a/src/useClickAway.ts
+++ b/src/useClickAway.ts
@@ -1,7 +1,7 @@
-import { RefObject, useEffect, useRef } from "react";
-import { off, on } from "./misc/util";
+import { RefObject, useEffect, useRef } from 'react';
+import { off, on } from './misc/util';
 
-const defaultEvents = ["mousedown", "touchstart"];
+const defaultEvents = ['mousedown', 'touchstart'];
 
 const useClickAway = <E extends Event = Event>(
   ref: RefObject<HTMLElement | null>,


### PR DESCRIPTION
# Description
```html
custom-element
   #shadow-root
      <button ref={buttonRef}>button</button>
   #shadow-root
custom-element
```
```ts
  useClickAway(
     buttonRef,
    (e) => {
      console.log(e.target) // custom-element
    },
    ['click']
  )
```
As shown above, clicking the button in shadowDOM will also incorrectly trigger the callback, because in shadowDOM, the target has been forwarded to :host, that is, custom-element, and events within the shadowDOM are not visible to the outside.
This PR will solve the problem.


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
