### PR TITLE
fix: update useMedia hook to use recommended approach of MDN

### DIFF
--- a/src/useMedia.ts
+++ b/src/useMedia.ts
@@ -34,12 +34,12 @@ const useMedia = (query: string, defaultState?: boolean) => {
       setState(!!mql.matches);
     };
 
-    mql.addListener(onChange);
+    mql.addEventListener('change', onChange);
     setState(mql.matches);
 
     return () => {
       mounted = false;
-      mql.removeListener(onChange);
+      mql.removeEventListener('change', onChange);
     };
   }, [query]);
 

--- a/tests/useMedia.test.ts
+++ b/tests/useMedia.test.ts
@@ -4,8 +4,8 @@ import { useMedia } from '../src';
 
 const createMockMediaMatcher = (matches: Record<string, boolean>) => (qs: string) => ({
   matches: matches[qs] ?? false,
-  addListener: () => {},
-  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
 });
 
 describe('useMedia', () => {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
As of our, `useMedia` hook uses [addListener](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener) which is deprecated. This PR simply updates the current hook to the recommended approach from MDN :) 

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
