### PR TITLE
Issue/2533

### DIFF
--- a/src/useCopyToClipboard.ts
+++ b/src/useCopyToClipboard.ts
@@ -9,7 +9,7 @@ export interface CopyToClipboardState {
   error?: Error;
 }
 
-const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] => {
+const useCopyToClipboard = (): [CopyToClipboardState, (value: string, options?: any) => void] => {
   const isMounted = useMountedState();
   const [state, setState] = useSetState<CopyToClipboardState>({
     value: undefined,
@@ -17,7 +17,7 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
     noUserInteraction: true,
   });
 
-  const copyToClipboard = useCallback((value) => {
+  const copyToClipboard = useCallback((value, options = {}) => {
     if (!isMounted()) {
       return;
     }
@@ -49,7 +49,7 @@ const useCopyToClipboard = (): [CopyToClipboardState, (value: string) => void] =
         return;
       }
       normalizedValue = value.toString();
-      noUserInteraction = writeText(normalizedValue);
+      noUserInteraction = writeText(normalizedValue, options);
       setState({
         value: normalizedValue,
         error: undefined,

--- a/tests/useCopyToClipboard.test.ts
+++ b/tests/useCopyToClipboard.test.ts
@@ -45,7 +45,7 @@ describe('useCopyToClipboard', () => {
     const testValue = 'test';
     const testOptions = {
       debug: true,
-    }
+    };
     let [, copyToClipboard] = hook.result.current;
     act(() => copyToClipboard(testValue, testOptions));
     [, copyToClipboard] = hook.result.current;

--- a/tests/useCopyToClipboard.test.ts
+++ b/tests/useCopyToClipboard.test.ts
@@ -41,6 +41,19 @@ describe('useCopyToClipboard', () => {
     expect(state.error).not.toBeDefined();
   });
 
+  it('should pass given options to copy to clipboard', () => {
+    const testValue = 'test';
+    const testOptions = {
+      debug: true,
+    }
+    let [, copyToClipboard] = hook.result.current;
+    act(() => copyToClipboard(testValue, testOptions));
+    [, copyToClipboard] = hook.result.current;
+
+    expect(writeText).toBeCalled();
+    expect(writeText).toBeCalledWith(testValue, testOptions);
+  });
+
   it('should not call writeText if passed an invalid input and set state', () => {
     let testValue = {}; // invalid value
     let [state, copyToClipboard] = hook.result.current;
@@ -67,7 +80,7 @@ describe('useCopyToClipboard', () => {
     act(() => copyToClipboard(valueToRaiseMockException));
     [state, copyToClipboard] = hook.result.current;
 
-    expect(writeText).toBeCalledWith(valueToRaiseMockException);
+    expect(writeText).toBeCalledWith(valueToRaiseMockException, {});
     expect(state.value).toBe(valueToRaiseMockException);
     expect(state.noUserInteraction).not.toBeDefined();
     expect(state.error).toStrictEqual(new Error(valueToRaiseMockException));


### PR DESCRIPTION
# Description

As per issue #2533, the useCopyToClipboard didn't pass the options field to the copy-to-clipboard npm package (https://www.npmjs.com/package/copy-to-clipboard)


## Type of change

<!-- Check all relevant options. -->
- [ 

- [ x] Bug fix _(non-breaking change which fixes an issue)_

- [x ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x ] Perform a code self-review
- [x ] Comment the code, particularly in hard-to-understand areas
- [ x] Add documentation
- [ x] Add hook's story at Storybook
- [ x] Cover changes with tests
- [x ] Ensure the test suite passes (`yarn test`)
- [ x] Provide 100% tests coverage
- [x ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ x] Make sure types are fine (`yarn lint:types`).

