### PR TITLE
#2540 - implemented safeSet for useLocalStorage

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -15,9 +15,14 @@ const useLocalStorage = <T>(
   key: string,
   initialValue?: T,
   options?: parserOptions<T>
-): [T | undefined, Dispatch<SetStateAction<T | undefined>>, () => void] => {
+): [
+  T | undefined,
+  Dispatch<SetStateAction<T | undefined>>,
+  () => void,
+  Dispatch<SetStateAction<T | undefined>>
+] => {
   if (!isBrowser) {
-    return [initialValue as T, noop, noop];
+    return [initialValue as T, noop, noop, noop];
   }
   if (!key) {
     throw new Error('useLocalStorage key may not be falsy');
@@ -83,6 +88,20 @@ const useLocalStorage = <T>(
   );
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
+  const safeSet: Dispatch<SetStateAction<T | undefined>> = useCallback(
+    (valOrFunc) => {
+      if (localStorage.getItem(key)) {
+        console.warn(
+          `You are attempting to set a key that is already in use, the action has been prevented. To remove this warning, use set`
+        );
+        return;
+      }
+      set(valOrFunc);
+    },
+    [key, setState]
+  );
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const remove = useCallback(() => {
     try {
       localStorage.removeItem(key);
@@ -93,7 +112,7 @@ const useLocalStorage = <T>(
     }
   }, [key, setState]);
 
-  return [state, set, remove];
+  return [state, set, remove, safeSet];
 };
 
 export default useLocalStorage;

--- a/stories/useLocalStorage.story.tsx
+++ b/stories/useLocalStorage.story.tsx
@@ -5,13 +5,19 @@ import ShowDocs from './util/ShowDocs';
 
 const Demo = () => {
   const [value, setValue] = useLocalStorage('hello-key', 'foo');
-  const [removableValue, setRemovableValue, remove] = useLocalStorage('removeable-key');
+  const [removableValue, setRemovableValue, remove, setSafeValue] =
+    useLocalStorage('removeable-key');
 
   return (
     <div>
-      <div>Value: {value}</div>
+      <div>Set Value: {value}</div>
       <button onClick={() => setValue('bar')}>bar</button>
       <button onClick={() => setValue('baz')}>baz</button>
+      <br />
+      <br />
+      <div>Safe Value: {value}</div>
+      <button onClick={() => setSafeValue('bar')}>bar</button>
+      <button onClick={() => setSafeValue('baz')}>baz</button>
       <br />
       <br />
       <div>Removable Value: {removableValue}</div>


### PR DESCRIPTION
# Description

As per issue #2540 I implemented a separate functionality for people who don't want to overwrite items already existing in their localStorage.

safeSet will print out a warning when attempting to use set over an existing value

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
