### PR TITLE
fix: changing loading state issue 

### DIFF
--- a/src/useAsyncFn.ts
+++ b/src/useAsyncFn.ts
@@ -45,9 +45,9 @@ export default function useAsyncFn<T extends FunctionReturningPromise>(
   const callback = useCallback((...args: Parameters<T>): ReturnType<T> => {
     const callId = ++lastCallId.current;
 
-    if (!state.loading) {
-      set((prevState) => ({ ...prevState, loading: true }));
-    }
+    set((prevState) => {
+      return prevState.loading ? prevState : { ...prevState, loading: true };
+    });
 
     return fn(...args).then(
       (value) => {

--- a/tests/useAsyncFn.test.tsx
+++ b/tests/useAsyncFn.test.tsx
@@ -163,4 +163,42 @@ describe('useAsyncFn', () => {
     expect(hook.result.current[0].loading).toBe(false);
     expect(hook.result.current[0].value).toBe('new state');
   });
+
+  it('should change loading state when initial loading is true', async () => {
+    const fetch = async () => 'new state';
+    const initialState = { loading: true, value: 'init state' };
+
+    const hook = renderHook<
+      { fn: () => Promise<string> },
+      [AsyncState<string>, () => Promise<string>]
+    >(({ fn }) => useAsyncFn(fn, [], initialState), {
+      initialProps: { fn: fetch },
+    });
+
+    const [state, callback] = hook.result.current;
+    expect(state.loading).toBe(true);
+    expect(state.value).toBe('init state');
+
+    act(() => {
+      callback();
+    });
+
+    expect(hook.result.current[0].loading).toBe(true);
+    expect(hook.result.current[0].value).toBe('init state');
+
+    await hook.waitForNextUpdate();
+    expect(hook.result.current[0].loading).toBe(false);
+    expect(hook.result.current[0].value).toBe('new state');
+
+    act(() => {
+      callback();
+    });
+
+    expect(hook.result.current[0].loading).toBe(true);
+    expect(hook.result.current[0].value).toBe('new state');
+
+    await hook.waitForNextUpdate();
+    expect(hook.result.current[0].loading).toBe(false);
+    expect(hook.result.current[0].value).toBe('new state');
+  });
 });


### PR DESCRIPTION
# Description

The loading state in useAsyncFn hook is not changing to true when the initial loading state is true since the state is not defined as a dependency in the callback function.


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
