### PR TITLE
fix: fix usePermission to not break on environments without navigator.permissions

### DIFF
--- a/src/usePermission.ts
+++ b/src/usePermission.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { noop, off, on } from './misc/util';
 
-export type IState = PermissionState | '';
+export type IState = PermissionState | 'unavailable' | '';
 
 interface IPushPermissionDescriptor extends PermissionDescriptor {
   name: 'push';
@@ -39,14 +39,18 @@ const usePermission = (permissionDesc: IPermissionDescriptor): IState => {
       setState(() => permissionStatus?.state ?? '');
     };
 
-    navigator.permissions
-      .query(permissionDesc)
-      .then((status) => {
-        permissionStatus = status;
-        on(permissionStatus, 'change', onChange);
-        onChange();
-      })
-      .catch(noop);
+    if ('permissions' in navigator) {
+      navigator.permissions
+        .query(permissionDesc)
+        .then((status) => {
+          permissionStatus = status;
+          on(permissionStatus, 'change', onChange);
+          onChange();
+        })
+        .catch(noop);
+    } else {
+      setState('unavailable');
+    }
 
     return () => {
       permissionStatus && off(permissionStatus, 'change', onChange);


### PR DESCRIPTION
# Description
A breaking error occurs when usePermission hook gets called on an IOS safari with version smaller than 16. 
![image](https://github.com/streamich/react-use/assets/80627536/1ce48ab1-680d-4d55-93e9-af12becefce1)

Since this is a hook, which shouldn't be conditionally called in a component, I thought it would be better to have that condition checked inside the hook, so that it doesn't cause any unexpected breaking errors.

<!-- Please include a summary of the change along with relevant motivation and context. -->

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
