### PR TITLE
fix: useLocalStorage overload for correct undefined behavior

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -11,11 +11,21 @@ type parserOptions<T> =
       deserializer: (value: string) => T;
     };
 
-const useLocalStorage = <T>(
+function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+  options?: parserOptions<T>
+): [T, Dispatch<SetStateAction<T>>, () => void];
+function useLocalStorage<T>(
+  key: string,
+  initialValue?: undefined,
+  options?: parserOptions<T>
+): [T | undefined, Dispatch<SetStateAction<T | undefined>>, () => void];
+function useLocalStorage<T>(
   key: string,
   initialValue?: T,
   options?: parserOptions<T>
-): [T | undefined, Dispatch<SetStateAction<T | undefined>>, () => void] => {
+): [T | undefined, Dispatch<SetStateAction<T | undefined>>, () => void] {
   if (!isBrowser) {
     return [initialValue as T, noop, noop];
   }
@@ -94,6 +104,6 @@ const useLocalStorage = <T>(
   }, [key, setState]);
 
   return [state, set, remove];
-};
+}
 
 export default useLocalStorage;


### PR DESCRIPTION
Fixes #2551

Instead of using a single function which accepts `defaultValue?: T` - which forces a return type of `T | undefined`, use an overload. When a defaultValue is supplied, the useState-like tuple returned uses `T`. When no defaultValue is supplied, it's `T | undefined`.

Runtime usage is exaclty the same, this just improves the types.

[TypeScript playground demo](https://www.typescriptlang.org/play/?ssl=52&ssc=1&pln=52&pc=2#code/JYWwDg9gTgLgBAbwK4GcCmAZCBjAhgGwGUZpcBzNAXzgDMoIQ4ByKNXbGAWlTSYCg+CPnBFwA9GLgATNCAhwINOACMkZYaOwQAdinjJ0WPERJRyVOAF44uAO65g8UJFgAKFmw7d0TAJQaRLV14AG0ADwBdKzgeIwJiUgp3FAY0AGk0AE8mABpEXAAuOABGSn8AuDC4FFwYYBQaYDQUfKLtJBBlNChqCVoHfBQKsIBCatr6xubWuHbO7t7JFCRsbDQ0KSGKoL04EMyo61iceNNzAB4EQtmOrp6APmTUgHkYAAtujOzy0ThM8bqDSaLSubVuCzgAB8YtoZI1tBtxJJ3vU4KitFBWBw8gA3AhINBwPDaFSEpCwtDwxFdPA8ODvbq8FraeRw3BIfAwPiUASCCp9GRyBRKRphAS-GjkjjAHQxQwnEyJNDnAAqjwqvwA1lkinooMBtGQchrRAbHMACAA1fFoAD8RXJcING2Nv1+EDAdR0KHtcDAuCg6Cgz09Mt0qvuFV8RRCKqhMKdCKkeQAIvV-TBsG9zoQ0DBiLU0ABBaU6VXxx2U51Se73PKuXxWe5wHEQYBSCIAbgqku0pZJx2MCTMFAjrhNIm1mV1MH1htdbpEZrqVptRRVC8XHq9ul9-sD3RDO5QEajMY3cDTKAzWZzeYLMGL-YjdbgDabLbbHZ7Up3cswCrDhcarjouk46tUs4GkaE5oto5qrvgBK+husHbmGPpFPuQZHhhp6-NGexxtClZUsml7prUt65vmMCFiWO7liRFJkbW9aNpYzatu2URCGBcCsDASBQCSCDULgzJoDi3QVDy2zeqEkTRIOpxKk8IDpFkuQzKUPyiFUNSAlMILXHMdyLLMEC2NUKxrBsQy-KMAKTMCMxmRCfR6MA+D4DZqzrJs4qaApewHMp8pDmco6gjc8wPOpaCvB8UBfH4QUiP8hkudMMXuT0FYsdWSKQd5vnLP59npcVUgdCA-wfPgYDdPSmRNSgeTAGQLKsBUMCtYS2GHqG3oRtEuDaJkvX9RR15UdmarRAAYr+YZTU1cA0Q+T6MQt1gqgIlBAA) of the bug and the fix.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist

Note: I tested this in my `node_modules` folder and the typescript playground, but I pasted into the GitHub web UI, so I'm hoping that CI will catch any regressions. If anything goes red I'll clone locally and fix.

- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
