### PR TITLE
feat: add new hook: useBroadcastChannel

### DIFF
--- a/docs/useBroadcastChannel.md
+++ b/docs/useBroadcastChannel.md
@@ -1,0 +1,25 @@
+# `useBroadcastChannel`
+
+This is a react hook based on the [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API) interface, used for communication between different tabs of the same origin.
+
+## Usage
+
+```tsx
+import { useBroadcastChannel } from "react-use";
+
+const Demo = () => {
+  const { send, receive, close, isClosed } = useBroadcastChannel({
+    name: 'test-channel',
+  });
+
+  return (
+    <div>
+      <button onClick={() => send(Math.random())}> Send Message </button>
+      <p>Received Message: {receive}</p>
+      <button onClick={() => close()}> Close Channel </button>
+      <p>Channel Closed: {isClosed.toString()}</p>
+    </div>
+  );
+};
+
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,3 +115,4 @@ export { useFirstMountState } from './useFirstMountState';
 export { default as useSet } from './useSet';
 export { createGlobalState } from './factory/createGlobalState';
 export { useHash } from './useHash';
+export { useBroadcastChannel } from './useBroadcastChannel';

--- a/src/useBroadcastChannel.ts
+++ b/src/useBroadcastChannel.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react';
+
+export interface UseBroadcastChannelOptions {
+  name: string;
+}
+
+export function useBroadcastChannel<T>(
+  options: UseBroadcastChannelOptions
+): UseBroadcastChannelReturns<T> {
+  const { name } = options;
+  const channelRef = useRef<BroadcastChannel | null>(null);
+
+  const [error, setError] = useState<Event | null>(null);
+  const [receive, setReceive] = useState<T | null>(null);
+  const [isClosed, setIsClosed] = useState(false);
+
+  if (!(window && 'BroadcastChannel' in window)) {
+    throw new Error('BroadcastChannel is not supported');
+  }
+
+  const send = (data: T | null) => {
+    channelRef.current?.postMessage(data);
+  };
+
+  const close = () => {
+    channelRef.current?.close();
+    setIsClosed(true);
+  };
+
+  useEffect(() => {
+    setError(null);
+    channelRef.current = new BroadcastChannel(name);
+
+    channelRef.current.addEventListener(
+      'message',
+      (event: MessageEvent) => {
+        setReceive(event.data);
+      },
+      { passive: true }
+    );
+
+    channelRef.current.addEventListener(
+      'messageerror',
+      (event: MessageEvent) => {
+        setError(event);
+      },
+      { passive: true }
+    );
+
+    channelRef.current.addEventListener('close', () => {
+      setIsClosed(true);
+    });
+
+    return () => {
+      channelRef.current?.close();
+    };
+  }, [name]);
+
+  return { receive, send, close, error, isClosed, channel: channelRef.current };
+}
+
+export interface UseBroadcastChannelReturns<T> {
+  receive: T | null;
+  send: (data: T | null) => void;
+  close: () => void;
+  error: Event | null;
+  isClosed: boolean;
+  channel: BroadcastChannel | null;
+}

--- a/stories/useBroadcastChannel.story.tsx
+++ b/stories/useBroadcastChannel.story.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Meta, storiesOf } from '@storybook/react';
+import { useBroadcastChannel } from '../src/useBroadcastChannel';
+import ShowDocs from './util/ShowDocs';
+
+export default {
+  title: 'Hooks/useBroadcastChannel',
+  component: () => null,
+} as Meta;
+
+const Demo = () => {
+  const { send, receive, close, isClosed } = useBroadcastChannel({
+    name: 'test-channel',
+  });
+
+  return (
+    <div>
+      <button onClick={() => send(Math.random())}> Send Message </button>
+      <p>Received Message: {receive}</p>
+      <button onClick={() => close()}> Close Channel </button>
+      <p>Channel Closed: {isClosed.toString()}</p>
+    </div>
+  );
+};
+
+storiesOf('Side-effects/useBroadcastChannel', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useBroadcastChannel.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useBroadcastChannel.test.ts
+++ b/tests/useBroadcastChannel.test.ts
@@ -1,0 +1,75 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useBroadcastChannel, UseBroadcastChannelReturns } from '../src/useBroadcastChannel';
+
+class MockBroadcastChannel {
+  private listeners: { [key: string]: (event: MessageEvent) => void } = {};
+
+  addEventListener(eventType: string, listener: (event: MessageEvent) => void) {
+    this.listeners[eventType] = listener;
+  }
+
+  postMessage(data: any) {
+    const event = { data } as MessageEvent;
+    if (this.listeners['message']) {
+      this.listeners['message'](event);
+    }
+  }
+
+  close() {
+    if (this.listeners['close']) {
+      this.listeners['close']({} as MessageEvent);
+    }
+  }
+}
+
+describe('useBroadcastChannel', () => {
+  let mockChannel: MockBroadcastChannel;
+
+  beforeEach(() => {
+    mockChannel = new MockBroadcastChannel();
+
+    (window as any).BroadcastChannel = jest.fn().mockImplementation(() => {
+      return mockChannel;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw an error if BroadcastChannel is not supported', () => {
+    delete (window as any).BroadcastChannel;
+
+    const { result } = renderHook(() => useBroadcastChannel({ name: 'test-channel' }));
+
+    expect(result.error).toEqual(new Error('BroadcastChannel is not supported'));
+  });
+
+  it('should create a BroadcastChannel and receive messages', () => {
+    const mockData = { message: 'Hello' };
+
+    const { result } = renderHook<UseBroadcastChannelReturns<any>, any>(() =>
+      useBroadcastChannel({ name: 'test-channel' })
+    );
+
+    act(() => {
+      const { send } = result.current;
+      send(mockData);
+    });
+
+    expect(result.current.receive).toEqual(mockData);
+  });
+
+  it('should close the channel', () => {
+    const { result } = renderHook<UseBroadcastChannelReturns<any>, any>(() =>
+      useBroadcastChannel({ name: 'test-channel' })
+    );
+
+    act(() => {
+      const { close } = result.current;
+      close();
+    });
+
+    expect(result.current.isClosed).toBe(true);
+  });
+});


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
This PR adds a new React hook: useBroadcastChannel. This hook allows the usage of the Broadcast Channel API in the application to send and receive messages. It can be used for communication within the same browser tab or between different tabs.
This new feature is designed to provide a simple and reliable way to achieve browser communication, meeting the needs of certain scenarios such as synchronizing state across multiple tabs or real-time updates.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
