### PR TITLE
feat: adding restoreOriginalOnUnmount to useTitle 

### DIFF
--- a/src/useTitle.ts
+++ b/src/useTitle.ts
@@ -2,26 +2,37 @@ import { useEffect, useRef } from 'react';
 
 export interface UseTitleOptions {
   restoreOnUnmount?: boolean;
+  restoreOriginalOnUnmount?: boolean;
 }
 
 const DEFAULT_USE_TITLE_OPTIONS: UseTitleOptions = {
   restoreOnUnmount: false,
+  restoreOriginalOnUnmount: false,
 };
 
 function useTitle(title: string, options: UseTitleOptions = DEFAULT_USE_TITLE_OPTIONS) {
   const prevTitleRef = useRef(document.title);
-
+  const originalRender = useRef(true);
+  
   if (document.title !== title) document.title = title;
 
   useEffect(() => {
-    if (options && options.restoreOnUnmount) {
-      return () => {
-        document.title = prevTitleRef.current;
-      };
-    } else {
-      return;
+    if (options) {
+      if (options.restoreOnUnmount) {
+        return () => {
+          document.title = prevTitleRef.current;
+        };
+      } else if (options.restoreOriginalOnUnmount) {
+        return () => {
+          document.title = originalTitle;
+        }
+      } else {
+        return;
+      }
     }
-  }, []);
+
+    return;
+  }, [title]);
 }
 
 export default typeof document !== 'undefined' ? useTitle : (_title: string) => {};

--- a/src/useTitle.ts
+++ b/src/useTitle.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 export interface UseTitleOptions {
   restoreOnUnmount?: boolean;
@@ -12,27 +12,24 @@ const DEFAULT_USE_TITLE_OPTIONS: UseTitleOptions = {
 
 function useTitle(title: string, options: UseTitleOptions = DEFAULT_USE_TITLE_OPTIONS) {
   const prevTitleRef = useRef(document.title);
-  const originalRender = useRef(true);
-  
+  const originalTitle = useMemo(() => document.title, []);
+
   if (document.title !== title) document.title = title;
 
   useEffect(() => {
-    if (options) {
-      if (options.restoreOnUnmount) {
-        return () => {
-          document.title = prevTitleRef.current;
-        };
-      } else if (options.restoreOriginalOnUnmount) {
-        return () => {
-          document.title = originalTitle;
-        }
-      } else {
-        return;
+    
+    if (options && options.restoreOnUnmount && !options.restoreOriginalOnUnmount) {
+      return () => {
+        document.title = prevTitleRef.current;
+      };
+    } else if (options && options.restoreOriginalOnUnmount && !options.restoreOnUnmount) {
+      return () => {
+        document.title = originalTitle;
       }
+    } else {
+      return;
     }
-
-    return;
-  }, [title]);
+  }, []);
 }
 
 export default typeof document !== 'undefined' ? useTitle : (_title: string) => {};

--- a/tests/useTitle.test.ts
+++ b/tests/useTitle.test.ts
@@ -34,7 +34,7 @@ describe('useTitle', () => {
       initialProps: { title: 'New title', restore: true },
     });
 
-    hook.rerender({ title: 'Newer title', 'restore': true });
+    hook.rerender({ title: 'Newer title', restore: true });
 
     expect(document.title).toBe('Newer title');
     hook.unmount();

--- a/tests/useTitle.test.ts
+++ b/tests/useTitle.test.ts
@@ -25,4 +25,19 @@ describe('useTitle', () => {
     hook.unmount();
     expect(document.title).toBe('Old Title');
   });
+
+  it('should restore original document title on unmount', () => {
+    renderHook((props) => useTitle(props), { initialProps: 'Original title' });
+    expect(document.title).toBe('Original title');
+
+    const hook = renderHook((props) => useTitle(props.title, { restoreOnUnmount: false, restoreOriginalOnUnmount: props.restore }), {
+      initialProps: { title: 'New title', restore: true },
+    });
+
+    hook.rerender({ title: 'Newer title', 'restore': true });
+
+    expect(document.title).toBe('Newer title');
+    hook.unmount();
+    expect(document.title).toBe('Original title');
+  })
 });


### PR DESCRIPTION
# Description

New option added to the UseTitleOptions interface that will restore the first title passed into useTitle, as requested in issue #2561. I used useMemo to memoize it, I also added one test case to make sure it would pass. One issue that I need help with is determining what to do if both restoreOnUnmount and restoreOriginalOnUnmount are both true at the same time. I'm not sure how that should be handled.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ x ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ x ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ x ] Perform a code self-review
- [ x ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ x ] Cover changes with tests
- [ x ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ x ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ x ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
