### PR TITLE
Set value on adding setter

### DIFF
--- a/src/factory/createGlobalState.ts
+++ b/src/factory/createGlobalState.ts
@@ -35,6 +35,7 @@ export function createGlobalState<S>(initialState?: S) {
     useIsomorphicLayoutEffect(() => {
       if (!store.setters.includes(stateSetter)) {
         store.setters.push(stateSetter);
+        storeSetter(store.state);
       }
     });
 

--- a/tests/createGlobalState.test.tsx
+++ b/tests/createGlobalState.test.tsx
@@ -1,5 +1,6 @@
-import { act, renderHook } from '@testing-library/react-hooks';
-import createGlobalState from '../src/factory/createGlobalState';
+import { act, renderHook, render } from '@testing-library/react';
+import React from 'react';
+import createGlobalState from 'src/hooks/createGlobalState';
 
 describe('useGlobalState', () => {
   it('should be defined', () => {
@@ -69,6 +70,23 @@ describe('useGlobalState', () => {
       // @ts-expect-error this case it checks correctly, hence the comment
       result1.current[1]((value) => 1);
     });
+  });
+
+  it('should set ref correctly', async () => {
+    const useGlobalValue = createGlobalState<Element>();
+    const CheckComponent = ({ stateValue1 }) => {
+      const [stateValue2] = useGlobalValue();
+      return <>{String(stateValue2 !== undefined && stateValue2 === stateValue1)}</>;
+    };
+
+    const WrapperComponent = () => {
+      const [stateValue, setStateValue] = useGlobalValue();
+      return <div ref={setStateValue}>
+        <CheckComponent stateValue1={stateValue} />
+      </div>;
+    };
+    const { findByText } = render(<WrapperComponent />);
+    expect(await findByText('true')).toBeDefined();
   });
 
   it('initializes with function', () => {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
I found the issue with alike code I added as a test where while we used single global state we get different values in different components setting state as a ref. 
So there is a tiny time period when we already initialised both states with default state values (undefined), then added one setter, call global setter (with all setters added) and only then added another setter, forever remembering the initial state for that particular instance of global state.
So I added additional state update to the place we adding the setter to update it with actual global state.


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
