### PR TITLE
fix: fixed useStateWithHistory issue with history state being a function after running history.back

### DIFF
--- a/src/useStateWithHistory.ts
+++ b/src/useStateWithHistory.ts
@@ -30,7 +30,8 @@ export function useStateWithHistory<S, I extends S>(
   }
 
   const isFirstMount = useFirstMountState();
-  const [state, innerSetState] = useState<S>(initialState as S);
+  const [state, innerSetState] = useState<S>(resolveHookState(initialState) as S);
+
   const history = useRef<S[]>((initialHistory ?? []) as S[]);
   const historyPosition = useRef(0);
 
@@ -38,8 +39,8 @@ export function useStateWithHistory<S, I extends S>(
   if (isFirstMount) {
     if (history.current.length) {
       // if last element of history !== initial - push initial to history
-      if (history.current[history.current.length - 1] !== initialState) {
-        history.current.push(initialState as I);
+      if (history.current[history.current.length - 1] !== state) {
+        history.current.push(state as I);
       }
 
       // if initial history bigger that capacity - crop the first elements out
@@ -48,7 +49,7 @@ export function useStateWithHistory<S, I extends S>(
       }
     } else {
       // initiate the history with initial state
-      history.current.push(initialState as I);
+      history.current.push(state);
     }
 
     historyPosition.current = history.current.length && history.current.length - 1;

--- a/tests/useStateWithHistory.test.ts
+++ b/tests/useStateWithHistory.test.ts
@@ -172,6 +172,12 @@ describe('useStateWithHistory', () => {
       });
       expect(hook.result.current[0][0]).toBe(1);
     });
+
+    it('should not contain function as initial state', () => {
+      let hook = getHook(() => 1, 3);
+
+      expect(hook.result.current[0][2].history[0]).toEqual(1);
+    });
   });
 
   describe('history.forward()', () => {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
useStateWithHistory had an issue when the initialState is a function.
The back function breaks due to the history's first value remaining as a function. 

I fixed this so the resolved value to be stored in history. 

fixes #2568

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->


