### PR TITLE
feat(useMediatedState): add support for initializer and updater functions

### DIFF
--- a/docs/useMediatedState.md
+++ b/docs/useMediatedState.md
@@ -29,11 +29,11 @@ const Demo = () => {
 ```ts
 const [state, setState] = useMediatedState<S=any>(
   mediator: StateMediator<S>,
-  initialState?: S
+  initialState?: S | (() => S)
 );
 ```
 
 > Initial state will be set as-is.
 
 In case mediator expects 2 arguments it will receive the `setState` function as second argument, it is useful for async mediators.  
->This hook will not cancel previous mediation when new one been invoked, you have to handle it yourself._
+>This hook will not cancel previous mediation when new one been invoked, you have to handle it yourself.

--- a/tests/useMediatedState.test.ts
+++ b/tests/useMediatedState.test.ts
@@ -9,7 +9,7 @@ describe('useMediatedState', () => {
   });
 
   function getHook(
-    initialState: number = 2,
+    initialState: number | (() => number) = 2,
     fn: StateMediator<number> = jest.fn((newState) => newState / 2)
   ): [jest.Mock | StateMediator, RenderHookResult<any, UseMediatedStateReturn<number>>] {
     return [fn, renderHook(() => useMediatedState<number>(fn, initialState))];
@@ -64,5 +64,22 @@ describe('useMediatedState', () => {
 
     act(() => hook.result.current[1](3));
     expect(hook.result.current[0]).toBe(6);
+  });
+
+  it('should resolve initial state defined as initializer function', () => {
+    const [spy, hook] = getHook(() => 2);
+
+    expect(hook.result.current[0]).toBe(2);
+    expect(spy).toHaveBeenCalledTimes(0);
+  });
+
+  it('setState should execute updater function and pass the result to mediator', () => {
+    const [spy, hook] = getHook();
+    const [, setState] = hook.result.current;
+
+    act(() => setState((prev) => prev + 4));
+    expect(hook.result.current[0]).toBe(3);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenLastCalledWith(6);
   });
 });


### PR DESCRIPTION
# Description

The `useMediatedState` hook mimics the React `useState` hook’s return value, which means that `setState` expects either a _value_ or an _updater function_.

This creates a problem as the mediator function receives both _values_ and _functions_, which is unintuitive and inconvenient.

This PR addresses the issue by ensuring that if `setState` is given an updater function, the hook will first execute this function to compute the new state. It will then pass the resulting value to the mediator. Additionally, initializer functions are now supported for improved flexibility.


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).
