### PR TITLE
feat: add useScrollHeight hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
   - [`usePageLeave`](./docs/usePageLeave.md) &mdash; triggers when mouse leaves page boundaries.
   - [`useScratch`](./docs/useScratch.md) &mdash; tracks mouse click-and-scrub state.
   - [`useScroll`](./docs/useScroll.md) &mdash; tracks an HTML element's scroll position. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/sensors-usescroll--docs)
+  - [`useScrollHeight`](./docs/useScrollHeight.md) &mdash; tracks and return scroll height of a given block. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/sensors-usescrollheight--docs)
   - [`useScrolling`](./docs/useScrolling.md) &mdash; tracks whether HTML element is scrolling.
   - [`useStartTyping`](./docs/useStartTyping.md) &mdash; detects when user starts typing.
   - [`useWindowScroll`](./docs/useWindowScroll.md) &mdash; tracks `Window` scroll position. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/sensors-usewindowscroll--docs)

--- a/docs/useScrollHeight.md
+++ b/docs/useScrollHeight.md
@@ -1,0 +1,24 @@
+# `useScrollHeight`
+
+Hook that returns the actual scroll height of a given block.
+
+## Usage
+
+```jsx
+const Demo = () => {
+  const elRef = React.useRef(null);
+  const scrollHeight = useScrollHeight(elRef);
+
+  return (
+    <div>
+      {scrollHeight === 0 ? `Element has no scroll height` : `Element's scroll height is ${scrollHeight}px`}
+    </div>
+  );
+};
+```
+
+## Reference
+
+```typescript
+const scrollHeight: number = useScrollHeight(ref: React.RefObject<HTMLElement> | null);
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,3 +115,4 @@ export { useFirstMountState } from './useFirstMountState';
 export { default as useSet } from './useSet';
 export { createGlobalState } from './factory/createGlobalState';
 export { useHash } from './useHash';
+export { useScrollHeight } from './useScrollHeight';

--- a/src/useScrollHeight.ts
+++ b/src/useScrollHeight.ts
@@ -1,0 +1,19 @@
+import { RefObject, useEffect, useState } from 'react';
+
+export const useScrollHeight = (ref: RefObject<HTMLElement>): number => {
+  const [scrollHeight, setScrollHeight] = useState<number>(0);
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    setScrollHeight(ref.current.scrollHeight);
+    const observer = new MutationObserver(() => {
+      ref.current && setScrollHeight(ref.current.scrollHeight);
+    });
+
+    observer.observe(ref.current, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return scrollHeight;
+};

--- a/stories/useScrollHeight.story.tsx
+++ b/stories/useScrollHeight.story.tsx
@@ -1,0 +1,49 @@
+import { storiesOf } from '@storybook/react';
+import { useScrollHeight } from '../src';
+import React, { useEffect } from 'react';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const elRef = React.useRef<HTMLDivElement>(null);
+  const scrollHeight = useScrollHeight(elRef);
+
+  const [renderElements, setRenderElements] = React.useState<number[]>([]);
+  useEffect(() => {
+    for (let i = 0; i < 5; i++) {
+      setTimeout(() => {
+        setRenderElements((prev) => [...prev, i]);
+      }, i * 3000);
+    }
+  }, []);
+
+  return (
+    <div
+      ref={elRef}
+      style={{
+        height: '200px',
+        width: '200px',
+        overflow: 'auto',
+        border: '1px solid black',
+      }}>
+      <strong
+        style={{
+          position: 'sticky',
+          top: 0,
+          background: 'white',
+        }}>
+        ScrollHeight: {scrollHeight}
+      </strong>
+      {renderElements.map((el) => (
+        <div
+          style={{ height: '50px', width: '200px', background: 'red', marginTop: '20px' }}
+          key={el}>
+          {el}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+storiesOf('Sensors/useScrollHeight', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useScrollHeight.md')} />)
+  .add('Demo', () => <Demo />);


### PR DESCRIPTION
# Description

The useScrollHeight hook takes a RefObject<HTMLElement> as an argument and returns the current scroll height of the referenced HTML element. 

The motivation behind creating this custom hook is likely to provide a way to dynamically track the scroll height of an HTML element, which can be useful in various scenarios such as:
- Updating the layout or styling of an element based on its scroll height
- Monitoring the scroll height of a container element to trigger certain actions

The context in which this hook might be used is likely in a React application where the scroll height of an element needs to be tracked and updated in real-time (For example, in chats, where you will always need to show the last message)

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
