### PR TITLE
fix: useSize eslint fix

### DIFF
--- a/src/useSize.tsx
+++ b/src/useSize.tsx
@@ -16,41 +16,9 @@ const useSize = (
   element: Element,
   { width = Infinity, height = Infinity }: Partial<State> = {}
 ): [React.ReactElement<any>, State] => {
-  if (!isBrowser) {
-    return [
-      typeof element === 'function' ? element({ width, height }) : element,
-      { width, height },
-    ];
-  }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const [state, setState] = useState<State>({ width, height });
-
-  if (typeof element === 'function') {
-    element = element(state);
-  }
-
-  const style = element.props.style || {};
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const ref = useRef<HTMLIFrameElement | null>(null);
-  let window: Window | null = null;
-  const setSize = () => {
-    const iframe = ref.current;
-    const size = iframe
-      ? {
-          width: iframe.offsetWidth,
-          height: iframe.offsetHeight,
-        }
-      : { width, height };
 
-    setState(size);
-  };
-  const onWindow = (windowToListenOn: Window) => {
-    on(windowToListenOn, 'resize', setSize);
-    DRAF(setSize);
-  };
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     const iframe: HTMLIFrameElement | null = ref.current;
 
@@ -78,6 +46,35 @@ const useSize = (
       }
     };
   }, []);
+
+  if (!isBrowser) {
+    return [
+      typeof element === 'function' ? element({ width, height }) : element,
+      { width, height },
+    ];
+  }
+
+  if (typeof element === 'function') {
+    element = element(state);
+  }
+
+  const style = element.props.style || {};
+  let window: Window | null = null;
+  const setSize = () => {
+    const iframe = ref.current;
+    const size = iframe
+      ? {
+          width: iframe.offsetWidth,
+          height: iframe.offsetHeight,
+        }
+      : { width, height };
+
+    setState(size);
+  };
+  const onWindow = (windowToListenOn: Window) => {
+    on(windowToListenOn, 'resize', setSize);
+    DRAF(setSize);
+  };
 
   style.position = 'relative';
 


### PR DESCRIPTION
# Description

Fixes /* eslint-disable */ for useSize` per https://github.com/streamich/react-use/issues/947

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
