### PR TITLE
feat: useLanguage sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
   - [`useIdle`](./docs/useIdle.md) &mdash; tracks whether user is being inactive.
   - [`useIntersection`](./docs/useIntersection.md) &mdash; tracks an HTML element's intersection. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/sensors-useintersection--demo)
   - [`useKey`](./docs/useKey.md), [`useKeyPress`](./docs/useKeyPress.md), [`useKeyboardJs`](./docs/useKeyboardJs.md), and [`useKeyPressEvent`](./docs/useKeyPressEvent.md) &mdash; track keys. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/sensors-usekeypressevent--demo)
+  - [`useLanguage`](./docs/useLanguage.md) &mdash; tracks the language of the document.
   - [`useLocation`](./docs/useLocation.md) and [`useSearchParam`](./docs/useSearchParam.md) &mdash; tracks page navigation bar location state.
   - [`useLongPress`](./docs/useLongPress.md) &mdash; tracks long press gesture of some element.
   - [`useMedia`](./docs/useMedia.md) &mdash; tracks state of a CSS media query. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/sensors-usemedia--demo)

--- a/docs/useLanguage.md
+++ b/docs/useLanguage.md
@@ -1,0 +1,26 @@
+# `useLanguage`
+
+React state hook that tracks the document's `lang` attribute.
+
+## Usage
+
+```jsx
+import { useLanguage } from 'react-use';
+
+const Demo = () => {
+  const [lang, setLang] = useLanguage();
+
+  return (
+    <div>
+      <div>
+        The document's current language is: {lang}
+      </div>
+
+      <br />
+
+      <button onClick={() => setLang("en-US") }>Change to US English</button>
+      <button onClick={() => setLang("es") }>Cambiar a español</button>
+    </div>
+  );
+};
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export { default as createBreakpoint } from './factory/createBreakpoint';
 // export { default as useKeyboardJs } from './useKeyboardJs';
 export { default as useKeyPress } from './useKeyPress';
 export { default as useKeyPressEvent } from './useKeyPressEvent';
+export { default as useLanguage } from './useLanguage';
 export { default as useLatest } from './useLatest';
 export { default as useLifecycles } from './useLifecycles';
 export { default as useList } from './useList';

--- a/src/misc/util.ts
+++ b/src/misc/util.ts
@@ -21,3 +21,5 @@ export function off<T extends Window | Document | HTMLElement | EventTarget>(
 export const isBrowser = typeof window !== 'undefined';
 
 export const isNavigator = typeof navigator !== 'undefined';
+
+export const isDocument = typeof document !== 'undefined';

--- a/src/useLanguage.ts
+++ b/src/useLanguage.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState, Dispatch, SetStateAction } from 'react';
+import { isDocument } from './misc/util';
+
+function useLanguage() {
+  const [lang, setLangState] = useState<string>(document.documentElement.lang);
+
+  const setLang: Dispatch<SetStateAction<string>> = (action) => {
+    if (typeof action === 'function') {
+      document.documentElement.lang = action(lang);
+    } else {
+      document.documentElement.lang = action;
+    }
+  };
+
+  useEffect(() => {
+    const handler = () => {
+      setLangState(document.documentElement.lang);
+    };
+
+    const observer = new MutationObserver(handler);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['lang'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return [lang, setLang] as const;
+}
+
+export default typeof isDocument
+  ? useLanguage
+  : () => ['', (_action: SetStateAction<string>) => {}] as const;

--- a/src/useLanguage.ts
+++ b/src/useLanguage.ts
@@ -29,6 +29,6 @@ function useLanguage() {
   return [lang, setLang] as const;
 }
 
-export default typeof isDocument
+export default isDocument
   ? useLanguage
   : () => ['', (_action: SetStateAction<string>) => {}] as const;

--- a/stories/useLanguage.story.tsx
+++ b/stories/useLanguage.story.tsx
@@ -1,0 +1,26 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useLanguage } from '../src';
+import NewTabStory from './util/NewTabStory';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const [lang, setLang] = useLanguage();
+
+  return (
+    <NewTabStory>
+      <div>
+        <div>The document's current language is: {lang}</div>
+
+        <br />
+
+        <button onClick={() => setLang('en-US')}>Change to US English</button>
+        <button onClick={() => setLang('es')}>Cambiar a español</button>
+      </div>
+    </NewTabStory>
+  );
+};
+
+storiesOf('Sensors/useLanguage', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useLanguage.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useLanguage.test.ts
+++ b/tests/useLanguage.test.ts
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useLanguage from '../src/useLanguage';
+
+describe('useLanguage', () => {
+  it('should be defined', () => {
+    expect(useLanguage).toBeDefined();
+  });
+
+  it('should retrieve the document language', () => {
+    document.documentElement.lang = 'ar-SA';
+    const hook = renderHook(() => useLanguage());
+
+    expect(document.documentElement.lang).toBe(hook.result.current[0]);
+  });
+
+  it('should update document language', () => {
+    const hook = renderHook(() => useLanguage());
+
+    hook.result.current[1]('bn-BD');
+    expect(document.documentElement.lang).toBe('bn-BD');
+
+    hook.result.current[1]('bn-IN');
+    expect(document.documentElement.lang).toBe('bn-IN');
+  });
+});


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->
This hook tracks the value of the `lang` attribute of the `document` global object (the `<html>` tag). Its signature is the same as useState, returning a tuple with the value and a dispatcher. It takes no arguments.

It uses a MutationObserver to track the changes and causes a rerender, whether if it is updated from inside React or not.


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
