### PR TITLE
Remove unnecessary useEffect and ref in usePrevious hook

### DIFF
--- a/docs/usePrevious.md
+++ b/docs/usePrevious.md
@@ -1,6 +1,6 @@
 # `usePrevious`
 
-React state hook that returns the previous state as described in the [React hooks FAQ](https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state).
+React state hook that returns the previous state as described in [Adjusting some state when a prop changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).
 
 ## Usage
 

--- a/src/usePrevious.ts
+++ b/src/usePrevious.ts
@@ -1,11 +1,13 @@
-import { useEffect, useRef } from 'react';
+import { useState } from 'react';
 
 export default function usePrevious<T>(state: T): T | undefined {
-  const ref = useRef<T>();
+  const [current, setCurrent] = useState<T>(state);
+  const [previous, setPrevious] = useState<T>();
 
-  useEffect(() => {
-    ref.current = state;
-  });
+  if (current !== state) {
+    setCurrent(state);
+    setPrevious(current);
+  }
 
-  return ref.current;
+  return previous;
 }


### PR DESCRIPTION
# Description

This merge request resolves [GitHub Issue #2605](https://github.com/streamich/react-use/issues/2605) by updating the `usePrevious` hook to adhere to React's best practices. For a detailed explanation of the proposed implementation, please refer to the issue and its comments.

## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
