### PR TITLE
[useMeasure] ResizeObserverOptions added as prop

### DIFF
--- a/docs/useMeasure.md
+++ b/docs/useMeasure.md
@@ -25,9 +25,32 @@ const Demo = () => {
 };
 ```
 
+## Usage with observer options
+```jsx
+import { useMeasure } from "react-use";
+
+const Demo = () => {
+  const [ref, { x, y, width, height, top, right, bottom, left }] = useMeasure({ observerOptions: { box: 'border-box' } });
+
+  return (
+    <div ref={ref}>
+      <div>x: {x}</div>	
+      <div>y: {y}</div>
+      <div>width: {width}</div>
+      <div>height: {height}</div>
+      <div>top: {top}</div>
+      <div>right: {right}</div>
+      <div>bottom: {bottom}</div>
+      <div>left: {left}</div>
+    </div>
+  );
+};
+```
+
 This hook uses [`ResizeObserver` API][resize-observer], if you want to support 
 legacy browsers, consider installing [`resize-observer-polyfill`][resize-observer-polyfill] 
 before running your app. 
+In order to use observerOptions check [CanIUse](https://caniuse.com/resizeobserver).
 
 ```js
 if (!window.ResizeObserver) {

--- a/src/useMeasure.ts
+++ b/src/useMeasure.ts
@@ -13,6 +13,7 @@ export type UseMeasureResult<E extends Element = Element> = [
   E | null
 ];
 type UseMeasureParams = {
+  // @ts-ignore [ResizeObserverOptions is not defined in resize-observer-polyfill]
   observerOptions?: ResizeObserverOptions;
 };
 

--- a/src/useMeasure.ts
+++ b/src/useMeasure.ts
@@ -12,7 +12,7 @@ export type UseMeasureResult<E extends Element = Element> = [
   UseMeasureRect,
   E | null
 ];
-type UseMeasureProps = {
+type UseMeasureParams = {
   observerOptions?: ResizeObserverOptions;
 };
 
@@ -27,9 +27,8 @@ const defaultState: UseMeasureRect = {
   right: 0,
 };
 
-function useMeasure<E extends Element = Element>({
-  observerOptions,
-}: UseMeasureProps): UseMeasureResult<E> {
+function useMeasure<E extends Element = Element>(params?: UseMeasureParams): UseMeasureResult<E> {
+  const { observerOptions } = { ...params };
   const [element, ref] = useState<E | null>(null);
   const [rect, setRect] = useState<UseMeasureRect>(defaultState);
 

--- a/stories/useMeasure.story.tsx
+++ b/stories/useMeasure.story.tsx
@@ -16,6 +16,23 @@ const Demo = () => {
   );
 };
 
+const DemoObserverOptions = () => {
+  const [ref, state] = useMeasure({ observerOptions: { box: 'border-box' } });
+
+  return (
+    <>
+      <pre>{JSON.stringify(state, null, 2)}</pre>
+      <div ref={ref} style={{ background: 'red' }}>
+        resize me
+      </div>
+    </>
+  );
+};
+
 storiesOf('Sensors/useMeasure', module)
   .add('Docs', () => <ShowDocs md={require('../docs/useMeasure.md')} />)
   .add('Demo', () => <Demo />);
+
+storiesOf('Sensors/useMeasure', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useMeasure.md')} />)
+  .add('DemoObserverOptions', () => <DemoObserverOptions />);


### PR DESCRIPTION
# [useMeasure] ResizeObserverOptions added as prop

Now useMeasure accepts an `observerOptions` as parameter, plus the hook will also return the element ref in its last argument, just in case of some need.

This PR try to solve the issue [2501](https://github.com/streamich/react-use/issues/2501).
It is a really small change that shouldn't affect the current hook behavior if a parameter is not provided.
Almost sure I forgot something in the PR flow, please, just let me know.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
