### PR TITLE
fix: Modifying the useFirstMountState code for proper functioning in React 19 strict mode

### DIFF
--- a/src/useFirstMountState.ts
+++ b/src/useFirstMountState.ts
@@ -1,13 +1,14 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 export function useFirstMountState(): boolean {
   const isFirst = useRef(true);
 
-  if (isFirst.current) {
+  useEffect(() => {
     isFirst.current = false;
-
-    return true;
-  }
+    return () => {
+      isFirst.current = true;
+    };
+  }, []);
 
   return isFirst.current;
 }


### PR DESCRIPTION
to fix #2611

Hello! I am delighted to submit a PR to react-use, which I frequently use. 😁 While browsing the issues, I became curious about one particular matter, so I investigated and wrote some code.

# Description

## Issue

useUpdateEffect executes the callback function twice on mount in React 19's strict mode #2611 

## Example Code for Reproduction

useUpdateEffect is not working properly in React 19 strict mode.

By comparing `example 1` and `example 2`, we can see that this issue is new in React 19. Additionally, comparing `example 1` and `example 3` shows that the issue occurs when strict mode is enabled. (The issue arises if the alert—being the callback function of useUpdateEffect—is executed during the initial rendering.)

[example 1) react 18 + strict mode](https://stackblitz.com/edit/vitejs-vite-uqt4enr6?file=src%2FApp.jsx,package.json&terminal=dev)

[example 2) react 19 + strict mode](https://stackblitz.com/edit/vitejs-vite-673jyab4?file=src%2FApp.jsx,package.json&terminal=dev)

[example 3) react 19 + no strict mode](https://stackblitz.com/edit/vitejs-vite-rdbei3ns?file=src%2FApp.jsx,src%2Fmain.jsx,package.json&terminal=dev)

## Investigation of the Issue's Cause

To investigate the cause of this issue, I checked the [React 19 patch notes](https://github.com/facebook/react/releases/tag/v19.0.0). Among the various changes, [#25583 PR](https://github.com/facebook/react/pull/25583) is suspected to be the cause. React's #25583 includes changes that allow the memoized result from the first pass to be reused.

In `example 4`, I added console logs throughout the code to continuously monitor state changes. **The most notable difference is that during the second execution triggered by strict mode, the value of `isFirst.current` immediately becomes `false` right after the app renders.** This is unusual since the initial value of `useRef` is set to `true`. In the first rendering, it is correctly true. It appears that React reuses the changed value of `isFirst.current` (which became `false` in the first rendering) due to memoization of the result.

[example 4) (original code) react 19 + strict mode + with console](https://stackblitz.com/edit/vitejs-vite-hrcqqdsj?file=src%2FApp.tsx,src%2Fhooks%2FuseUpdateEffect.ts,src%2Fhooks%2FuseFirstMountState.ts&terminal=dev)

<img width="705" alt="Screenshot 2025-02-27 at 12 36 27 AM" src="https://github.com/user-attachments/assets/d1e883a1-c07b-4a4d-a648-2cf0f096d166" />

```ts
// useFirstMountState.ts

export function useFirstMountState(): boolean {
  const isFirst = useRef(true);
  console.log('first', isFirst.current);

  // ...
}
```

 As can be seen from the screenshot, the callback console.warn in useUpdateEffect is executed twice even during the initial execution. This behavior deviates from the intended functionality, so I improved the situation by using `useEffect` in `useFirstMountState`.

[example 5) (modified code) react 19 + strict mode + with console](https://stackblitz.com/edit/vitejs-vite-k7fjqcyu?file=src%2FApp.tsx,src%2Fhooks%2FuseUpdateEffect.ts,src%2Fhooks%2FuseFirstMountState.ts&terminal=dev)

 In `example 5`, I used the same code that I am submitting in this PR. **Since `isFirst.current` is updated using `useEffect`, it is safe from the behavior of memoized result reuse in strict mode.** The code inside useEffect executes after the second rendering, so in both the first and second renderings, it starts with the value `true`.

<img width="568" alt="스크린샷 2025-02-27 오전 2 01 55" src="https://github.com/user-attachments/assets/880ed46a-c008-4b97-9cc0-f42944eefcfb" />

## Additional Thoughts

Differentiating the first and second renderings using `useEffect` seems to better align with the intent of the `useFirstMountState` hook. In this PR, I also added a cleanup function that resets `isFirst.current` back to true. Although this code is not intended to solve the current issue (removing it does not change the behavior), I thought it would be a more desirable behavior considering that React has decided to use memoized values in strict mode.

Initially, I wanted to add tests to confirm the changed behavior in React 19, but I couldn’t find an appropriate method. Since the behavior in strict mode is quite peculiar, reproducing it would require additional test code. If you have any good ideas, please let me know! I will incorporate your suggestions and add the corresponding code.

Thank you for reading this lengthy PR. 😁

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [x] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
