### PR TITLE
fix: references to the window object instead of state history in story

### DIFF
--- a/stories/useStateWithHistory.story.tsx
+++ b/stories/useStateWithHistory.story.tsx
@@ -24,7 +24,7 @@ const Demo = () => {
         return;
       }
 
-      window.history.back(stepSize);
+      history.back(stepSize);
     },
     [history, stepSize]
   );
@@ -35,7 +35,7 @@ const Demo = () => {
         return;
       }
 
-      window.history.forward(stepSize);
+      history.forward(stepSize);
     },
     [history, stepSize]
   );
@@ -60,12 +60,12 @@ const Demo = () => {
         Current state: <span>{state}</span>
       </div>
       <div style={{ marginTop: 8 }}>
-        <button onClick={handleBackClick} disabled={!window.history.position}>
+        <button onClick={handleBackClick} disabled={!history.position}>
           &lt; Back
         </button>
         <button
           onClick={handleForwardClick}
-          disabled={window.history.position >= window.history.window.history.length - 1}>
+          disabled={history.position >= history.history.length - 1}>
           Forward &gt;
         </button>
         &nbsp; Step size:&nbsp;
@@ -76,7 +76,7 @@ const Demo = () => {
         <div>Current history</div>
         <div
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(window.history.history, null, 2)
+            __html: JSON.stringify(history.history, null, 2)
               .replace(/\n/g, '<br/>')
               .replace(/ /g, '&nbsp;'),
           }}


### PR DESCRIPTION
# Description

I was trying to use `useStateWithHistory` and saw there was an error in the story that didn't allow me to demo how to use the hook. This fixes the error which was just a lot of references to the window.history object instead of the state history object.


## Type of change

<!-- Check all relevant options. -->
- [x ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x ] Perform a code self-review
- [ n/a] Comment the code, particularly in hard-to-understand areas
- [n/a ] Add documentation
- [ x] Add hook's story at Storybook
- [ n/a] Cover changes with tests
- [ n/a] Ensure the test suite passes (`yarn test`)
- [ n/a] Provide 100% tests coverage
- [x ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
