### PR TITLE
fix: ssr issue, move fns inside useEffect

### DIFF
--- a/src/useGeolocation.ts
+++ b/src/useGeolocation.ts
@@ -36,13 +36,11 @@ const useGeolocation = (options?: PositionOptions): GeoLocationSensorState => {
     latitude: null,
     longitude: null,
     speed: null,
-    timestamp: Date.now(),
+    timestamp: null,
   });
-  let mounted = true;
-  let watchId: any;
 
-  const onEvent = (event: any) => {
-    if (mounted) {
+  useEffect(() => {
+    const onEvent = (event: any) => {
       setState({
         loading: false,
         accuracy: event.coords.accuracy,
@@ -54,17 +52,14 @@ const useGeolocation = (options?: PositionOptions): GeoLocationSensorState => {
         speed: event.coords.speed,
         timestamp: event.timestamp,
       });
-    }
-  };
-  const onEventError = (error: IGeolocationPositionError) =>
-    mounted && setState((oldState) => ({ ...oldState, loading: false, error }));
+    };
+    const onEventError = (error: IGeolocationPositionError) =>
+      setState((oldState) => ({ ...oldState, loading: false, error }));
 
-  useEffect(() => {
     navigator.geolocation.getCurrentPosition(onEvent, onEventError, options);
-    watchId = navigator.geolocation.watchPosition(onEvent, onEventError, options);
+    let watchId = navigator.geolocation.watchPosition(onEvent, onEventError, options);
 
     return () => {
-      mounted = false;
       navigator.geolocation.clearWatch(watchId);
     };
   }, []);


### PR DESCRIPTION
# Description

The hook as is is not SSR safe (repro: [https://ck29z6-3000.csb.app/](https://ck29z6-3000.csb.app/) ). The timestamp is initialized on the server and on the client as `Date.now()` so it's guaranteed to cause a hydration issue when `.timestamp` is used on the DOM (unless the client's clock is behind and by chance it happens to be the same during client rendering).

Moreover, the server's clock is more than likely in a different timezone which would result in a wrong value being passed on the initial response.

Additionally, there's no point in initializing `.timestamp` as it arguably should only be initialized/set by the geolocation events.

Additional changes include: moving the functions inside useEffect so they're not needed in the deps array, removing `mounted` as it's a useless check. 


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
