### PR TITLE
add 'type: module' field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-use",
   "version": "17.6.0",
   "description": "Collection of React Hooks",
+  "type": "module",
   "main": "lib/index.js",
   "module": "esm/index.js",
   "sideEffects": false,


### PR DESCRIPTION
This PR adds the "type": "module" field to the package.json file, which properly signals to Node.js and bundlers that the package uses ESM (ECMAScript Modules) syntax.

This change ensures better compatibility when consuming react-use in modern ESM environments, resolves issues related to module imports, and aligns with the ongoing transition to ESM support.

Fixes: #2614