### PR TITLE
docs(useGeolocation): add import example for GeoLocationSensorState type

### DIFF
--- a/docs/useGeolocation.md
+++ b/docs/useGeolocation.md
@@ -23,3 +23,10 @@ const Demo = () => {
 ```ts
 useGeolocation(options: PositionOptions)
 ```
+## Types
+
+If you need to use the return type of `useGeolocation`, you can import the `GeoLocationSensorState` type directly from the hook module:
+
+```ts
+import type { GeoLocationSensorState } from 'react-use/lib/useGeolocation';
+```


### PR DESCRIPTION
This adds a documentation note explaining how to import the GeoLocationSensorState type from react-use/lib/useGeolocation.

It addresses confusion reported in issue #2632.

Closes #2632