### PR TITLE
fix(useLocalStorage): fix setter function returns incorrect previous value

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -19,13 +19,14 @@ const useLocalStorage = <T>(
   if (!isBrowser) {
     return [initialValue as T, noop, noop];
   }
+
   if (!key) {
     throw new Error('useLocalStorage key may not be falsy');
   }
 
   const deserializer = options
     ? options.raw
-      ? (value) => value
+      ? (value: string) => value
       : options.deserializer
     : JSON.parse;
 
@@ -79,7 +80,8 @@ const useLocalStorage = <T>(
         // localStorage can throw. Also JSON.stringify can throw.
       }
     },
-    [key, setState]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [key, setState, state]
   );
 
   // eslint-disable-next-line react-hooks/rules-of-hooks


### PR DESCRIPTION
# Description

This PR fixes a bug in the `useLocalStorage` hook where the `setValue` function does not return the correct previous value. The issue occurs because the setter function is wrapped in a `useCallback`, but the current state value was not included in the dependency array. As a result, the stale value was being captured and returned incorrectly.

This fix adds the missing dependency to ensure the latest state is used in the callback.

## Type of change

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).