### PR TITLE
fix: export GeoLocationSensorState type for external use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,9 @@ export { default as useError } from './useError';
 export { default as useFavicon } from './useFavicon';
 export { default as useFullscreen } from './useFullscreen';
 export { default as useGeolocation } from './useGeolocation';
+export * from './useGeolocation';
+export type { GeoLocationSensorState } from './useGeolocation';
+
 export { default as useGetSet } from './useGetSet';
 export { default as useGetSetState } from './useGetSetState';
 export { default as useHarmonicIntervalFn } from './useHarmonicIntervalFn';


### PR DESCRIPTION
The `GeoLocationSensorState` type is used in consumer apps that rely on the `useGeolocation` hook from react-use.  
This PR adds it to the package entry point so it can be imported from `'react-use'` directly.

Before:
import { GeoLocationSensorState } from 'react-use'; //  Module not found

After:
import { GeoLocationSensorState } from 'react-use'; // Works 