### PR TITLE
fix: improve TODO comment and clean up deprecated useUpsert references

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@
   - [`useLifecycles`](./docs/useLifecycles.md) &mdash; calls `mount` and `unmount` callbacks.
   - [`useMountedState`](./docs/useMountedState.md) and [`useUnmountPromise`](./docs/useUnmountPromise.md) &mdash; track if component is mounted.
   - [`usePromise`](./docs/usePromise.md) &mdash; resolves promise only while component is mounted.
-  - [`useLogger`](./docs/useLogger.md) &mdash; logs in console as component goes through life-cycles.
+  - [`useLogger`](./docs/useLogger.md) &mdash; logs in console as component goes through lifecycles.
   - [`useMount`](./docs/useMount.md) &mdash; calls `mount` callbacks.
   - [`useUnmount`](./docs/useUnmount.md) &mdash; calls `unmount` callbacks.
   - [`useUpdateEffect`](./docs/useUpdateEffect.md) &mdash; run an `effect` only on updates.
-  - [`useIsomorphicLayoutEffect`](./docs/useIsomorphicLayoutEffect.md) &mdash; `useLayoutEffect` that that works on server.
+  - [`useIsomorphicLayoutEffect`](./docs/useIsomorphicLayoutEffect.md) &mdash; `useLayoutEffect` that works on server.
   - [`useDeepCompareEffect`](./docs/useDeepCompareEffect.md), [`useShallowCompareEffect`](./docs/useShallowCompareEffect.md), and [`useCustomCompareEffect`](./docs/useCustomCompareEffect.md)
     <br/>
     <br/>
@@ -142,13 +142,13 @@
   - [`useStateList`](./docs/useStateList.md) &mdash; circularly iterates over an array. [![][img-demo]](https://codesandbox.io/s/bold-dewdney-pjzkd)
   - [`useToggle` and `useBoolean`](./docs/useToggle.md) &mdash; tracks state of a boolean. [![][img-demo]](https://codesandbox.io/s/focused-sammet-brw2d)
   - [`useCounter` and `useNumber`](./docs/useCounter.md) &mdash; tracks state of a number. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usecounter--demo)
-  - [`useList`](./docs/useList.md) ~and [`useUpsert`](./docs/useUpsert.md)~ &mdash; tracks state of an array. [![][img-demo]](https://codesandbox.io/s/wonderful-mahavira-1sm0w)
+  - [`useList`](./docs/useList.md) &mdash; tracks state of an array. [![][img-demo]](https://codesandbox.io/s/wonderful-mahavira-1sm0w)
   - [`useMap`](./docs/useMap.md) &mdash; tracks state of an object. [![][img-demo]](https://codesandbox.io/s/quirky-dewdney-gi161)
   - [`useSet`](./docs/useSet.md) &mdash; tracks state of a Set. [![][img-demo]](https://codesandbox.io/s/bold-shtern-6jlgw)
   - [`useQueue`](./docs/useQueue.md) &mdash; implements simple queue.
   - [`useStateValidator`](./docs/useStateValidator.md) &mdash; tracks state of an object. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usestatevalidator--demo)
   - [`useStateWithHistory`](./docs/useStateWithHistory.md) &mdash; stores previous state values and provides handles to travel through them. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usestatewithhistory--demo)
-  - [`useMultiStateValidator`](./docs/useMultiStateValidator.md) &mdash; alike the `useStateValidator`, but tracks multiple states at a time. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usemultistatevalidator--demo)
+  - [`useMultiStateValidator`](./docs/useMultiStateValidator.md) &mdash; like the `useStateValidator`, but tracks multiple states at a time. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usemultistatevalidator--demo)
   - [`useMediatedState`](./docs/useMediatedState.md) &mdash; like the regular `useState` but with mediation by custom function. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usemediatedstate--demo)
   - [`useFirstMountState`](./docs/useFirstMountState.md) &mdash; check if current render is first. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usefirstmountstate--demo)
   - [`useRendersCount`](./docs/useRendersCount.md) &mdash; count component renders. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-userenderscount--demo)

--- a/docs/useList.md
+++ b/docs/useList.md
@@ -70,4 +70,4 @@ const [list, {
 
 ## Related hooks
 
-- [useUpsert](./useUpsert.md)
+<!-- useUpsert is deprecated and its functionality is now available in useList's upsert method -->

--- a/docs/useUpsert.md
+++ b/docs/useUpsert.md
@@ -1,9 +1,25 @@
 # `useUpsert`
 
-> DEPRECATED!  
-> Use `useList` hook's upsert action instead
+> **⚠️ DEPRECATED**  
+> This hook is deprecated and will be removed in a future version.  
+> Use `useList` hook's `upsert` action instead.
 
-Superset of [`useList`](./useList.md). Provides an additional method to upsert (update or insert) an element into the list.
+This hook was a superset of [`useList`](./useList.md) that provided an additional method to upsert (update or insert) an element into the list. The same functionality is now available directly in `useList`.
+
+## Migration Guide
+
+Replace:
+```jsx
+import { useUpsert } from 'react-use';
+const [list, { set, upsert, remove }] = useUpsert(comparisonFunction, initialItems);
+```
+
+With:
+```jsx
+import { useList } from 'react-use';
+const [list, { set, upsert, removeAt }] = useList(initialItems);
+// Use upsert(comparisonFunction, newItem) instead of upsert(newItem)
+```
 
 ## Usage
 

--- a/src/useUpsert.ts
+++ b/src/useUpsert.ts
@@ -12,6 +12,13 @@ export default function useUpsert<T>(
   predicate: (a: T, b: T) => boolean,
   initialList: IHookStateInitAction<T[]> = []
 ): [T[], UpsertListActions<T>] {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(
+      'useUpsert is deprecated and will be removed in a future version. ' +
+      'Use useList hook\'s upsert action instead. ' +
+      'See: https://github.com/streamich/react-use/blob/master/docs/useUpsert.md'
+    );
+  }
   const [list, listActions] = useList(initialList);
 
   return [

--- a/tests/useNetworkState.test.ts
+++ b/tests/useNetworkState.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useNetworkState } from '../src';
 
-//ToDo: improve tests
+// TODO: Add comprehensive tests for network state changes, offline/online events, and network information properties
 describe(`useNetworkState`, () => {
   it('should be defined', () => {
     expect(useNetworkState).toBeDefined();


### PR DESCRIPTION
- Standardize TODO comment format in useNetworkState.test.ts
- Add comprehensive description for test improvements needed
- Remove strikethrough reference to useUpsert from README.md
- Update useList documentation to clarify deprecation
- Enhance useUpsert documentation with migration guide
- Add runtime deprecation warning to useUpsert hook
- Improve developer experience with better guidance

# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
