### PR TITLE
feat: add new hook useDocumentTitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
   - [`useCookie`](./docs/useCookie.md) &mdash; provides way to read, update and delete a cookie. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/side-effects-usecookie--demo)
   - [`useCopyToClipboard`](./docs/useCopyToClipboard.md) &mdash; copies text to clipboard.
   - [`useDebounce`](./docs/useDebounce.md) &mdash; debounces a function. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/side-effects-usedebounce--demo)
+  - [`useDocumentTitle`](./docs/useDocumentTitle.md) &mdash; changes document title.
   - [`useError`](./docs/useError.md) &mdash; error dispatcher. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/side-effects-useerror--demo)
   - [`useFavicon`](./docs/useFavicon.md) &mdash; sets favicon of the page.
   - [`useLocalStorage`](./docs/useLocalStorage.md) &mdash; manages a value in `localStorage`.

--- a/docs/useDocumentTitle.md
+++ b/docs/useDocumentTitle.md
@@ -1,0 +1,31 @@
+# `useDocumentTitle`
+
+React hook that updates the `document.title` when the component mounts or when the title changes.  
+It also restores the previous title on unmount.
+
+## Usage
+
+```jsx
+import { useDocumentTitle } from 'react-use';
+
+const Demo = () => {
+  const [count, setCount] = React.useState(0);
+
+  useDocumentTitle(`Clicked ${count} times`);
+
+  return (
+    <div>
+      <h3>Click the button to update document title</h3>
+      <button onClick={() => setCount(c => c + 1)}>
+        Clicked {count} times
+      </button>
+    </div>
+  );
+};
+```
+
+## Reference
+
+```ts
+useDocumentTitle(title);
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export { default as useCustomCompareEffect } from './useCustomCompareEffect';
 export { default as useDebounce } from './useDebounce';
 export { default as useDeepCompareEffect } from './useDeepCompareEffect';
 export { default as useDefault } from './useDefault';
+export { default as useDocumentTitle } from './useDocumentTitle';
 export { default as useDrop } from './useDrop';
 export { default as useDropArea } from './useDropArea';
 export { default as useEffectOnce } from './useEffectOnce';

--- a/src/useDocumentTitle.ts
+++ b/src/useDocumentTitle.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+export default function useDocumentTitle(title: string) {
+  useEffect(() => {
+    const previousTitle = document.title;
+    document.title = title;
+
+    return () => {
+      document.title = previousTitle;
+    };
+  }, [title]);
+}

--- a/stories/useDocumentTitle.story.tsx
+++ b/stories/useDocumentTitle.story.tsx
@@ -1,0 +1,22 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { useDocumentTitle } from '../src';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const [count, setCount] = React.useState(0);
+
+  // Update document title whenever count changes
+  useDocumentTitle(`Clicked ${count} times`);
+
+  return (
+    <div>
+      <h3>Click the button to update document title</h3>
+      <button onClick={() => setCount((c) => c + 1)}>Clicked {count} times</button>
+    </div>
+  );
+};
+
+storiesOf('SideEffects/useDocumentTitle', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useDocumentTitle.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useDocumentTitle.test.ts
+++ b/tests/useDocumentTitle.test.ts
@@ -1,0 +1,22 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useDocumentTitle } from '../src';
+
+it('should set the document title on mount', () => {
+  const title = 'Doc Title';
+
+  renderHook(() => useDocumentTitle(title));
+
+  expect(document.title).toBe(title);
+});
+
+it('should update the title when argument changes', () => {
+  const { rerender } = renderHook(({ title }) => useDocumentTitle(title), {
+    initialProps: { title: 'First Title' },
+  });
+
+  expect(document.title).toBe('First Title');
+
+  rerender({ title: 'Second Title' });
+
+  expect(document.title).toBe('Second Title');
+});


### PR DESCRIPTION
# Description

The useDocumentTitle hook takes a string as an argument and set the document title to that string.

The motivation behind creating this custom hook is likely to provide a way to change document title on component mount.

## Type of change

<!-- Check all relevant options. -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [ ] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [ ] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [ ] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [ ] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->
