### PR TITLE
Add useTextSelection hook

### DIFF
--- a/src/useTextSelection.ts
+++ b/src/useTextSelection.ts
@@ -1,0 +1,128 @@
+import { useCallback, useLayoutEffect, useState } from "react";
+
+type ClientRect = Record<keyof Omit<DOMRect, "toJSON">, number>;
+
+function roundValues(_rect: ClientRect) {
+  const rect: ClientRect = { ..._rect };
+  for (const key of Object.keys(rect) as Array<keyof ClientRect>) {
+    rect[key] = Math.round(rect[key]);
+  }
+  return rect;
+}
+
+function shallowDiff(prev?: ClientRect, next?: ClientRect): boolean {
+  if (prev != null && next != null) {
+    for (const key of Object.keys(next) as Array<keyof ClientRect>) {
+      if (prev[key] !== next[key]) {
+        return true;
+      }
+    }
+  } else if (prev !== next) {
+    return true;
+  }
+  return false;
+}
+
+type TextSelectionState = {
+  clientRect?: ClientRect;
+  isCollapsed?: boolean;
+  textContent?: string;
+};
+
+const defaultState: TextSelectionState = {};
+
+/**
+ * useTextSelection(ref)
+ *
+ * @description
+ * hook to get information about the current text selection
+ *
+ */
+export function useTextSelection(target?: HTMLElement) {
+  const [{ clientRect, isCollapsed, textContent }, setState] =
+    useState<TextSelectionState>(defaultState);
+
+  const handler = useCallback(() => {
+    setState((prev) => {
+      const selection = window.getSelection();
+      const nextState: TextSelectionState = {};
+
+      if (selection == null || !selection.rangeCount) {
+        return defaultState;
+      }
+
+      const range = selection.getRangeAt(0);
+
+      if (target != null && !target.contains(range.commonAncestorContainer)) {
+        return defaultState;
+      }
+
+      const contents = range.cloneContents();
+
+      if (contents.textContent != null) {
+        nextState.textContent = contents.textContent;
+      }
+
+      const rects = range.getClientRects();
+      let computedRect: ClientRect | undefined;
+
+      if (rects.length === 0 && range.commonAncestorContainer != null) {
+        const node = range.commonAncestorContainer;
+        const el =
+          node.nodeType === Node.ELEMENT_NODE
+            ? (node as Element)
+            : node.parentElement ?? document.body;
+        const r = el.getBoundingClientRect();
+        computedRect = roundValues({
+          x: r.x,
+          y: r.y,
+          top: r.top,
+          right: r.right,
+          bottom: r.bottom,
+          left: r.left,
+          width: r.width,
+          height: r.height,
+        });
+      } else if (rects.length > 0) {
+        const r0 = rects[0];
+        computedRect = roundValues({
+          x: r0.x,
+          y: r0.y,
+          top: r0.top,
+          right: r0.right,
+          bottom: r0.bottom,
+          left: r0.left,
+          width: r0.width,
+          height: r0.height,
+        });
+      }
+
+      if (computedRect && shallowDiff(prev.clientRect, computedRect)) {
+        nextState.clientRect = computedRect;
+      }
+      nextState.isCollapsed = range.collapsed;
+
+      return nextState;
+    });
+  }, [target]);
+
+  useLayoutEffect(() => {
+    document.addEventListener("selectionchange", handler);
+    document.addEventListener("keydown", handler);
+    document.addEventListener("keyup", handler);
+    window.addEventListener("resize", handler);
+
+    return () => {
+      document.removeEventListener("selectionchange", handler);
+      document.removeEventListener("keydown", handler);
+      document.removeEventListener("keyup", handler);
+      window.removeEventListener("resize", handler);
+    };
+  }, [handler]);
+
+  return {
+    clientRect,
+    isCollapsed,
+    textContent,
+  };
+}


### PR DESCRIPTION
# Description

This PR introduces a new hook: **`useTextSelection`**.

The hook allows developers to easily access information about the current text selection inside the document (or optionally within a given target element). It provides:

- `clientRect`: the bounding rectangle of the selection.
- `isCollapsed`: whether the selection is collapsed or not.
- `textContent`: the selected text content.

This hook can be useful for building rich text editors, annotation tools, tooltips, and context-aware UIs that need to react to user text selection.  

It fits the **sensors** category, since it exposes live environmental data from the DOM, similar to hooks like `useMouse` or `useHover`.

## Type of change

- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

