### PR TITLE
fix(useFullscreen):accept nullable ref and add minimal test

### DIFF
--- a/src/useFullscreen.ts
+++ b/src/useFullscreen.ts
@@ -11,7 +11,7 @@ export interface FullScreenOptions {
 }
 
 const useFullscreen = (
-  ref: RefObject<Element>,
+  ref: RefObject<HTMLElement | null>,
   enabled: boolean,
   options: FullScreenOptions = {}
 ): boolean => {
@@ -48,7 +48,7 @@ const useFullscreen = (
         screenfull.request(ref.current);
         setIsFullscreen(true);
       } catch (error) {
-        onClose(error);
+        onClose(error as Error);
         setIsFullscreen(false);
       }
       screenfull.on('change', onChange);

--- a/tests/useFullscreen.test.ts
+++ b/tests/useFullscreen.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { createRef } from 'react';
+import useFullscreen from '../src/useFullscreen';
+
+// Mock screenfull
+const mockScreenfull = {
+  isEnabled: true,
+  isFullscreen: false,
+  request: jest.fn(),
+  exit: jest.fn(),
+  on: jest.fn(),
+  off: jest.fn(),
+};
+
+jest.mock('screenfull', () => mockScreenfull);
+
+// Mock the on/off functions from misc/util
+jest.mock('../src/misc/util', () => ({
+  noop: () => {},
+  on: jest.fn(),
+  off: jest.fn(),
+}));
+
+describe('useFullscreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockScreenfull.isEnabled = true;
+    mockScreenfull.isFullscreen = false;
+  });
+
+  it('should be defined', () => {
+    expect(useFullscreen).toBeDefined();
+  });
+
+  it('should return false when disabled', () => {
+    const ref = createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useFullscreen(ref, false));
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should return a boolean value', () => {
+    const ref = createRef<HTMLDivElement>();
+    const { result } = renderHook(() => useFullscreen(ref, true));
+
+    expect(typeof result.current).toBe('boolean');
+  });
+
+  it('should accept options parameter', () => {
+    const ref = createRef<HTMLDivElement>();
+    const options = { onClose: jest.fn() };
+    const { result } = renderHook(() => useFullscreen(ref, true, options));
+
+    expect(typeof result.current).toBe('boolean');
+  });
+});


### PR DESCRIPTION
Fixes #2662

# Overview
This PR fixes a type-safety issue in `useFullscreen` and adds a minimal test to ensure basic functionality.

# Description
`useFullscreen` currently expects `RefObject<HTMLElement>` which is not compatible with React's `useRef`/`createRef` that can be null. This PR changes the type to `RefObject<HTMLElement | null>`. Also added a small cast in the catch block for better TypeScript safety.


## Type of change

- `src/useFullscreen.ts`:
  - Type change for `ref` parameter
  - Cast caught error to `Error` (`onClose(error as Error)`)
- `tests/useFullscreen.test.ts`:
  - Minimal test to ensure the hook is defined and returns a boolean

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

