### PR TITLE
feat: add useStack hook (LIFO stack) with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@
   - [`useMap`](./docs/useMap.md) &mdash; tracks state of an object. [![][img-demo]](https://codesandbox.io/s/quirky-dewdney-gi161)
   - [`useSet`](./docs/useSet.md) &mdash; tracks state of a Set. [![][img-demo]](https://codesandbox.io/s/bold-shtern-6jlgw)
   - [`useQueue`](./docs/useQueue.md) &mdash; implements simple queue.
+    - [`useStack`](./docs/useStack.md) &mdash; implements simple Stack (LIFO).
   - [`useStateValidator`](./docs/useStateValidator.md) &mdash; tracks state of an object. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usestatevalidator--demo)
   - [`useStateWithHistory`](./docs/useStateWithHistory.md) &mdash; stores previous state values and provides handles to travel through them. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usestatewithhistory--demo)
   - [`useMultiStateValidator`](./docs/useMultiStateValidator.md) &mdash; alike the `useStateValidator`, but tracks multiple states at a time. [![][img-demo]](https://streamich.github.io/react-use/?path=/story/state-usemultistatevalidator--demo)

--- a/docs/useStack.md
+++ b/docs/useStack.md
@@ -1,0 +1,26 @@
+### useStack
+
+React hook implementing stack (LIFO) behavior.
+
+```tsx
+import { useStack } from 'react-use';
+
+const Demo = () => {
+  const [stack, { push, pop, peek, clear, reset, size }] = useStack([1, 2]);
+
+  return (
+    <div>
+      <ul>
+        <li>Stack: {JSON.stringify(stack)}</li>
+        <li>Top: {peek()}</li>
+        <li>Size: {size()}</li>
+      </ul>
+
+      <button onClick={() => push((peek() || 0) + 1)}>Push</button>
+      <button onClick={() => pop()}>Pop</button>
+      <button onClick={() => clear()}>Clear</button>
+      <button onClick={() => reset()}>Reset</button>
+    </div>
+  );
+};
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,3 +115,4 @@ export { useFirstMountState } from './useFirstMountState';
 export { default as useSet } from './useSet';
 export { createGlobalState } from './factory/createGlobalState';
 export { useHash } from './useHash';
+export { default as useStack } from './useStack';

--- a/src/useStack.ts
+++ b/src/useStack.ts
@@ -1,0 +1,93 @@
+import { useMemo, useRef } from 'react';
+import useUpdate from './useUpdate';
+import { IHookStateInitAction, IHookStateSetAction, resolveHookState } from './misc/hookState';
+
+export interface StackActions<T> {
+  /**
+   * @description Push an element onto the stack (top).
+   */
+  push: (item: T) => void;
+
+  /**
+   * @description Pop and return the top element. Returns undefined if empty.
+   */
+  pop: () => T | undefined;
+
+  /**
+   * @description Returns the top element without removing it.
+   */
+  peek: () => T | undefined;
+
+  /**
+   * @description Clear all elements from the stack.
+   */
+  clear: () => void;
+
+  /**
+   * @description Reset stack to its initial value.
+   */
+  reset: () => void;
+
+  /**
+   * @description Replace the entire stack manually.
+   */
+  set: (newStack: IHookStateSetAction<T[]>) => void;
+
+  /**
+   * @description Returns the current stack size.
+   */
+  size: () => number;
+}
+
+/**
+ * @name useStack
+ * @description React hook that provides stack (LIFO) operations.
+ * @example
+ * const [stack, { push, pop, peek, clear, reset, size }] = useStack<number>([1, 2]);
+ */
+function useStack<T>(initialStack: IHookStateInitAction<T[]> = []): [T[], StackActions<T>] {
+  const stack = useRef(resolveHookState(initialStack));
+  const update = useUpdate();
+
+  const actions = useMemo<StackActions<T>>(() => {
+    const a = {
+      set: (newStack: IHookStateSetAction<T[]>) => {
+        stack.current = resolveHookState(newStack, stack.current);
+        update();
+      },
+
+      push: (item: T) => {
+        a.set((curr: T[]) => curr.concat(item));
+      },
+
+      pop: () => {
+        if (stack.current.length === 0) return undefined;
+        const item = stack.current[stack.current.length - 1];
+        a.set((curr: T[]) => curr.slice(0, -1));
+        return item;
+      },
+
+      peek: () => {
+        return stack.current[stack.current.length - 1];
+      },
+
+      clear: () => {
+        a.set([]);
+      },
+
+      reset: () => {
+        a.set(resolveHookState(initialStack).slice());
+      },
+
+      size: () => {
+        return stack.current.length;
+      },
+    };
+
+    return a as StackActions<T>;
+  }, []);
+
+  return [stack.current, actions];
+}
+
+export default useStack;

--- a/stories/useStack.story.tsx
+++ b/stories/useStack.story.tsx
@@ -1,0 +1,27 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import useStack from '../src/useStack';
+import ShowDocs from './util/ShowDocs';
+
+const Demo = () => {
+  const [stack, { push, pop, peek, clear, reset, size }] = useStack<number>([1, 2]);
+
+  return (
+    <div>
+      <ul>
+        <li>Stack: {JSON.stringify(stack)}</li>
+        <li>Top: {peek()}</li>
+        <li>Size: {size()}</li>
+      </ul>
+
+      <button onClick={() => push((peek() || 0) + 1)}>Push</button>
+      <button onClick={() => pop()}>Pop</button>
+      <button onClick={clear}>Clear</button>
+      <button onClick={reset}>Reset</button>
+    </div>
+  );
+};
+
+storiesOf('State/useStack', module)
+  .add('Docs', () => <ShowDocs md={require('../docs/useStack.md')} />)
+  .add('Demo', () => <Demo />);

--- a/tests/useStack.test.ts
+++ b/tests/useStack.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import useStack from '../src/useStack';
+
+describe('useStack', () => {
+  it('should initialize with initial values', () => {
+    const { result } = renderHook(() => useStack([1, 2]));
+    expect(result.current[0]).toEqual([1, 2]);
+  });
+
+  it('should push and pop elements correctly', () => {
+    const { result } = renderHook(() => useStack<number>());
+    const [, actions] = result.current;
+
+    act(() => {
+      actions.push(10);
+      actions.push(20);
+    });
+
+    expect(result.current[0]).toEqual([10, 20]);
+    expect(actions.peek()).toBe(20);
+
+    act(() => {
+      actions.pop();
+    });
+
+    expect(result.current[0]).toEqual([10]);
+  });
+
+  it('should clear and reset stack', () => {
+    const { result } = renderHook(() => useStack([1, 2, 3]));
+    const [, actions] = result.current;
+
+    act(() => {
+      actions.clear();
+    });
+    expect(result.current[0]).toEqual([]);
+
+    act(() => {
+      actions.reset();
+    });
+    expect(result.current[0]).toEqual([1, 2, 3]);
+  });
+
+  it('should return correct size', () => {
+    const { result } = renderHook(() => useStack([1, 2]));
+    const [, actions] = result.current;
+    expect(actions.size()).toBe(2);
+  });
+});


### PR DESCRIPTION
# Description

Motivation

Hooks like useQueue, useList, and useSet provide developers with convenient, declarative wrappers for common data structures.
useStack completes this family by adding LIFO support, which is particularly useful for:

Undo/redo systems

Navigation history management

Game or simulation states

Expression parsing or algorithm visualization


## Implimentation way

- Built using React’s useState

- Immutable updates for React compatibility

- Fully typed with TypeScript

# Checklist
- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [x] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [x] Add hook's story at Storybook
- [x] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [x] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

