### PR TITLE
fix: Remove warnings from useDeepCompareEffect

### DIFF
--- a/docs/useDeepCompareEffect.md
+++ b/docs/useDeepCompareEffect.md
@@ -23,6 +23,15 @@ const Demo = () => {
 };
 ```
 
+## When to Use
+
+This hook is handy when:
+- Your dependencies might be `undefined` or an object (common with optional props/config)
+- You need to compare objects by their values, not just references
+- You're mixing primitives and objects in your dependency array
+
+Works fine with any dependency types - primitives, objects, or a mix of both.
+
 ## Reference
 
 ```ts

--- a/src/useDeepCompareEffect.ts
+++ b/src/useDeepCompareEffect.ts
@@ -2,23 +2,7 @@ import { DependencyList, EffectCallback } from 'react';
 import useCustomCompareEffect from './useCustomCompareEffect';
 import isDeepEqual from './misc/isDeepEqual';
 
-const isPrimitive = (val: any) => val !== Object(val);
-
 const useDeepCompareEffect = (effect: EffectCallback, deps: DependencyList) => {
-  if (process.env.NODE_ENV !== 'production') {
-    if (!(deps instanceof Array) || !deps.length) {
-      console.warn(
-        '`useDeepCompareEffect` should not be used with no dependencies. Use React.useEffect instead.'
-      );
-    }
-
-    if (deps.every(isPrimitive)) {
-      console.warn(
-        '`useDeepCompareEffect` should not be used with dependencies that are all primitive values. Use React.useEffect instead.'
-      );
-    }
-  }
-
   useCustomCompareEffect(effect, deps, isDeepEqual);
 };
 


### PR DESCRIPTION
Removes console.warn statements from useDeepCompareEffect hook as requested in #755. This allows users to use the hook with dependencies that could be either undefined or an object without receiving warnings.