### PR TITLE
fix(useScrolling): clear timeout on unmount to prevent memory leak

### DIFF
--- a/src/useScrolling.ts
+++ b/src/useScrolling.ts
@@ -20,6 +20,7 @@ const useScrolling = (ref: RefObject<HTMLElement>): boolean => {
 
       on(ref.current, 'scroll', handleScroll, false);
       return () => {
+        clearTimeout(scrollingTimeout);
         if (ref.current) {
           off(ref.current, 'scroll', handleScroll, false);
         }


### PR DESCRIPTION
## Summary

The `useEffect` cleanup function in [useScrolling](cci:1://file:///c:/Users/DELL/Documents/OneDrive/Desktop/Portfolio-projects/open-soure-contri/react-contributions/src/useScrolling.ts:3:0-32:2) was not clearing the `scrollingTimeout`. This could lead to:
- A **memory leak** from the retained timeout reference
- A **setState call on an unmounted component**, causing a React warning

## Changes

Added `clearTimeout(scrollingTimeout)` to the `useEffect` cleanup/return function so that the timeout is properly cleared when the component unmounts or the effect re-runs.

## Before

```js
return () => {
  if (ref.current) {
    off(ref.current, 'scroll', handleScroll, false);
  }
};    

after


return () => {
  clearTimeout(scrollingTimeout);
  if (ref.current) {
    off(ref.current, 'scroll', handleScroll, false);
  }
};