### PR TITLE
Improve useDebounce callback type

### DIFF
--- a/docs/useDebounce.md
+++ b/docs/useDebounce.md
@@ -48,10 +48,10 @@ const Demo = () => {
 const [
     isReady: () => boolean | null,
     cancel: () => void,
-] = useDebounce(fn: Function, ms: number, deps: DependencyList = []);
+] = useDebounce<F extends () => unknown>(fn: F, ms: number, deps: DependencyList = []);
 ```
 
-- **`fn`**_`: Function`_ - function that will be called;
+- **`fn`**_`: F extends () => unknown`_ - function that will be called;
 - **`ms`**_`: number`_ - delay in milliseconds;
 - **`deps`**_`: DependencyList`_ - array of values that the debounce depends on, in the same manner as useEffect;
 - **`isReady`**_`: ()=>boolean|null`_ - function returning current debounce state:

--- a/docs/useDebounce.md
+++ b/docs/useDebounce.md
@@ -48,10 +48,10 @@ const Demo = () => {
 const [
     isReady: () => boolean | null,
     cancel: () => void,
-] = useDebounce<F extends () => unknown>(fn: F, ms: number, deps: DependencyList = []);
+] = useDebounce(fn: () => void, ms: number, deps: DependencyList = []);
 ```
 
-- **`fn`**_`: F extends () => unknown`_ - function that will be called;
+- **`fn`**_`: () => void`_ - function that will be called;
 - **`ms`**_`: number`_ - delay in milliseconds;
 - **`deps`**_`: DependencyList`_ - array of values that the debounce depends on, in the same manner as useEffect;
 - **`isReady`**_`: ()=>boolean|null`_ - function returning current debounce state:

--- a/src/useDebounce.ts
+++ b/src/useDebounce.ts
@@ -2,9 +2,10 @@ import { DependencyList, useEffect } from 'react';
 import useTimeoutFn from './useTimeoutFn';
 
 export type UseDebounceReturn = [() => boolean | null, () => void];
+export type UseDebounceFn = () => unknown;
 
-export default function useDebounce(
-  fn: Function,
+export default function useDebounce<F extends UseDebounceFn>(
+  fn: F,
   ms: number = 0,
   deps: DependencyList = []
 ): UseDebounceReturn {

--- a/src/useDebounce.ts
+++ b/src/useDebounce.ts
@@ -2,10 +2,10 @@ import { DependencyList, useEffect } from 'react';
 import useTimeoutFn from './useTimeoutFn';
 
 export type UseDebounceReturn = [() => boolean | null, () => void];
-export type UseDebounceFn = () => unknown;
+export type UseDebounceFn = () => void;
 
-export default function useDebounce<F extends UseDebounceFn>(
-  fn: F,
+export default function useDebounce(
+  fn: UseDebounceFn,
   ms: number = 0,
   deps: DependencyList = []
 ): UseDebounceReturn {


### PR DESCRIPTION
Fixes #2677

# Description

Updates `useDebounce` to type the callback as a callable instead of the broad `Function` type. The callable is constrained to zero arguments because `useDebounce` schedules the callback through `useTimeoutFn`, which invokes it without forwarding arguments.

Runtime behavior and the existing `[isReady, cancel]` return type are unchanged.

## Validation

- `yarn lint:types`
- `yarn test tests/useDebounce.test.ts`
- `yarn lint` (passes with existing warnings)

## Type of change

- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist

- [x] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [x] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).