### PR TITLE
fix(useLocalStorage): replace useLayoutEffect with useIsomorphicLayoutEffect

### DIFF
--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -1,4 +1,5 @@
-import { Dispatch, SetStateAction, useCallback, useState, useRef, useLayoutEffect } from 'react';
+import { Dispatch, SetStateAction, useCallback, useState, useRef } from 'react';
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 import { isBrowser, noop } from './misc/util';
 
 type parserOptions<T> =
@@ -53,7 +54,7 @@ const useLocalStorage = <T>(
   const [state, setState] = useState<T | undefined>(() => initializer.current(key));
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  useLayoutEffect(() => setState(initializer.current(key)), [key]);
+  useIsomorphicLayoutEffect(() => setState(initializer.current(key)), [key]);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const set: Dispatch<SetStateAction<T | undefined>> = useCallback(


### PR DESCRIPTION
## Problem

`useLocalStorage` imports and uses `useLayoutEffect` directly from React (line 1 & 56), 
which causes this warning in SSR environments:

> Warning: useLayoutEffect does nothing on the server because its effect cannot 
> be encoded into the server renderer's output format.

## Fix

Replaced `useLayoutEffect` with `useIsomorphicLayoutEffect` — the utility already 
exported by this library — which automatically falls back to `useEffect` on the 
server and uses `useLayoutEffect` in the browser.

This is the same pattern already used in `createGlobalState.ts` (fixed in #956).

Relates to: #956