### PR TITLE
fix: remove all-primitive-deps warning from useDeepCompareEffect / useShallowCompareEffect

### DIFF
--- a/src/useDeepCompareEffect.ts
+++ b/src/useDeepCompareEffect.ts
@@ -2,19 +2,11 @@ import { DependencyList, EffectCallback } from 'react';
 import useCustomCompareEffect from './useCustomCompareEffect';
 import isDeepEqual from './misc/isDeepEqual';
 
-const isPrimitive = (val: any) => val !== Object(val);
-
 const useDeepCompareEffect = (effect: EffectCallback, deps: DependencyList) => {
   if (process.env.NODE_ENV !== 'production') {
     if (!(deps instanceof Array) || !deps.length) {
       console.warn(
         '`useDeepCompareEffect` should not be used with no dependencies. Use React.useEffect instead.'
-      );
-    }
-
-    if (deps.every(isPrimitive)) {
-      console.warn(
-        '`useDeepCompareEffect` should not be used with dependencies that are all primitive values. Use React.useEffect instead.'
       );
     }
   }

--- a/src/useShallowCompareEffect.ts
+++ b/src/useShallowCompareEffect.ts
@@ -2,7 +2,6 @@ import { DependencyList, EffectCallback } from 'react';
 import { equal as isShallowEqual } from 'fast-shallow-equal';
 import useCustomCompareEffect from './useCustomCompareEffect';
 
-const isPrimitive = (val: any) => val !== Object(val);
 const shallowEqualDepsList = (prevDeps: DependencyList, nextDeps: DependencyList) =>
   prevDeps.every((dep, index) => isShallowEqual(dep, nextDeps[index]));
 
@@ -11,12 +10,6 @@ const useShallowCompareEffect = (effect: EffectCallback, deps: DependencyList) =
     if (!(deps instanceof Array) || !deps.length) {
       console.warn(
         '`useShallowCompareEffect` should not be used with no dependencies. Use React.useEffect instead.'
-      );
-    }
-
-    if (deps.every(isPrimitive)) {
-      console.warn(
-        '`useShallowCompareEffect` should not be used with dependencies that are all primitive values. Use React.useEffect instead.'
       );
     }
   }


### PR DESCRIPTION
Fixes #755

## What
Removes the console.warn that fires when every value in the deps array passed to `useDeepCompareEffect` / `useShallowCompareEffect` is a primitive. The "no dependencies passed" warning is left untouched.

## Why
A dependency that starts as `undefined` and later becomes an object is valid, expected usage of these hooks — but the current all-primitive check warns on the very first render regardless. The maintainer confirmed in the issue thread that this specific warning should be removed while keeping the no-dependencies warning: https://github.com/streamich/react-use/issues/755#issuecomment-586574852

No existing tests assert on `console.warn`, so behavior otherwise is unchanged.

This PR was opened by an automated OSS contribution bot.